### PR TITLE
Send Fixes

### DIFF
--- a/src/navigation/wallet-connect/components/WalletSelector.tsx
+++ b/src/navigation/wallet-connect/components/WalletSelector.tsx
@@ -24,6 +24,7 @@ import {
   WalletSelectMenuBodyContainer,
 } from '../../wallet/screens/GlobalSelect';
 import KeyWalletsRow, {
+  KeyWallet,
   KeyWalletsRowProps,
 } from '../../../components/list/KeyWalletsRow';
 import merge from 'lodash.merge';
@@ -98,7 +99,7 @@ export default ({
     [allWallets],
   );
 
-  let keyWallets: KeyWalletsRowProps[] = [];
+  let keyWallets: KeyWalletsRowProps<KeyWallet>[] = [];
 
   supportedCoins.forEach(supportedCoin => {
     const keyWallet = Object.keys(supportedCoin.availableWalletsByKey).map(
@@ -111,7 +112,8 @@ export default ({
             const {
               balance,
               currencyAbbreviation,
-              credentials: {network},
+              credentials: {network, walletName: fallbackName},
+              walletName,
             } = wallet;
             return merge(cloneDeep(wallet), {
               cryptoBalance: balance.crypto,
@@ -121,6 +123,7 @@ export default ({
               ),
               currencyAbbreviation: currencyAbbreviation.toUpperCase(),
               network,
+              walletName: walletName || fallbackName,
             });
           }),
         };

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -20,6 +20,7 @@ import SheetModal from '../../../components/modal/base/sheet/SheetModal';
 import {ScreenGutter} from '../../../components/styled/Containers';
 import _ from 'lodash';
 import KeyWalletsRow, {
+  KeyWallet,
   KeyWalletsRowProps,
 } from '../../../components/list/KeyWalletsRow';
 import merge from 'lodash.merge';
@@ -199,7 +200,8 @@ const GlobalSelect: React.FC<GlobalSelectProps> = ({
   const [walletSelectModalVisible, setWalletSelectModalVisible] =
     useState(false);
   // object to pass to select modal
-  const [keyWallets, setKeysWallets] = useState<KeyWalletsRowProps[]>();
+  const [keyWallets, setKeysWallets] =
+    useState<KeyWalletsRowProps<KeyWallet>[]>();
 
   const NON_BITPAY_SUPPORTED_TOKENS = Object.keys(tokens).filter(
     token => !SUPPORTED_CURRENCIES.includes(token),
@@ -270,7 +272,8 @@ const GlobalSelect: React.FC<GlobalSelectProps> = ({
                 const {
                   balance,
                   currencyAbbreviation,
-                  credentials: {network},
+                  credentials: {network, walletName: fallbackName},
+                  walletName,
                 } = wallet;
                 return merge(cloneDeep(wallet), {
                   cryptoBalance: balance.crypto,
@@ -285,6 +288,7 @@ const GlobalSelect: React.FC<GlobalSelectProps> = ({
                   ),
                   currencyAbbreviation: currencyAbbreviation.toUpperCase(),
                   network,
+                  walletName: walletName || fallbackName,
                 });
               }),
           };

--- a/src/navigation/wallet/screens/send/SendTo.tsx
+++ b/src/navigation/wallet/screens/send/SendTo.tsx
@@ -93,7 +93,7 @@ const BuildKeyWalletRow = (
   currentNetwork: string,
   defaultAltCurrencyIsoCode: string,
 ) => {
-  let filteredKeys: KeyWalletsRowProps[] = [];
+  let filteredKeys: KeyWalletsRowProps<KeyWallet>[] = [];
   Object.entries(keys).forEach(([key, value]) => {
     const wallets: KeyWallet[] = [];
     value.wallets
@@ -109,7 +109,8 @@ const BuildKeyWalletRow = (
         const {
           balance,
           currencyAbbreviation,
-          credentials: {network},
+          credentials: {network, walletName: fallbackName},
+          walletName,
         } = wallet;
         // Clone wallet to avoid altering store values
         const _wallet = merge(cloneDeep(wallet), {
@@ -122,6 +123,7 @@ const BuildKeyWalletRow = (
           fiatLockedBalance: '',
           currencyAbbreviation: currencyAbbreviation.toUpperCase(),
           network,
+          walletName: walletName || fallbackName,
         });
         wallets.push(_wallet);
       });
@@ -165,7 +167,7 @@ const SendTo = () => {
     id,
     credentials: {network},
   } = wallet;
-  const keyWallets: KeyWalletsRowProps[] = BuildKeyWalletRow(
+  const keyWallets: KeyWalletsRowProps<KeyWallet>[] = BuildKeyWalletRow(
     keys,
     id,
     currencyAbbreviation,

--- a/src/store/scan/scan.effects.ts
+++ b/src/store/scan/scan.effects.ts
@@ -52,6 +52,12 @@ import {Wallet, Key} from '../wallet/wallet.models';
 import {FormatAmount} from '../wallet/effects/amount/amount';
 import {ButtonState} from '../../components/button/Button';
 import {InteractionManager} from 'react-native';
+import {
+  BitcoreLibs,
+  bitcoreLibs,
+  GetAddressNetwork,
+} from '../wallet/effects/address/address';
+import {Network} from '../../constants';
 
 export const incomingData =
   (data: string, wallet?: Wallet): Effect<Promise<void>> =>
@@ -283,7 +289,12 @@ export const goToAmount =
     opts: urlOpts,
   }: {
     coin: string;
-    recipient: {type: string; address: string; currency: string};
+    recipient: {
+      type: string;
+      address: string;
+      currency: string;
+      network?: Network;
+    };
     wallet?: Wallet;
     opts?: {
       message?: string;
@@ -396,6 +407,7 @@ const handleBitcoinUri =
       type: 'address',
       currency: coin,
       address,
+      network: address && GetAddressNetwork(address, coin),
     };
     if (parsed.r) {
       dispatch(goToPayPro(parsed.r));
@@ -425,6 +437,7 @@ const handleBitcoinCashUri =
       type: 'address',
       currency: coin,
       address,
+      network: address && GetAddressNetwork(address, coin),
     };
     if (parsed.r) {
       dispatch(goToPayPro(parsed.r));
@@ -466,6 +479,7 @@ const handleBitcoinCashUriLegacyAddress =
       type: 'address',
       currency: coin,
       address,
+      network: address && GetAddressNetwork(address, coin),
     };
     if (parsed.r) {
       dispatch(goToPayPro(parsed.r));
@@ -557,6 +571,7 @@ const handleDogecoinUri =
       type: 'address',
       currency: coin,
       address,
+      network: address && GetAddressNetwork(address, coin),
     };
 
     if (parsed.r) {
@@ -582,6 +597,7 @@ const handleLitecoinUri =
       type: 'address',
       currency: coin,
       address,
+      network: address && GetAddressNetwork(address, coin),
     };
     if (parsed.r) {
       dispatch(goToPayPro(parsed.r));
@@ -732,10 +748,14 @@ const handlePlainAddress =
   (address: string, coin: string, wallet?: Wallet): Effect<void> =>
   dispatch => {
     console.log(`Incoming-data: ${coin} plain address`);
+    const network =
+      Object.keys(bitcoreLibs).includes(coin) &&
+      GetAddressNetwork(address, coin as keyof BitcoreLibs);
     const recipient = {
       type: 'address',
       currency: coin,
       address,
+      network,
     };
     dispatch(goToAmount({coin, recipient, wallet}));
   };

--- a/src/store/wallet/effects/address/address.ts
+++ b/src/store/wallet/effects/address/address.ts
@@ -13,6 +13,20 @@ const BitcoreDoge = BWC.getBitcoreDoge();
 const BitcoreLtc = BWC.getBitcoreLtc();
 const Core = BWC.getCore();
 
+export interface BitcoreLibs {
+  bch: any;
+  btc: any;
+  doge: any;
+  ltc: any;
+}
+
+export const bitcoreLibs: BitcoreLibs = {
+  bch: BitcoreCash,
+  btc: Bitcore,
+  doge: BitcoreDoge,
+  ltc: BitcoreLtc,
+};
+
 interface Address {
   address: string;
   coin: string;
@@ -112,18 +126,20 @@ export interface CoinNetwork {
   network: string;
 }
 
+export const GetAddressNetwork = (address: string, coin: keyof BitcoreLibs) => {
+  return bitcoreLibs[coin].Address(address).network.name;
+};
+
 export const GetCoinAndNetwork = (
   str: string,
   network: string = 'livenet',
 ): CoinNetwork | null => {
   const address = ExtractCoinNetworkAddress(str);
   try {
-    network = Bitcore.Address(address).network.name;
-    return {coin: 'btc', network};
+    return {coin: 'btc', network: GetAddressNetwork(address, 'btc')};
   } catch (e) {
     try {
-      network = BitcoreCash.Address(address).network.name;
-      return {coin: 'bch', network};
+      return {coin: 'bch', network: GetAddressNetwork(address, 'bch')};
     } catch (bchErr) {
       try {
         const isValidEthAddress = Core.Validation.validateAddress(
@@ -150,12 +166,10 @@ export const GetCoinAndNetwork = (
           }
         } catch (xrpErr) {
           try {
-            network = BitcoreDoge.Address(address).network.name;
-            return {coin: 'doge', network};
+            return {coin: 'doge', network: GetAddressNetwork(address, 'doge')};
           } catch (dogeErr) {
             try {
-              network = BitcoreLtc.Address(address).network.name;
-              return {coin: 'ltc', network};
+              return {coin: 'ltc', network: GetAddressNetwork(address, 'ltc')};
             } catch (ltcErr) {
               return null;
             }

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -412,7 +412,8 @@ export const BuildKeysAndWalletsList = ({
           .map(walletObj => {
             const {
               balance,
-              credentials: {network},
+              credentials: {network, walletName: fallbackName},
+              walletName,
             } = walletObj;
             return merge(cloneDeep(walletObj), {
               cryptoBalance: balance.crypto,
@@ -426,6 +427,7 @@ export const BuildKeysAndWalletsList = ({
                 defaultAltCurrencyIsoCode,
               ),
               network,
+              walletName: walletName || fallbackName,
             });
           }),
       };


### PR DESCRIPTION
1. Check address network of scanned address before showing wallet list in global send flow
2. Ensure user-defined wallet names are shown in the wallet selector

Also fixes a typescript error related to `KeyWalletsRowProps` missing a type argument