### PR TITLE
Fix: enable renew subscription for silent push notifications

### DIFF
--- a/src/navigation/tabs/settings/components/Notifications.tsx
+++ b/src/navigation/tabs/settings/components/Notifications.tsx
@@ -125,6 +125,16 @@ const Notifications = () => {
     return () => AppState.removeEventListener('change', onAppStateChange);
   }, [dispatch, setNotificationValue, notificationsState.pushNotifications]);
 
+  useEffect(() => {
+    if (notificationsState && notificationsState.pushNotifications) {
+      // Subscribe for silent push notifications
+      const silentPushInterval = setInterval(() => {
+        dispatch(AppEffects.renewSubscription());
+      }, 3 * 60 * 1000); // 3 min
+      return () => clearInterval(silentPushInterval);
+    }
+  }, [dispatch, notificationsState]);
+
   return (
     <SettingsComponent>
       {notificationsList.map(({title, checked, onPress, show}, i) =>

--- a/src/navigation/tabs/settings/components/Notifications.tsx
+++ b/src/navigation/tabs/settings/components/Notifications.tsx
@@ -1,6 +1,13 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Alert, View, AppState, AppStateStatus, Linking} from 'react-native';
+import {
+  Alert,
+  View,
+  AppState,
+  AppStateStatus,
+  Linking,
+  LogBox,
+} from 'react-native';
 import Checkbox from '../../../../components/checkbox/Checkbox';
 import {
   Hr,
@@ -124,6 +131,9 @@ const Notifications = () => {
     AppState.addEventListener('change', onAppStateChange);
     return () => AppState.removeEventListener('change', onAppStateChange);
   }, [dispatch, setNotificationValue, notificationsState.pushNotifications]);
+
+  // Ignore warning: Setting a timer for long period of time...
+  LogBox.ignoreLogs(['Setting a timer']);
 
   useEffect(() => {
     if (notificationsState && notificationsState.pushNotifications) {

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -514,6 +514,7 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
       DeviceEmitterEvents.WALLET_LOAD_HISTORY,
       () => {
         loadHistoryRef.current(true);
+        setNeedActionTxps(pendingTxps);
       },
     );
     return () => subscription.remove();
@@ -1028,23 +1029,25 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
                 ) : null}
               </HeaderContainer>
               {pendingTxps && pendingTxps[0] ? (
-                <TransactionSectionHeaderContainer>
-                  <H5>
-                    {fullWalletObj.credentials.m > 1
-                      ? t('Pending Proposals')
-                      : t('Unsent Transactions')}
-                  </H5>
-                  <ProposalBadgeContainer onPress={onPressTxpBadge}>
-                    <ProposalBadge>{pendingTxps.length}</ProposalBadge>
-                  </ProposalBadgeContainer>
-                </TransactionSectionHeaderContainer>
+                <>
+                  <TransactionSectionHeaderContainer>
+                    <H5>
+                      {fullWalletObj.credentials.m > 1
+                        ? t('Pending Proposals')
+                        : t('Unsent Transactions')}
+                    </H5>
+                    <ProposalBadgeContainer onPress={onPressTxpBadge}>
+                      <ProposalBadge>{pendingTxps.length}</ProposalBadge>
+                    </ProposalBadgeContainer>
+                  </TransactionSectionHeaderContainer>
+                  <FlatList
+                    contentContainerStyle={{paddingTop: 20, paddingBottom: 20}}
+                    data={needActionPendingTxps}
+                    keyExtractor={pendingTxpsKeyExtractor}
+                    renderItem={renderTxp}
+                  />
+                </>
               ) : null}
-              <FlatList
-                contentContainerStyle={{paddingTop: 20, paddingBottom: 20}}
-                data={needActionPendingTxps}
-                keyExtractor={pendingTxpsKeyExtractor}
-                renderItem={renderTxp}
-              />
 
               {Number(cryptoLockedBalance) > 0 ? (
                 <LockedBalanceContainer>

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -52,12 +52,12 @@ import {
 import {SilentPushEvent} from '../../Root';
 import {
   startUpdateAllKeyAndWalletStatus,
-  startUpdateAllWalletStatusForKey,
   startUpdateWalletStatus,
 } from '../wallet/effects/status/status';
 import {createWalletAddress} from '../wallet/effects/address/address';
 import {DeviceEmitterEvents} from '../../constants/device-emitter-events';
 import {APP_ANALYTICS_ENABLED} from '../../constants/config';
+import {debounce} from 'lodash';
 
 // Subscription groups (Braze)
 const PRODUCTS_UPDATES_GROUP_ID = __DEV__
@@ -687,6 +687,32 @@ export const setOffersAndPromotionsNotifications =
     }
   };
 
+const _startUpdateAllKeyAndWalletStatus = debounce(
+  async dispatch => {
+    dispatch(startUpdateAllKeyAndWalletStatus());
+    DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
+  },
+  5000,
+  {leading: true, trailing: false},
+);
+
+const _createWalletAddress = debounce(
+  async (dispatch, wallet) => {
+    dispatch(createWalletAddress({wallet, newAddress: true}));
+  },
+  5000,
+  {leading: true, trailing: false},
+);
+
+const _startUpdateWalletStatus = debounce(
+  async (dispatch, keyObj, wallet) => {
+    dispatch(startUpdateWalletStatus({key: keyObj, wallet}));
+    DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
+  },
+  5000,
+  {leading: true, trailing: false},
+);
+
 export const handleBwsEvent =
   (response: SilentPushEvent): Effect =>
   async (dispatch, getState) => {
@@ -709,18 +735,6 @@ export const handleBwsEvent =
       ) {
         return;
       }
-      console.log(
-        '#### wallet found! Sending Event...',
-        wallet.credentials.walletId,
-      );
-      let walletId = wallet.credentials.walletId;
-      if (response.tokenAddress) {
-        walletId =
-          wallet.credentials.walletId +
-          '-' +
-          response.tokenAddress.toLowerCase();
-        console.log(`### event for token wallet: ${walletId}`);
-      }
 
       // TODO showInappNotification(data);
 
@@ -733,12 +747,11 @@ export const handleBwsEvent =
 
       switch (response.notification_type) {
         case 'NewAddress':
-          dispatch(createWalletAddress({wallet, newAddress: true}));
+          _createWalletAddress(dispatch, wallet);
           break;
         case 'NewBlock':
           if (response.network && response.network === 'livenet') {
-            dispatch(startUpdateAllKeyAndWalletStatus());
-            DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
+            _startUpdateAllKeyAndWalletStatus(dispatch);
           }
           break;
         case 'TxProposalAcceptedBy':
@@ -748,8 +761,7 @@ export const handleBwsEvent =
         case 'NewIncomingTx':
         case 'NewTxProposal':
         case 'TxConfirmation':
-          await dispatch(startUpdateWalletStatus({key: keyObj, wallet}));
-          DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
+          _startUpdateWalletStatus(dispatch, keyObj, wallet);
           break;
       }
     }

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -612,6 +612,30 @@ export const checkNotificationsPermissions = (): Promise<boolean> => {
   });
 };
 
+export const renewSubscription = (): Effect => (dispatch, getState) => {
+  const {
+    WALLET: {keys},
+    APP,
+  } = getState();
+  console.log('[app.effects.ts:619] #### renew subscription'); /* TODO */
+
+  getAllWalletClients(keys).then(walletClients => {
+    walletClients.forEach(walletClient => {
+      console.log(
+        '[app.effects.ts:623] ### for wallet',
+        walletClient.credentials.walletId,
+      ); /* TODO */
+      dispatch(subscribePushNotifications(walletClient, APP.brazeEid!));
+      dispatch(
+        LogActions.debug(
+          'Review Subscription Push Notifications for: ' +
+            walletClient.credentials.walletId,
+        ),
+      );
+    });
+  });
+};
+
 export const setNotifications =
   (accepted: boolean): Effect =>
   (dispatch, getState) => {

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -553,30 +553,15 @@ export const Analytics = {
 };
 
 export const subscribePushNotifications =
-  (walletClient: any, eid: string): Effect<Promise<void>> =>
-  async dispatch => {
+  (walletClient: any, eid: string): Effect =>
+  () => {
     const opts = {
       externalUserId: eid,
       platform: Platform.OS,
       packageName: 'BitPay',
       walletId: walletClient.credentials.walletId,
     };
-    walletClient.pushNotificationsSubscribe(opts, (err: any) => {
-      if (err) {
-        dispatch(
-          LogActions.error(
-            'Push Notifications error subscribing: ' + JSON.stringify(err),
-          ),
-        );
-      } else {
-        dispatch(
-          LogActions.info(
-            'Push Notifications success subscribing: ' +
-              walletClient.credentials.walletName,
-          ),
-        );
-      }
-    });
+    walletClient.pushNotificationsSubscribe(opts);
   };
 
 export const unSubscribePushNotifications =
@@ -621,12 +606,6 @@ export const renewSubscription = (): Effect => (dispatch, getState) => {
   getAllWalletClients(keys).then(walletClients => {
     walletClients.forEach(walletClient => {
       dispatch(subscribePushNotifications(walletClient, APP.brazeEid!));
-      dispatch(
-        LogActions.debug(
-          'Review Subscription Push Notifications for: ' +
-            walletClient.credentials.walletId,
-        ),
-      );
     });
   });
 };

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -617,14 +617,9 @@ export const renewSubscription = (): Effect => (dispatch, getState) => {
     WALLET: {keys},
     APP,
   } = getState();
-  console.log('[app.effects.ts:619] #### renew subscription'); /* TODO */
 
   getAllWalletClients(keys).then(walletClients => {
     walletClients.forEach(walletClient => {
-      console.log(
-        '[app.effects.ts:623] ### for wallet',
-        walletClient.credentials.walletId,
-      ); /* TODO */
       dispatch(subscribePushNotifications(walletClient, APP.brazeEid!));
       dispatch(
         LogActions.debug(
@@ -749,13 +744,11 @@ export const handleBwsEvent =
         case 'TxProposalAcceptedBy':
         case 'TxProposalRejectedBy':
         case 'TxProposalRemoved':
-          dispatch(startUpdateAllWalletStatusForKey({key: keyObj}));
-          break;
         case 'NewOutgoingTx':
         case 'NewIncomingTx':
         case 'NewTxProposal':
         case 'TxConfirmation':
-          dispatch(startUpdateWalletStatus({key: keyObj, wallet}));
+          await dispatch(startUpdateWalletStatus({key: keyObj, wallet}));
           DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
           break;
       }


### PR DESCRIPTION
* Renew subscription for receive silent push notification and keep app active when it's open. 
* Debounce functions to avoid multiple calls
* Update list of transactions proposals when receive an update
* Ignore warning: Settings a time for long period of time (https://github.com/ably/ably-js/issues/749#issuecomment-455680414) 