### PR TITLE
Make gift card amount copyable

### DIFF
--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -276,11 +276,14 @@ const GiftCardDetails = ({
             />
           ) : undefined
         }>
-        <Amount>
-          {formatFiatAmount(giftCard.amount, giftCard.currency, {
-            currencyDisplay: 'symbol',
-          })}
-        </Amount>
+        <TouchableWithoutFeedback
+          onPress={() => copyToClipboard(`${giftCard.amount}`)}>
+          <Amount>
+            {formatFiatAmount(giftCard.amount, giftCard.currency, {
+              currencyDisplay: 'symbol',
+            })}
+          </Amount>
+        </TouchableWithoutFeedback>
         <RemoteImage
           uri={cardConfig.cardImage}
           height={169}


### PR DESCRIPTION
Useful for gift card redemption flows that require the user to enter the amount of the gift card to be applied to the purchase.