### PR TITLE
Feat/shop online deeplink

### DIFF
--- a/src/navigation/tabs/shop/ShopHome.tsx
+++ b/src/navigation/tabs/shop/ShopHome.tsx
@@ -8,25 +8,32 @@ import {
   getGiftCardCurations,
 } from '../../../lib/gift-cards/gift-card';
 import {useDispatch} from 'react-redux';
-import {RootState} from '../../../store';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import {ScreenOptions} from '../../../styles/tabNavigator';
 import {ShopOnline} from './components/ShopOnline';
-import {
-  CardConfig,
-  Category,
-  DirectIntegrationApiObject,
-  GiftCard,
-} from '../../../store/shop/shop.models';
+import {CardConfig, Category, GiftCard} from '../../../store/shop/shop.models';
 import {ShopEffects} from '../../../store/shop';
-import {selectAvailableGiftCards} from '../../../store/shop/shop.selectors';
+import {
+  selectAvailableGiftCards,
+  selectCategories,
+  selectCategoriesAndCurations,
+  selectCategoriesWithIntegrations,
+  selectIntegrations,
+} from '../../../store/shop/shop.selectors';
 import {APP_NETWORK} from '../../../constants/config';
 import {useAppSelector} from '../../../utils/hooks';
+import {StackScreenProps} from '@react-navigation/stack';
+import {ShopScreens, ShopStackParamList} from './ShopStack';
 
-enum ShopTabs {
+export enum ShopTabs {
   GIFT_CARDS = 'Gift Cards',
   SHOP_ONLINE = 'Shop Online',
 }
+
+export type ShopHomeParamList = {
+  [ShopTabs.GIFT_CARDS]: undefined;
+  [ShopTabs.SHOP_ONLINE]: undefined;
+};
 
 const Tab = createMaterialTopTabNavigator();
 
@@ -80,16 +87,11 @@ const getScrollViewHeight = (
     : getShopOnlineScrollViewHeight(integrationsCategories);
 };
 
-const ShopHome = () => {
-  const availableCardMap = useAppSelector(
-    ({SHOP}: RootState) => SHOP.availableCardMap,
-  );
-  const supportedCardMap = useAppSelector(
-    ({SHOP}: RootState) => SHOP.supportedCardMap,
-  );
-  const integrationsMap = useAppSelector(
-    ({SHOP}: RootState) => SHOP.integrations,
-  );
+const ShopHome: React.FC<
+  StackScreenProps<ShopStackParamList, ShopScreens.HOME>
+> = ({route}) => {
+  const availableCardMap = useAppSelector(({SHOP}) => SHOP.availableCardMap);
+  const supportedCardMap = useAppSelector(({SHOP}) => SHOP.supportedCardMap);
   const giftCards = useAppSelector(
     ({SHOP}) => SHOP.giftCards[APP_NETWORK],
   ) as GiftCard[];
@@ -99,9 +101,7 @@ const ShopHome = () => {
   const activeGiftCards = purchasedGiftCards.filter(
     giftCard => !giftCard.archived,
   );
-  const categoriesAndCurations = useAppSelector(
-    ({SHOP}: RootState) => SHOP.categoriesAndCurations,
-  );
+  const categoriesAndCurations = useAppSelector(selectCategoriesAndCurations);
   const scrollViewRef = useRef<ScrollView>(null);
 
   const availableGiftCards = useAppSelector(selectAvailableGiftCards);
@@ -121,27 +121,10 @@ const ShopHome = () => {
     [availableGiftCards, categoriesAndCurations, purchasedGiftCards],
   );
 
-  const integrations = useMemo(
-    () => Object.values(integrationsMap) as DirectIntegrationApiObject[],
-    [integrationsMap],
-  );
-
-  const categories = useMemo(
-    () => Object.values(categoriesAndCurations.categories) as Category[],
-    [categoriesAndCurations.categories],
-  );
-
-  const categoriesWitIntegrations = useMemo(
-    () =>
-      categories
-        .map(category => ({
-          ...category,
-          integrations: integrations.filter(integration =>
-            category.tags.some((tag: string) => integration.tags.includes(tag)),
-          ),
-        }))
-        .filter(category => category.integrations.length),
-    [categories, integrations],
+  const integrations = useAppSelector(selectIntegrations);
+  const categories = useAppSelector(selectCategories);
+  const categoriesWitIntegrations = useAppSelector(
+    selectCategoriesWithIntegrations,
   );
 
   const categoriesWithGiftCards = categories
@@ -204,6 +187,12 @@ const ShopHome = () => {
     dispatch(ShopEffects.startFetchCatalog());
     dispatch(ShopEffects.retryGiftCardRedemptions());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (route.params?.screen) {
+      setActiveTab(route.params.screen);
+    }
+  }, [route.params?.screen]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSetScrollViewHeight = useCallback(

--- a/src/navigation/tabs/shop/ShopStack.tsx
+++ b/src/navigation/tabs/shop/ShopStack.tsx
@@ -4,12 +4,13 @@ import {
   baseNavigatorOptions,
   baseScreenOptions,
 } from '../../../constants/NavigationOptions';
-import ShopHome from './ShopHome';
+import ShopHome, {ShopHomeParamList} from './ShopHome';
 import {HeaderTitle} from '../../../components/styled/Text';
 import {t} from 'i18next';
+import {NavigatorScreenParams} from '@react-navigation/native';
 
 export type ShopStackParamList = {
-  Home: undefined;
+  Home: NavigatorScreenParams<ShopHomeParamList>;
 };
 
 export enum ShopScreens {

--- a/src/store/shop/shop.selectors.ts
+++ b/src/store/shop/shop.selectors.ts
@@ -1,7 +1,11 @@
 import {createSelector} from 'reselect';
 import {AppSelector} from '..';
 import {getCardConfigFromApiConfigMap} from '../../lib/gift-cards/gift-card';
-import {AvailableCardMap} from './shop.models';
+import {
+  AvailableCardMap,
+  CategoriesAndCurations,
+  DirectIntegrationMap,
+} from './shop.models';
 
 export const selectAvailableCardMap: AppSelector<AvailableCardMap> = ({
   SHOP,
@@ -12,4 +16,44 @@ export const selectAvailableCardMap: AppSelector<AvailableCardMap> = ({
 export const selectAvailableGiftCards = createSelector(
   [selectAvailableCardMap],
   availableCardMap => getCardConfigFromApiConfigMap(availableCardMap),
+);
+
+export const selectCategoriesAndCurations: AppSelector<
+  CategoriesAndCurations
+> = ({SHOP}) => {
+  return SHOP.categoriesAndCurations;
+};
+
+export const selectCategories = createSelector(
+  [selectCategoriesAndCurations],
+  categoriesAndCurations => {
+    return Object.values(categoriesAndCurations.categories);
+  },
+);
+
+export const selectIntegrationsMap: AppSelector<DirectIntegrationMap> = ({
+  SHOP,
+}) => {
+  return SHOP.integrations as DirectIntegrationMap;
+};
+
+export const selectIntegrations = createSelector(
+  [selectIntegrationsMap],
+  integrationsMap => {
+    return Object.values(integrationsMap);
+  },
+);
+
+export const selectCategoriesWithIntegrations = createSelector(
+  [selectCategories, selectIntegrations],
+  (categories, integrations) => {
+    return categories
+      .map(category => ({
+        ...category,
+        integrations: integrations.filter(integration =>
+          category.tags?.some((tag: string) => integration.tags.includes(tag)),
+        ),
+      }))
+      .filter(category => category.integrations.length);
+  },
 );


### PR DESCRIPTION
### Changes
- updated OfferCard to handle links to ShopOnline merchants
- added and exported cached integration shop selectors

### Testing
- open `MockOffers.tsx` and change the `url` from `giftcard?merchant=something` to `shoponline?merchant=jomashop` or some other ShopOnline merchant name
- on the home screen, tap the updated offer to navigate to the merchant screen
- using a merchant that is not found should take you to the ShopOnline tab