### PR TITLE
Optimize memo component

### DIFF
--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -309,8 +309,11 @@ const Confirm = () => {
 
   return (
     <ConfirmContainer>
-      <ConfirmScrollView contentContainerStyle={{paddingBottom: 50}}>
-        <DetailsList>
+      <ConfirmScrollView
+        extraScrollHeight={50}
+        contentContainerStyle={{paddingBottom: 50}}
+        keyboardShouldPersistTaps={'handled'}>
+        <DetailsList keyboardShouldPersistTaps={'handled'}>
           <Header>Summary</Header>
           <SendingTo recipient={recipientData} hr />
           <Fee

--- a/src/navigation/wallet/screens/send/confirm/Memo.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Memo.tsx
@@ -134,7 +134,8 @@ const MemoInputContainer = styled.View<MemoInputContainerParams>`
     hasFocus
       ? Action
       : getMemoBorderColor({hasFocus, isEditMode, isEmpty}, theme.dark)};
-  border-right-width: ${({isEmpty}) => (isEmpty ? memoBorderWidth : 0)}px;
+  border-right-width: ${({isEmpty, isEditMode}) =>
+    isEmpty && !isEditMode ? memoBorderWidth : 0}px;
   flex-direction: row;
 `;
 
@@ -183,6 +184,11 @@ export const Memo = ({
   const [draftMemo, setDraftMemo] = useState(memo);
   const theme = useTheme();
   const inputRef = useRef<TextInput>(null);
+  const save = () => {
+    setIsEditMode(false);
+    onChange(draftMemo);
+    inputRef.current?.blur();
+  };
   return (
     <>
       <MemoRow>
@@ -235,20 +241,26 @@ export const Memo = ({
           </MemoInputContainer>
           {draftMemo || isEditMode ? (
             <MemoOuterButtonContainer isEditMode={isEditMode}>
-              <MemoOuterButton
-                onPress={async () => {
-                  setIsEditMode(!isEditMode);
-                  await sleep(0);
-                  isEditMode ? onChange(draftMemo) : inputRef.current?.focus();
-                }}>
-                {isEditMode ? (
+              {isEditMode ? (
+                <MemoOuterButton
+                  onPress={async () => {
+                    save();
+                    // Prevent refocus after delayed autocorrect
+                    await sleep(300);
+                    save();
+                  }}>
                   <CheckSvg width={14} />
-                ) : theme.dark ? (
-                  <PencilDarkSvg />
-                ) : (
-                  <PencilSvg />
-                )}
-              </MemoOuterButton>
+                </MemoOuterButton>
+              ) : (
+                <MemoOuterButton
+                  onPress={async () => {
+                    setIsEditMode(true);
+                    await sleep(0);
+                    inputRef.current?.focus();
+                  }}>
+                  {theme.dark ? <PencilDarkSvg /> : <PencilSvg />}
+                </MemoOuterButton>
+              )}
             </MemoOuterButtonContainer>
           ) : null}
         </MemoContainer>

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -320,8 +320,11 @@ const PayProConfirm = () => {
 
   return (
     <ConfirmContainer>
-      <ConfirmScrollView contentContainerStyle={{paddingBottom: 50}}>
-        <DetailsList>
+      <ConfirmScrollView
+        extraScrollHeight={50}
+        contentContainerStyle={{paddingBottom: 50}}
+        keyboardShouldPersistTaps={'handled'}>
+        <DetailsList keyboardShouldPersistTaps={'handled'}>
           <Header hr>Summary</Header>
           <SendingTo
             recipient={{


### PR DESCRIPTION
1. Fix a border styling issue when the input is both empty and in edit mode
2. Ensure taps on the save and clear buttons are handled (rather than ignored) while the keyboard is open
3. On focus, scroll sufficiently to make sure entire memo input is above the keyboard (iOS only)

