### PR TITLE
Fix: build app on Android Studio Arctic Fox

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.3"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 30

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.0")
+        classpath('com.android.tools.build:gradle:4.2.2')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.android.gms:strict-version-matcher-plugin:1.2.1'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [x] Updated to SDK Build Tools 30.0.2
- [x] "yarn android" tested
- [x] Android Arctic Fox
- [x] Android Studio Chipmunk

### Warning

```
WARNING:: The specified Android SDK Build Tools version (29.0.3) is ignored, as it is below the minimum supported version (30.0.2) for Android Gradle Plugin 4.2.2.
Android SDK Build Tools 30.0.2 will be used.
```

### Notes

 compileSdkVersion = 31 <--- requires JDK 11 (OpenJDK Runtime Environment Zulu11.56+19-CA)

Check this: https://github.com/react-native-device-info/react-native-device-info/issues/1350#issuecomment-977615001