### PR TITLE
[FIX] store gasLimit in txp object

### DIFF
--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -498,6 +498,7 @@ const buildTransactionProposal =
           case 'eth':
             txp.from = tx.from;
             txp.nonce = tx.nonce;
+            txp.gasLimit = tx.gasLimit;
             txp.tokenAddress = tx.tokenAddress;
             txp.multisigContractAddress = tx.multisigContractAddress;
             break;


### PR DESCRIPTION
Changing the nonce in the confirmation view resets the value of the gas limit