### PR TITLE
Fix confirm screen line-item overlap on resize

### DIFF
--- a/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
+++ b/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
@@ -1,4 +1,8 @@
-import {useFocusEffect, useLinkTo} from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useLinkTo,
+  useNavigation,
+} from '@react-navigation/native';
 import React from 'react';
 import {ImageStyle, Linking, StyleProp} from 'react-native';
 import ReactAppboy, {ContentCard} from 'react-native-appboy-sdk';
@@ -75,6 +79,7 @@ const IconStyle: StyleProp<ImageStyle> = {
 const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
   const {contentCard, ctaOverride} = props;
   const {image, url, openURLInWebView} = contentCard;
+  const navigation = useNavigation();
   const dispatch = useAppDispatch();
   const linkTo = useLinkTo();
   const theme = useTheme();
@@ -129,7 +134,10 @@ const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
     if (url.startsWith(APP_DEEPLINK_PREFIX)) {
       try {
         const path = '/' + url.replace(APP_DEEPLINK_PREFIX, '');
-
+        if (path === '/giftcard') {
+          navigation.navigate('Tabs', {screen: 'Shop'});
+          return;
+        }
         linkTo(path);
 
         return;

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -309,7 +309,7 @@ const Confirm = () => {
 
   return (
     <ConfirmContainer>
-      <ConfirmScrollView>
+      <ConfirmScrollView contentContainerStyle={{paddingBottom: 50}}>
         <DetailsList>
           <Header>Summary</Header>
           <SendingTo recipient={recipientData} hr />

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -320,7 +320,7 @@ const PayProConfirm = () => {
 
   return (
     <ConfirmContainer>
-      <ConfirmScrollView>
+      <ConfirmScrollView contentContainerStyle={{paddingBottom: 50}}>
         <DetailsList>
           <Header hr>Summary</Header>
           <SendingTo

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -61,14 +61,14 @@ export interface DetailContainerParams {
 }
 
 export const DetailContainer = styled.View<DetailContainerParams>`
-  min-height: 53px;
+  min-height: 60px;
   padding: 20px 0;
   justify-content: center;
   ${({height}) => (height ? `height: ${height}px;` : '')}
 `;
 
 export const PressableDetailContainer = styled.TouchableOpacity<DetailContainerParams>`
-  min-height: 53px;
+  min-height: 60px;
   padding: 20px 0;
   justify-content: center;
   ${({height}) => (height ? `height: ${height}px;` : '')}
@@ -373,12 +373,7 @@ export const RemainingTime = ({
   }, [computeRemainingTime, expirationTime, setDisableSwipeSendButton]);
 
   return (
-    <SharedDetailRow
-      description={t('Expires')}
-      height={60}
-      value={remainingTime}
-      hr
-    />
+    <SharedDetailRow description={t('Expires')} value={remainingTime} hr />
   );
 };
 


### PR DESCRIPTION
Increases line item min-height to 60px to prevent collapsing on confirm screen resize.

Also fixes braze shop tab link handling.