### PR TITLE
fix/dosh crash (android)

### DIFF
--- a/android/app/src/main/java/com/bitpay/wallet/DoshModule.java
+++ b/android/app/src/main/java/com/bitpay/wallet/DoshModule.java
@@ -43,10 +43,14 @@ public class DoshModule extends ReactContextBaseJavaModule {
     activity.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        PoweredByDosh.Companion.initialize(self.applicationId, self.getReactApplicationContext());
-        self.initialized = true;
-        self.uiOptions = self.mapToUiOptions(uiOptions);
-        promise.resolve(true);
+        try {
+          PoweredByDosh.Companion.initialize(self.applicationId, self.getReactApplicationContext());
+          self.initialized = true;
+          self.uiOptions = self.mapToUiOptions(uiOptions);
+          promise.resolve(true);
+        } catch (Exception ex) {
+          promise.reject(BpErrorCodes.UNEXPECTED_ERROR, ex.getMessage());
+        }
       }
     });
   }

--- a/src/store/card/card.effects.ts
+++ b/src/store/card/card.effects.ts
@@ -91,7 +91,14 @@ export const startCardStoreInit =
       await Dosh.setDoshToken(doshToken);
     } catch (err) {
       dispatch(LogActions.error('An error occurred while initializing Dosh.'));
-      dispatch(LogActions.error(JSON.stringify(err)));
+
+      // check for Android exception (see: DoshModule.java)
+      // TODO: iOS exceptions
+      if ((err as any).message) {
+        dispatch(LogActions.error((err as any).message));
+      } else {
+        dispatch(LogActions.error(JSON.stringify(err)));
+      }
     }
   };
 


### PR DESCRIPTION
Add try/catch and log if Dosh init fails on Android. This happens if you forget to set the Dosh app ID, or if it's invalid in general. Also just to catch any unexpected errors to prevent app crash.