### PR TITLE
Fix/dosh crash ios

### DIFF
--- a/src/lib/dosh/Dosh.ts
+++ b/src/lib/dosh/Dosh.ts
@@ -42,8 +42,10 @@ interface DoshModule {
 interface Dosh extends Omit<DoshModule, 'initializeDosh'> {
   /**
    * This should be done before any other calls to the PoweredByDosh SDK.
+   *
+   * TODO: returns a Promise<any> on Android, but void iOS. See if we can update iOS bridge.
    */
-  initializeDosh: (uiOptions: DoshUiOptions) => Promise<any>;
+  initializeDosh: (uiOptions: DoshUiOptions) => void;
 }
 
 const DoshModule = ReactNative.NativeModules.Dosh as DoshModule;

--- a/src/lib/dosh/Dosh.ts
+++ b/src/lib/dosh/Dosh.ts
@@ -8,26 +8,27 @@ interface DoshModule {
   /**
    * This should be done before any other calls to the PoweredByDosh SDK.
    * TODO: pass in applicationId from JS?
+   * TODO: returns a Promise<any> on Android, but void iOS. See if we can update iOS bridge.
    * @param uiOptions Required on Android. Options to customize the SDK's header title and brand page UI.
    */
-  initializeDosh: (uiOptions: DoshUiOptions) => Promise<any>;
+  initializeDosh: (uiOptions: DoshUiOptions) => void;
 
   /**
    * User authorization between the app and Dosh is coordinated by providing the SDK with an authorization token.
    * This token should be requested from the BitPay server.
    */
-  setDoshToken: (token: string) => Promise<any>;
+  setDoshToken: (token: string) => void;
 
   /**
    * Present a full screen view that is managed by the SDK.
    */
-  present: () => Promise<any>;
+  present: () => void;
 
   /**
    * Any time the app's current user changes, such as when the user logs out, the user's information should be cleared.
    * As of now only written for the Android bridge.
    */
-  clearUser: () => Promise<any>;
+  clearUser: () => void;
 
   /**
    * @deprecated For development purposes only. Do not call this in production.
@@ -42,8 +43,6 @@ interface DoshModule {
 interface Dosh extends Omit<DoshModule, 'initializeDosh'> {
   /**
    * This should be done before any other calls to the PoweredByDosh SDK.
-   *
-   * TODO: returns a Promise<any> on Android, but void iOS. See if we can update iOS bridge.
    */
   initializeDosh: (uiOptions: DoshUiOptions) => void;
 }

--- a/src/store/card/card.effects.ts
+++ b/src/store/card/card.effects.ts
@@ -77,31 +77,31 @@ export const startCardStoreInit =
     } else {
       const options = new DoshUiOptions('Card Offers', 'CIRCLE', 'DIAGONAL');
 
-      Dosh.initializeDosh(options)
-        .then(() => {
-          dispatch(LogActions.info('Successfully initialized Dosh.'));
+      try {
+        Dosh.initializeDosh(options);
 
-          const {doshToken} = initialData;
-          if (!doshToken) {
-            dispatch(LogActions.debug('No doshToken provided.'));
-            return;
-          }
+        dispatch(LogActions.info('Successfully initialized Dosh.'));
 
-          return Dosh.setDoshToken(doshToken);
-        })
-        .catch(err => {
-          dispatch(
-            LogActions.error('An error occurred while initializing Dosh.'),
-          );
+        const {doshToken} = initialData;
+        if (!doshToken) {
+          dispatch(LogActions.debug('No doshToken provided.'));
+          return;
+        }
 
-          // check for Android exception (see: DoshModule.java)
-          // TODO: iOS exceptions
-          if ((err as any).message) {
-            dispatch(LogActions.error((err as any).message));
-          } else {
-            dispatch(LogActions.error(JSON.stringify(err)));
-          }
-        });
+        Dosh.setDoshToken(doshToken);
+      } catch (err: any) {
+        dispatch(
+          LogActions.error('An error occurred while initializing Dosh.'),
+        );
+
+        // check for Android exception (see: DoshModule.java)
+        // TODO: iOS exceptions
+        if ((err as any).message) {
+          dispatch(LogActions.error((err as any).message));
+        } else {
+          dispatch(LogActions.error(JSON.stringify(err)));
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Dosh bridge (iOS) is not setup to return promises at the moment, removed instances of `.then()` and update types