### PR TITLE
Fix: avoid select signed txp. If multipleSignAvailable is active...

### DIFF
--- a/src/navigation/wallet/screens/TransactionProposalDetails.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalDetails.tsx
@@ -70,7 +70,7 @@ import {BottomNotificationConfig} from '../../../components/modal/bottom-notific
 import {startUpdateWalletStatus} from '../../../store/wallet/effects/status/status';
 import {useTranslation} from 'react-i18next';
 
-const TxsDetailsContainer = styled.View`
+const TxsDetailsContainer = styled.SafeAreaView`
   flex: 1;
 `;
 

--- a/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
@@ -61,7 +61,7 @@ import SwipeButton from '../../../components/swipe-button/SwipeButton';
 import {publishAndSignMultipleProposals} from '../../../store/wallet/effects/send/send';
 import {HamburgerContainer} from '../../tabs/settings/general/screens/customize-home/Shared';
 
-const NotificationsContainer = styled.View`
+const NotificationsContainer = styled.SafeAreaView`
   flex: 1;
 `;
 
@@ -364,7 +364,8 @@ const TransactionProposalNotifications = () => {
           {item?.txps[0]
             ? item.txps.map((txp: any) => (
                 <ProposalsContainer key={txp.id}>
-                  {selectingProposalsWalletId === _walletId ? (
+                  {selectingProposalsWalletId === _walletId &&
+                  item.multipleSignAvailable ? (
                     <CheckBoxContainer>
                       <Checkbox
                         checked={!!txpChecked[txp.id]}
@@ -380,7 +381,12 @@ const TransactionProposalNotifications = () => {
                       creator={txp.uiCreator}
                       time={txp.uiTime}
                       value={txp.uiValue}
-                      onPressTransaction={() => onPressTxp(txp, fullWalletObj)}
+                      onPressTransaction={() =>
+                        selectingProposalsWalletId === _walletId &&
+                        item.multipleSignAvailable
+                          ? txpSelectionChange(txp)
+                          : onPressTxp(txp, fullWalletObj)
+                      }
                       hideIcon={true}
                     />
                   </ProposalsInfoContainer>


### PR DESCRIPTION
* If multipleSignAvailable is active, do not open details view, just select clicking on the row. 
* Adds SafeAreaView

![Simulator Screen Shot - iPhone 12 - 2022-07-12 at 16 31 11](https://user-images.githubusercontent.com/237435/178578443-16693e51-d5e6-40d3-8817-7dae2d9c58f2.png)

