### PR TITLE
Refactor wallet selector to be DRYer and misc fixes

### DIFF
--- a/src/navigation/tabs/shop/components/styled/ShopTabComponents.tsx
+++ b/src/navigation/tabs/shop/components/styled/ShopTabComponents.tsx
@@ -105,7 +105,6 @@ export const NavIconButtonContainer = styled.TouchableOpacity`
   height: 40px;
   width: 40px;
   overflow: hidden;
-  margin-top: -2px;
 `;
 
 export const Terms = styled(BaseText)<{maxWidth?: number}>`

--- a/src/navigation/tabs/shop/gift-card/GiftCardStack.tsx
+++ b/src/navigation/tabs/shop/gift-card/GiftCardStack.tsx
@@ -82,7 +82,7 @@ const GiftCardStack = () => {
         name={GiftCardScreens.ENTER_PHONE}
         component={EnterPhone}
         options={{
-          headerTitle: () => <HeaderTitle>Enter your phone number</HeaderTitle>,
+          headerTitle: () => <HeaderTitle>Enter Phone</HeaderTitle>,
         }}
       />
       <GiftCards.Screen

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -270,6 +270,16 @@ const BuyGiftCard = ({
     requestPhoneIfNeeded(amount, phone);
   };
 
+  const buyGiftCard = () => {
+    const selectedAmount = (cardConfig.supportedAmounts || [])[
+      selectedAmountIndex
+    ];
+    const activationFee = getActivationFee(selectedAmount, cardConfig);
+    return activationFee
+      ? showActivationFeeSheet(activationFee, selectedAmount)
+      : next(selectedAmount);
+  };
+
   return (
     <>
       <ScrollView
@@ -302,7 +312,7 @@ const BuyGiftCard = ({
                 </SupportedAmounts>
               </DenomSelectionContainer>
             ) : (
-              <TouchableWithoutFeedback onPress={() => goToAmountScreen()}>
+              <TouchableWithoutFeedback onPress={() => buyGiftCard()}>
                 <Amount>{formatFiatAmount(0, cardConfig.currency)}</Amount>
               </TouchableWithoutFeedback>
             )}
@@ -342,17 +352,7 @@ const BuyGiftCard = ({
           shadowRadius: 12,
           elevation: 5,
         }}>
-        <Button
-          onPress={() => {
-            const selectedAmount = (cardConfig.supportedAmounts || [])[
-              selectedAmountIndex
-            ];
-            const activationFee = getActivationFee(selectedAmount, cardConfig);
-            return activationFee
-              ? showActivationFeeSheet(activationFee, selectedAmount)
-              : next(selectedAmount);
-          }}
-          buttonStyle={'primary'}>
+        <Button onPress={() => buyGiftCard()} buttonStyle={'primary'}>
           {cardConfig.supportedAmounts ? 'Continue' : 'Buy Gift Card'}
         </Button>
       </FooterButton>

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -1,10 +1,10 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {useNavigation, useRoute} from '@react-navigation/native';
 import {Hr} from '../../../../../components/styled/Containers';
 import {RouteProp, StackActions} from '@react-navigation/core';
 import {WalletScreens, WalletStackParamList} from '../../../WalletStack';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
-import {H4, TextAlign} from '../../../../../components/styled/Text';
+import {H4} from '../../../../../components/styled/Text';
 import {
   Recipient,
   TransactionProposal,
@@ -17,7 +17,6 @@ import {
   createPayProTxProposal,
   handleCreateTxProposalError,
   removeTxp,
-  showNoWalletsModal,
   startSendPayment,
 } from '../../../../../store/wallet/effects/send/send';
 import {sleep, formatFiatAmount} from '../../../../../utils/helper-methods';
@@ -25,15 +24,6 @@ import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {OnGoingProcessMessages} from '../../../../../components/modal/ongoing-process/OngoingProcess';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
 import RemoteImage from '../../../../tabs/shop/components/RemoteImage';
-import SheetModal from '../../../../../components/modal/base/sheet/SheetModal';
-import {
-  WalletSelectMenuBodyContainer,
-  WalletSelectMenuContainer,
-  WalletSelectMenuHeaderContainer,
-} from '../../GlobalSelect';
-import KeyWalletsRow, {
-  KeyWallet,
-} from '../../../../../components/list/KeyWalletsRow';
 import {ShopActions, ShopEffects} from '../../../../../store/shop';
 import {BuildPayProWalletSelectorList} from '../../../../../store/wallet/utils/wallet';
 import {
@@ -44,6 +34,7 @@ import {
   DetailsList,
   Header,
   SendingFrom,
+  WalletSelector,
 } from './Shared';
 import {AppActions} from '../../../../../store/app';
 import {CustomErrorMessage} from '../../../components/ErrorMessages';
@@ -55,14 +46,12 @@ import {
   Invoice,
 } from '../../../../../store/shop/shop.models';
 import {WalletRowProps} from '../../../../../components/list/WalletRow';
-import CoinbaseSmall from '../../../../../../assets/img/logos/coinbase-small.svg';
 import {
   CoinbaseAccountProps,
   CoinbaseErrorMessages,
 } from '../../../../../api/coinbase/coinbase.types';
 import {startGetRates} from '../../../../../store/wallet/effects';
 import {coinbasePayInvoice} from '../../../../../store/coinbase';
-
 export interface GiftCardConfirmParamList {
   amount: number;
   cardConfig: CardConfig;
@@ -115,8 +104,7 @@ const Confirm = () => {
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const giftCards = useAppSelector(({SHOP}) => SHOP.giftCards[APP_NETWORK]);
 
-  const [walletSelectModalVisible, setWalletSelectModalVisible] =
-    useState(false);
+  const [walletSelectorVisible, setWalletSelectorVisible] = useState(false);
   const [key, setKey] = useState(keys[_wallet ? _wallet.keyId : '']);
   const [wallet, setWallet] = useState(_wallet);
   const [coinbaseAccount, setCoinbaseAccount] =
@@ -139,7 +127,7 @@ const Confirm = () => {
 
   const reshowWalletSelector = async () => {
     await sleep(400);
-    setWalletSelectModalVisible(true);
+    setWalletSelectorVisible(true);
   };
 
   useEffect(() => {
@@ -149,15 +137,9 @@ const Confirm = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const openKeyWalletSelector = useCallback(async () => {
-    const {keyWallets, coinbaseWallets} = memoizedKeysAndWalletsList;
-    if (keyWallets.length || coinbaseWallets.length) {
-      await sleep(10);
-      setWalletSelectModalVisible(true);
-    } else {
-      dispatch(showNoWalletsModal({navigation}));
-    }
-  }, [dispatch, memoizedKeysAndWalletsList, navigation]);
+  const openWalletSelector = () => {
+    setWalletSelectorVisible(true);
+  };
 
   const createGiftCardInvoice = async ({
     clientId,
@@ -166,9 +148,6 @@ const Confirm = () => {
     clientId: string;
     transactionCurrency: string;
   }) => {
-    setWalletSelectModalVisible(false);
-    // not ideal - will dive into why the timeout has to be this long
-    await sleep(400);
     dispatch(
       startOnGoingProcessModal(OnGoingProcessMessages.FETCHING_PAYMENT_INFO),
     );
@@ -375,7 +354,7 @@ const Confirm = () => {
   };
 
   useEffect(() => {
-    openKeyWalletSelector();
+    openWalletSelector();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -388,7 +367,7 @@ const Confirm = () => {
             <Header hr>Summary</Header>
             <SendingFrom
               sender={sendingFrom!}
-              onPress={openKeyWalletSelector}
+              onPress={openWalletSelector}
               hr
             />
             {unsoldGiftCard && unsoldGiftCard.totalDiscount ? (
@@ -449,34 +428,20 @@ const Confirm = () => {
         </>
       ) : null}
 
-      <SheetModal
-        isVisible={walletSelectModalVisible}
+      <WalletSelector
+        isVisible={walletSelectorVisible}
+        setWalletSelectorVisible={setWalletSelectorVisible}
+        walletsAndAccounts={memoizedKeysAndWalletsList}
+        onWalletSelect={onWalletSelect}
+        onCoinbaseAccountSelect={onCoinbaseAccountSelect}
         onBackdropPress={async () => {
-          setWalletSelectModalVisible(false);
+          setWalletSelectorVisible(false);
           if (!wallet && !coinbaseAccount) {
             await sleep(100);
             navigation.goBack();
           }
-        }}>
-        <WalletSelectMenuContainer>
-          <WalletSelectMenuHeaderContainer>
-            <TextAlign align={'center'}>
-              <H4>Select a wallet</H4>
-            </TextAlign>
-          </WalletSelectMenuHeaderContainer>
-          <WalletSelectMenuBodyContainer>
-            <KeyWalletsRow<KeyWallet>
-              keyWallets={memoizedKeysAndWalletsList.keyWallets}
-              onPress={onWalletSelect}
-            />
-            <KeyWalletsRow<WalletRowProps>
-              keyWallets={memoizedKeysAndWalletsList.coinbaseWallets}
-              keySvg={CoinbaseSmall}
-              onPress={onCoinbaseAccountSelect}
-            />
-          </WalletSelectMenuBodyContainer>
-        </WalletSelectMenuContainer>
-      </SheetModal>
+        }}
+      />
     </ConfirmContainer>
   );
 };

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -4,9 +4,7 @@ import {useNavigation, useRoute} from '@react-navigation/native';
 import {RouteProp, StackActions} from '@react-navigation/core';
 import {WalletScreens, WalletStackParamList} from '../../../WalletStack';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
-import {H4, TextAlign} from '../../../../../components/styled/Text';
 import SecureLockIcon from '../../../../../../assets/img/secure-lock.svg';
-import CoinbaseSmall from '../../../../../../assets/img/logos/coinbase-small.svg';
 import {
   Recipient,
   TransactionProposal,
@@ -19,7 +17,6 @@ import {
   createPayProTxProposal,
   handleCreateTxProposalError,
   removeTxp,
-  showNoWalletsModal,
   startSendPayment,
 } from '../../../../../store/wallet/effects/send/send';
 import PaymentSent from '../../../components/PaymentSent';
@@ -27,15 +24,6 @@ import {sleep} from '../../../../../utils/helper-methods';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {OnGoingProcessMessages} from '../../../../../components/modal/ongoing-process/OngoingProcess';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
-import SheetModal from '../../../../../components/modal/base/sheet/SheetModal';
-import {
-  WalletSelectMenuBodyContainer,
-  WalletSelectMenuContainer,
-  WalletSelectMenuHeaderContainer,
-} from '../../GlobalSelect';
-import KeyWalletsRow, {
-  KeyWallet,
-} from '../../../../../components/list/KeyWalletsRow';
 import {BuildPayProWalletSelectorList} from '../../../../../store/wallet/utils/wallet';
 import {
   Amount,
@@ -45,6 +33,7 @@ import {
   Header,
   SendingFrom,
   SendingTo,
+  WalletSelector,
 } from './Shared';
 import {AppActions} from '../../../../../store/app';
 import {CustomErrorMessage} from '../../../components/ErrorMessages';
@@ -81,8 +70,8 @@ const PayProConfirm = () => {
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
 
-  const [walletSelectModalVisible, setWalletSelectModalVisible] =
-    useState(false);
+  const [walletSelectorVisible, setWalletSelectorVisible] = useState(false);
+
   const [key, setKey] = useState(keys[_wallet ? _wallet.keyId : '']);
   const [coinbaseAccount, setCoinbaseAccount] =
     useState<CoinbaseAccountProps>();
@@ -112,7 +101,7 @@ const PayProConfirm = () => {
 
   const reshowWalletSelector = async () => {
     await sleep(400);
-    setWalletSelectModalVisible(true);
+    setWalletSelectorVisible(true);
   };
 
   const createTxp = async (selectedWallet: Wallet) => {
@@ -163,12 +152,7 @@ const PayProConfirm = () => {
   }, []);
 
   const openKeyWalletSelector = () => {
-    const {keyWallets, coinbaseWallets} = memoizedKeysAndWalletsList;
-    if (keyWallets.length || coinbaseWallets.length) {
-      setWalletSelectModalVisible(true);
-    } else {
-      dispatch(showNoWalletsModal({navigation}));
-    }
+    setWalletSelectorVisible(true);
   };
 
   const handleCreateGiftCardInvoiceOrTxpError = async (err: any) => {
@@ -191,9 +175,6 @@ const PayProConfirm = () => {
   };
 
   const onCoinbaseAccountSelect = async (walletRowProps: WalletRowProps) => {
-    setWalletSelectModalVisible(false);
-    // not ideal - will dive into why the timeout has to be this long
-    await sleep(400);
     dispatch(
       startOnGoingProcessModal(OnGoingProcessMessages.FETCHING_PAYMENT_INFO),
     );
@@ -225,7 +206,7 @@ const PayProConfirm = () => {
   };
 
   const onWalletSelect = async (selectedWallet: Wallet) => {
-    setWalletSelectModalVisible(false);
+    setWalletSelectorVisible(false);
     // not ideal - will dive into why the timeout has to be this long
     await sleep(400);
     createTxp(selectedWallet);
@@ -368,34 +349,20 @@ const PayProConfirm = () => {
         </>
       ) : null}
 
-      <SheetModal
-        isVisible={walletSelectModalVisible}
+      <WalletSelector
+        isVisible={walletSelectorVisible}
+        setWalletSelectorVisible={setWalletSelectorVisible}
+        walletsAndAccounts={memoizedKeysAndWalletsList}
+        onWalletSelect={onWalletSelect}
+        onCoinbaseAccountSelect={onCoinbaseAccountSelect}
         onBackdropPress={async () => {
-          setWalletSelectModalVisible(false);
+          setWalletSelectorVisible(false);
           if (!wallet && !coinbaseAccount) {
             await sleep(100);
             navigation.goBack();
           }
-        }}>
-        <WalletSelectMenuContainer>
-          <WalletSelectMenuHeaderContainer>
-            <TextAlign align={'center'}>
-              <H4>Select a wallet</H4>
-            </TextAlign>
-          </WalletSelectMenuHeaderContainer>
-          <WalletSelectMenuBodyContainer>
-            <KeyWalletsRow<KeyWallet>
-              keyWallets={memoizedKeysAndWalletsList.keyWallets}
-              onPress={onWalletSelect}
-            />
-            <KeyWalletsRow<WalletRowProps>
-              keyWallets={memoizedKeysAndWalletsList.coinbaseWallets}
-              keySvg={CoinbaseSmall}
-              onPress={onCoinbaseAccountSelect}
-            />
-          </WalletSelectMenuBodyContainer>
-        </WalletSelectMenuContainer>
-      </SheetModal>
+        }}
+      />
 
       <PaymentSent
         isVisible={showPaymentSentModal}

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -400,6 +400,11 @@ export const BuildKeysAndWalletsList = ({
     .filter(key => key.wallets.length);
 };
 
+export interface WalletsAndAccounts {
+  keyWallets: KeyWalletsRowProps<KeyWallet>[];
+  coinbaseWallets: KeyWalletsRowProps<WalletRowProps>[];
+}
+
 export const BuildPayProWalletSelectorList =
   ({
     keys,
@@ -411,10 +416,7 @@ export const BuildPayProWalletSelectorList =
     network?: Network;
     payProOptions?: PayProOptions;
     defaultAltCurrencyIsoCode?: string;
-  }): Effect<{
-    keyWallets: KeyWalletsRowProps<KeyWallet>[];
-    coinbaseWallets: KeyWalletsRowProps<WalletRowProps>[];
-  }> =>
+  }): Effect<WalletsAndAccounts> =>
   (_, getState) => {
     const {COINBASE} = getState();
     const coinbaseAccounts = COINBASE.accounts[COINBASE_ENV];


### PR DESCRIPTION
Currently wallet selector logic is duplicated across 3 confirm pages. This PR consolidates wallet selector logic by turning it into a shared component, making future wallet selector changes more maintainable. 

This PR also:
1. Fixes an issue with the wallet selector not appearing on the paypro confirm screen after a successful paypro scan
2. Fixes a positioning issue with the settings navbar button on the gift card details screen
3. Includes misc improvements to the mastercard gift card purchase flow
4. Automatically selects the only wallet available on the gift card, debit card, and general paypro confirm screens (if only one wallet is available) while making auto-selection 500ms faster by eliminating an unneeded delay