### PR TITLE
Check status of multisig wallet in Key Overview before navigating

### DIFF
--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -391,6 +391,15 @@ const KeyOverview: React.FC<KeyOverviewScreenProps> = ({navigation, route}) => {
                     // TODO
                     console.log(err);
                   }
+                  if (status.wallet.status === 'complete') {
+                    fullWalletObj.openWallet({}, () => {
+                      navigation.navigate('WalletDetails', {
+                        walletId: item.id,
+                        key,
+                      });
+                    });
+                    return;
+                  }
                   navigation.navigate('Copayers', {
                     wallet: fullWalletObj,
                     status: status.wallet,
@@ -407,7 +416,7 @@ const KeyOverview: React.FC<KeyOverviewScreenProps> = ({navigation, route}) => {
         />
       );
     },
-    [navigation, keys],
+    [key, navigation],
   );
 
   return (


### PR DESCRIPTION
Currently, creating a multisig wallet, then accepting the invite with a different device, then going back to Key Overview, and then tapping on the newly created multisig wallet takes you back to the Copayers screen even though the invite has already been accepted. This can be confusing to users, especially if they are not aware that they need to pull to refresh on the Copayers screen to complete multisig wallet creation. This PR checks the status of the newly created multisig wallet on the Key Overview screen, and, if it is complete, navigates to the Wallet Details screen rather than the Copayers screen.