### PR TITLE
International Gift Card Fixes

### DIFF
--- a/src/lib/gift-cards/gift-card.ts
+++ b/src/lib/gift-cards/gift-card.ts
@@ -131,7 +131,11 @@ export function spreadAmounts(values: Array<number>, currency: string): string {
   let caption = '';
   values.forEach((value: number, index: number) => {
     caption =
-      caption + formatFiatAmount(value, currency, {customPrecision: 'minimal'});
+      caption +
+      formatFiatAmount(value, currency, {
+        customPrecision: 'minimal',
+        currencyDisplay: 'symbol',
+      });
     if (values.length - index >= 2) {
       caption += ', ';
     }

--- a/src/navigation/tabs/shop/components/GiftCardCreditsItem.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardCreditsItem.tsx
@@ -126,6 +126,7 @@ export default (props: {cardConfig: CardConfig; amount: number}) => {
       <GiftCardAmount logoBackgroundColor={logoBackgroundColor}>
         {formatFiatAmount(amount, cardConfig.currency, {
           customPrecision: 'minimal',
+          currencyDisplay: 'symbol',
         })}
       </GiftCardAmount>
     </GiftCardItem>

--- a/src/navigation/tabs/shop/components/GiftCardDenomSelector.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardDenomSelector.tsx
@@ -59,6 +59,7 @@ export default ({
       <SelectedAmount>
         {formatFiatAmount(amounts[selectedIndex], cardConfig.currency, {
           customPrecision: 'minimal',
+          currencyDisplay: 'symbol',
         })}
       </SelectedAmount>
       <TouchableWithoutFeedback

--- a/src/navigation/tabs/shop/components/GiftCardDenoms.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardDenoms.tsx
@@ -18,10 +18,12 @@ export default ({cardConfig}: {cardConfig: CardConfig}) => {
         <>
           {formatFiatAmount(cardConfig.minAmount, cardConfig.currency, {
             customPrecision: 'minimal',
+            currencyDisplay: 'symbol',
           })}
           &nbsp;—&nbsp;
           {formatFiatAmount(cardConfig.maxAmount, cardConfig.currency, {
             customPrecision: 'minimal',
+            currencyDisplay: 'symbol',
           })}
         </>
       )}

--- a/src/navigation/tabs/shop/components/GiftCardItem.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardItem.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import TimeAgo from 'react-native-timeago';
-import {CardConfig, GiftCard} from '../../../../store/shop/shop.models';
+import {CardConfig} from '../../../../store/shop/shop.models';
 import RemoteImage from './RemoteImage';
-import GiftCardDenoms, {GiftCardDenomText} from './GiftCardDenoms';
+import GiftCardDenoms from './GiftCardDenoms';
 import {BaseText} from '../../../../components/styled/Text';
 import GiftCardDiscountText from './GiftCardDiscountText';
-import {formatFiatAmount} from '../../../../utils/helper-methods';
 import {isSupportedDiscountType} from '../../../../lib/gift-cards/gift-card';
 
 const GiftCardItemContainer = styled.View`

--- a/src/navigation/tabs/shop/gift-card/GiftCardStack.tsx
+++ b/src/navigation/tabs/shop/gift-card/GiftCardStack.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
+import {createStackNavigator} from '@react-navigation/stack';
 import {
   baseNavigatorOptions,
   baseScreenOptions,
@@ -14,6 +14,10 @@ import GiftCardDetails from './screens/GiftCardDetails';
 import EnterPhone from './screens/EnterPhone';
 import EnterEmail from './screens/EnterEmail';
 import {HeaderTitle} from '../../../../components/styled/Text';
+import Amount, {AmountParamList} from '../../../wallet/screens/Amount';
+import Confirm, {
+  GiftCardConfirmParamList,
+} from '../../../wallet/screens/send/confirm/GiftCardConfirm';
 
 export type GiftCardStackParamList = {
   BuyGiftCard: {cardConfig: CardConfig};
@@ -35,7 +39,8 @@ export type GiftCardStackParamList = {
     }) => void;
   };
   GiftCardDetails: {cardConfig: CardConfig; giftCard: GiftCard};
-  GiftCardDetailsModal: {cardConfig: CardConfig; giftCard: GiftCard};
+  GiftCardAmount: AmountParamList;
+  GiftCardConfirm: GiftCardConfirmParamList;
 };
 
 export enum GiftCardScreens {
@@ -44,6 +49,8 @@ export enum GiftCardScreens {
   ENTER_PHONE = 'EnterPhone',
   GIFT_CARD_DETAILS = 'GiftCardDetails',
   GIFT_CARD_DETAILS_MODAL = 'GiftCardDetailsModal',
+  GIFT_CARD_AMOUNT = 'GiftCardAmount',
+  GIFT_CARD_CONFIRM = 'GiftCardConfirm',
 }
 
 const GiftCards = createStackNavigator<GiftCardStackParamList>();
@@ -82,10 +89,16 @@ const GiftCardStack = () => {
         }}
       />
       <GiftCards.Screen
-        name={GiftCardScreens.GIFT_CARD_DETAILS_MODAL}
-        component={GiftCardDetails}
+        name={GiftCardScreens.GIFT_CARD_AMOUNT}
+        component={Amount}
         options={{
-          ...TransitionPresets.ModalPresentationIOS,
+          gestureEnabled: false,
+        }}
+      />
+      <GiftCards.Screen
+        name={GiftCardScreens.GIFT_CARD_CONFIRM}
+        component={Confirm}
+        options={{
           gestureEnabled: false,
         }}
       />

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -10,6 +10,7 @@ import {
   BaseText,
   fontFamily,
   HeaderTitle,
+  TextAlign,
 } from '../../../../../components/styled/Text';
 import styled from 'styled-components/native';
 import {
@@ -97,6 +98,7 @@ const DenomSelectionContainer = styled.View`
 const SupportedAmounts = styled.View`
   margin-top: 10px;
   align-items: center;
+  padding: 0 30px;
 `;
 
 const SupportedAmountsLabel = styled(GiftCardDenomText)`
@@ -319,7 +321,9 @@ const BuyGiftCard = ({
                   <SupportedAmountsLabel>
                     Purchase Amounts:
                   </SupportedAmountsLabel>
-                  <GiftCardDenoms cardConfig={cardConfig} />
+                  <TextAlign align="center">
+                    <GiftCardDenoms cardConfig={cardConfig} />
+                  </TextAlign>
                 </SupportedAmounts>
               </DenomSelectionContainer>
             ) : (

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -37,7 +37,6 @@ import {useDispatch} from 'react-redux';
 import {AppActions} from '../../../../../store/app';
 import GiftCardDiscountText from '../../components/GiftCardDiscountText';
 import {formatFiatAmount, sleep} from '../../../../../utils/helper-methods';
-import {WalletScreens} from '../../../../wallet/WalletStack';
 import {CustomErrorMessage} from '../../../../wallet/components/ErrorMessages';
 import {ShopActions} from '../../../../../store/shop';
 import {APP_NETWORK} from '../../../../../constants/config';
@@ -169,8 +168,8 @@ const BuyGiftCard = ({
 
   const goToConfirmScreen = async (amount: number) => {
     const discount = getVisibleDiscount(cardConfig);
-    navigator.navigate('Wallet', {
-      screen: WalletScreens.GIFT_CARD_CONFIRM,
+    navigator.navigate('GiftCard', {
+      screen: GiftCardScreens.GIFT_CARD_CONFIRM,
       params: {
         amount,
         cardConfig,
@@ -180,8 +179,8 @@ const BuyGiftCard = ({
   };
 
   const goToAmountScreen = (phone?: string) => {
-    navigator.navigate('Wallet', {
-      screen: WalletScreens.AMOUNT,
+    navigator.navigate('GiftCard', {
+      screen: GiftCardScreens.GIFT_CARD_AMOUNT,
       params: {
         fiatCurrencyAbbreviation: cardConfig.currency,
         opts: {hideSendMax: true},

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -152,6 +152,7 @@ const BuyGiftCard = ({
         } gift cards contain an additional activation fee of ${formatFiatAmount(
           activationFee,
           cardConfig.currency,
+          {currencyDisplay: 'symbol'},
         )}.`,
         enableBackdropDismiss: true,
         actions: [
@@ -203,7 +204,7 @@ const BuyGiftCard = ({
             errMsg: `The purchase amount must be at least ${formatFiatAmount(
               minAmount,
               cardConfig.currency,
-              {customPrecision: 'minimal'},
+              {customPrecision: 'minimal', currencyDisplay: 'symbol'},
             )}. Please modify your amount.`,
           }),
         ),
@@ -218,7 +219,7 @@ const BuyGiftCard = ({
             errMsg: `The purchase amount is limited to ${formatFiatAmount(
               maxAmount,
               cardConfig.currency,
-              {customPrecision: 'minimal'},
+              {customPrecision: 'minimal', currencyDisplay: 'symbol'},
             )}. Please modify your amount.`,
           }),
         ),
@@ -328,7 +329,11 @@ const BuyGiftCard = ({
               </DenomSelectionContainer>
             ) : (
               <TouchableWithoutFeedback onPress={() => buyGiftCard()}>
-                <Amount>{formatFiatAmount(0, cardConfig.currency)}</Amount>
+                <Amount>
+                  {formatFiatAmount(0, cardConfig.currency, {
+                    currencyDisplay: 'symbol',
+                  })}
+                </Amount>
               </TouchableWithoutFeedback>
             )}
           </AmountContainer>

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -276,7 +276,11 @@ const GiftCardDetails = ({
             />
           ) : undefined
         }>
-        <Amount>{formatFiatAmount(giftCard.amount, giftCard.currency)}</Amount>
+        <Amount>
+          {formatFiatAmount(giftCard.amount, giftCard.currency, {
+            currencyDisplay: 'symbol',
+          })}
+        </Amount>
         <RemoteImage
           uri={cardConfig.cardImage}
           height={169}

--- a/src/navigation/wallet/screens/Amount.tsx
+++ b/src/navigation/wallet/screens/Amount.tsx
@@ -349,7 +349,10 @@ const Amount: React.FC<AmountProps> = ({
           ) : null}
         </AmountHeroContainer>
         <View>
-          <VirtualKeyboard onCellPress={onCellPress} />
+          <VirtualKeyboard
+            onCellPress={onCellPress}
+            showDot={currency !== 'JPY'}
+          />
           <ActionContainer>
             <Button
               state={buttonState}

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -282,7 +282,7 @@ const Confirm = () => {
       dispatch(ShopEffects.waitForConfirmation(giftCard.invoiceId));
     }
     navigation.dispatch(StackActions.popToTop());
-    navigation.dispatch(StackActions.pop(3));
+    navigation.dispatch(StackActions.pop());
     navigation.navigate('GiftCard', {
       screen: 'GiftCardDetails',
       params: {

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -76,10 +76,7 @@ const GiftCardHeader = ({
       </Header>
       <DetailContainer height={73}>
         <DetailRow>
-          <H4>
-            {formatFiatAmount(amount, cardConfig.currency)}{' '}
-            {cardConfig.currency}
-          </H4>
+          <H4>{formatFiatAmount(amount, cardConfig.currency)}</H4>
           <RemoteImage uri={cardConfig.icon} height={40} borderRadius={40} />
         </DetailRow>
       </DetailContainer>


### PR DESCRIPTION
1. The international gift card experience is improved by displaying the currency symbol for all gift card related amounts (rather than the currency ISO code)
2. The virtual keyboard hides the decimal if the currency is JPY
3. Buy Gift Card screen now cleanly handles long lists of supported amounts for fixed denomination gift cards
4. The PR also ensures that all screens within the gift card purchase flow exist within the same stack so that popToTop() will always take the user back to the BuyGiftCard screen and then pop() will take them back to where they were before starting the purchase. This resolves an issue where the user would be taken back too far (to an onboarding screen) after purchasing a gift card.