### PR TITLE
Feat/persist keyboard taps

### DIFF
--- a/src/components/form/BoxInput.tsx
+++ b/src/components/form/BoxInput.tsx
@@ -1,10 +1,11 @@
 import React, {useState} from 'react';
-import {TextInput, TextInputProps} from 'react-native';
+import {KeyboardTypeOptions, TextInput, TextInputProps} from 'react-native';
 import TextInputMask, {TextInputMaskProps} from 'react-native-text-input-mask';
 import styled, {css} from 'styled-components/native';
 import ObfuscationHide from '../../../assets/img/obfuscation-hide.svg';
 import ObfuscationShow from '../../../assets/img/obfuscation-show.svg';
 import Search from '../../../assets/img/search.svg';
+import {IS_ANDROID} from '../../constants';
 import {
   Caution,
   LightBlack,
@@ -147,6 +148,10 @@ const BoxInput = React.forwardRef<
     const isSearch = type === 'search';
     const [isFocused, setIsFocused] = useState(false);
     const [isSecureTextEntry, setSecureTextEntry] = useState(isPassword);
+    const keyboardType: KeyboardTypeOptions | undefined =
+      isPassword && !isSecureTextEntry && IS_ANDROID
+        ? 'visible-password'
+        : undefined;
 
     const _onFocus = () => {
       setIsFocused(true);
@@ -184,6 +189,7 @@ const BoxInput = React.forwardRef<
           {prefix ? <Prefix>{prefix()}</Prefix> : null}
 
           <Input
+            keyboardType={keyboardType}
             {...props}
             ref={ref}
             secureTextEntry={isPassword && isSecureTextEntry}

--- a/src/navigation/auth/components/AuthFormContainer.tsx
+++ b/src/navigation/auth/components/AuthFormContainer.tsx
@@ -3,7 +3,9 @@ import {ScreenGutter} from '../../../components/styled/Containers';
 import {BaseText} from '../../../components/styled/Text';
 import {Caution} from '../../../styles/colors';
 
-const AuthFormContainer = styled.ScrollView`
+const AuthFormContainer = styled.ScrollView.attrs(() => ({
+  keyboardShouldPersistTaps: 'handled',
+}))`
   padding: 24px ${ScreenGutter};
 `;
 

--- a/src/navigation/auth/screens/CreateAccount.tsx
+++ b/src/navigation/auth/screens/CreateAccount.tsx
@@ -3,7 +3,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect, useRef, useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
-import {SafeAreaView, TextInput} from 'react-native';
+import {Keyboard, SafeAreaView, TextInput} from 'react-native';
 import * as yup from 'yup';
 import A from '../../../components/anchor/Anchor';
 import Button from '../../../components/button/Button';
@@ -16,7 +16,7 @@ import {navigationRef} from '../../../Root';
 import {AppActions} from '../../../store/app';
 import {BitPayIdActions, BitPayIdEffects} from '../../../store/bitpay-id';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
-import {AuthStackParamList} from '../AuthStack';
+import {AuthScreens, AuthStackParamList} from '../AuthStack';
 import AuthFormContainer, {
   AuthActionRow,
   AuthActionsContainer,
@@ -31,7 +31,7 @@ import RecaptchaModal, {CaptchaRef} from '../components/RecaptchaModal';
 export type CreateAccountScreenParamList = {} | undefined;
 type CreateAccountScreenProps = StackScreenProps<
   AuthStackParamList,
-  'CreateAccount'
+  AuthScreens.CREATE_ACCOUNT
 >;
 
 const schema = yup.object().shape({
@@ -134,24 +134,32 @@ const CreateAccountScreen: React.VFC<CreateAccountScreenProps> = ({
     t,
   ]);
 
-  const onSubmit = handleSubmit(formData => {
-    const {email, givenName, familyName, agreedToTOSandPP, password} = formData;
+  const onSubmit = handleSubmit(
+    formData => {
+      Keyboard.dismiss();
 
-    if (!session.captchaDisabled) {
-      setRecaptchaVisible(true);
-      return;
-    }
+      const {email, givenName, familyName, agreedToTOSandPP, password} =
+        formData;
 
-    dispatch(
-      BitPayIdEffects.startCreateAccount({
-        givenName,
-        familyName,
-        email,
-        password,
-        agreedToTOSandPP,
-      }),
-    );
-  });
+      if (!session.captchaDisabled) {
+        setRecaptchaVisible(true);
+        return;
+      }
+
+      dispatch(
+        BitPayIdEffects.startCreateAccount({
+          givenName,
+          familyName,
+          email,
+          password,
+          agreedToTOSandPP,
+        }),
+      );
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   const onCaptchaResponse = (gCaptchaResponse: string) => {
     setRecaptchaVisible(false);

--- a/src/navigation/auth/screens/ForgotPassword.tsx
+++ b/src/navigation/auth/screens/ForgotPassword.tsx
@@ -1,4 +1,5 @@
 import {yupResolver} from '@hookform/resolvers/yup';
+import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect, useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
@@ -13,6 +14,7 @@ import {BitPayIdActions, BitPayIdEffects} from '../../../store/bitpay-id';
 import {sleep} from '../../../utils/helper-methods';
 import {useAppDispatch} from '../../../utils/hooks/useAppDispatch';
 import {useAppSelector} from '../../../utils/hooks/useAppSelector';
+import {AuthScreens, AuthStackParamList} from '../AuthStack';
 import AuthFormContainer, {
   AuthActionRow,
   AuthActionsContainer,
@@ -30,7 +32,9 @@ interface ResetPasswordFormFieldValues {
   email: string;
 }
 
-const ForgotPassword = () => {
+const ForgotPasswordScreen: React.VFC<
+  StackScreenProps<AuthStackParamList, AuthScreens.FORGOT_PASSWORD>
+> = () => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const session = useAppSelector(({BITPAY_ID}) => BITPAY_ID.session);
@@ -90,15 +94,20 @@ const ForgotPassword = () => {
     }
   }, [dispatch, forgotPasswordEmailStatus, t]);
 
-  const onSubmit = handleSubmit(({email}) => {
-    Keyboard.dismiss();
+  const onSubmit = handleSubmit(
+    ({email}) => {
+      Keyboard.dismiss();
 
-    if (session.captchaDisabled) {
-      dispatch(BitPayIdEffects.startSubmitForgotPasswordEmail({email}));
-    } else {
-      setCaptchaModalVisible(true);
-    }
-  });
+      if (session.captchaDisabled) {
+        dispatch(BitPayIdEffects.startSubmitForgotPasswordEmail({email}));
+      } else {
+        setCaptchaModalVisible(true);
+      }
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   const onCaptchaResponse = async (gCaptchaResponse: string) => {
     const {email} = getValues();
@@ -154,4 +163,4 @@ const ForgotPassword = () => {
   );
 };
 
-export default ForgotPassword;
+export default ForgotPasswordScreen;

--- a/src/navigation/auth/screens/Login.tsx
+++ b/src/navigation/auth/screens/Login.tsx
@@ -16,7 +16,7 @@ import {BitPayIdActions, BitPayIdEffects} from '../../../store/bitpay-id';
 import {sleep} from '../../../utils/helper-methods';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
 import {BitpayIdScreens} from '../../bitpay-id/BitpayIdStack';
-import {AuthStackParamList} from '../AuthStack';
+import {AuthScreens, AuthStackParamList} from '../AuthStack';
 import AuthFormContainer, {
   AuthActionRow,
   AuthActionsContainer,
@@ -31,7 +31,7 @@ export type LoginScreenParamList =
     }
   | undefined;
 
-type LoginScreenProps = StackScreenProps<AuthStackParamList, 'Login'>;
+type LoginScreenProps = StackScreenProps<AuthStackParamList, AuthScreens.LOGIN>;
 
 const schema = yup.object().shape({
   email: yup.string().email().required().trim(),
@@ -43,7 +43,7 @@ interface LoginFormFieldValues {
   password: string;
 }
 
-const LoginScreen: React.FC<LoginScreenProps> = ({navigation, route}) => {
+const LoginScreen: React.VFC<LoginScreenProps> = ({navigation, route}) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const {
@@ -128,14 +128,19 @@ const LoginScreen: React.FC<LoginScreenProps> = ({navigation, route}) => {
     }
   }, [dispatch, onLoginSuccess, navigation, loginStatus, loginError, t]);
 
-  const onSubmit = handleSubmit(({email, password}) => {
-    Keyboard.dismiss();
-    if (session.captchaDisabled) {
-      dispatch(BitPayIdEffects.startLogin({email, password}));
-    } else {
-      setCaptchaModalVisible(true);
-    }
-  });
+  const onSubmit = handleSubmit(
+    ({email, password}) => {
+      Keyboard.dismiss();
+      if (session.captchaDisabled) {
+        dispatch(BitPayIdEffects.startLogin({email, password}));
+      } else {
+        setCaptchaModalVisible(true);
+      }
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   const onTroubleLoggingIn = () => {
     navigation.navigate('ForgotPassword');

--- a/src/navigation/auth/screens/TwoFactor.Auth.tsx
+++ b/src/navigation/auth/screens/TwoFactor.Auth.tsx
@@ -3,6 +3,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
+import {Keyboard} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
 import * as yup from 'yup';
 import Button from '../../../components/button/Button';
@@ -11,7 +12,7 @@ import {RootState} from '../../../store';
 import {AppActions} from '../../../store/app';
 import {BitPayIdActions, BitPayIdEffects} from '../../../store/bitpay-id';
 import {TwoFactorAuthStatus} from '../../../store/bitpay-id/bitpay-id.reducer';
-import {AuthStackParamList} from '../AuthStack';
+import {AuthScreens, AuthStackParamList} from '../AuthStack';
 import AuthFormContainer, {
   AuthActionsContainer,
   AuthFormParagraph,
@@ -26,7 +27,7 @@ export type TwoFactorAuthenticationParamList =
 
 type TwoFactorAuthenticationScreenProps = StackScreenProps<
   AuthStackParamList,
-  'TwoFactorAuthentication'
+  AuthScreens.TWO_FACTOR_AUTH
 >;
 
 interface TwoFactorAuthFieldValues {
@@ -37,7 +38,7 @@ const schema = yup.object().shape({
   code: yup.string().required('Required'),
 });
 
-const TwoFactorAuthentication: React.FC<
+const TwoFactorAuthentication: React.VFC<
   TwoFactorAuthenticationScreenProps
 > = props => {
   const {t} = useTranslation();
@@ -109,13 +110,20 @@ const TwoFactorAuthentication: React.FC<
     onLoginSuccess,
   ]);
 
-  const onSubmit = handleSubmit(({code}) => {
-    if (!code) {
-      return;
-    }
+  const onSubmit = handleSubmit(
+    ({code}) => {
+      Keyboard.dismiss();
 
-    dispatch(BitPayIdEffects.startTwoFactorAuth(code));
-  });
+      if (!code) {
+        return;
+      }
+
+      dispatch(BitPayIdEffects.startTwoFactorAuth(code));
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   return (
     <AuthFormContainer>

--- a/src/navigation/auth/screens/TwoFactor.Pair.tsx
+++ b/src/navigation/auth/screens/TwoFactor.Pair.tsx
@@ -3,6 +3,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect, useMemo} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
+import {Keyboard} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
 import * as yup from 'yup';
 import Button from '../../../components/button/Button';
@@ -13,7 +14,7 @@ import {AppActions} from '../../../store/app';
 import {BitPayIdActions, BitPayIdEffects} from '../../../store/bitpay-id';
 import {TwoFactorPairingStatus} from '../../../store/bitpay-id/bitpay-id.reducer';
 import {BitpayIdScreens} from '../../bitpay-id/BitpayIdStack';
-import {AuthStackParamList} from '../AuthStack';
+import {AuthScreens, AuthStackParamList} from '../AuthStack';
 import AuthFormContainer, {
   AuthActionsContainer,
   AuthFormParagraph,
@@ -27,14 +28,14 @@ export type TwoFactorPairingParamList = {
 
 type TwoFactorPairingScreenProps = StackScreenProps<
   AuthStackParamList,
-  'TwoFactorPairing'
+  AuthScreens.TWO_FACTOR_PAIR
 >;
 
 interface TwoFactorPairingFieldValues {
   code: string;
 }
 
-const TwoFactorPairing: React.FC<TwoFactorPairingScreenProps> = ({
+const TwoFactorPairing: React.VFC<TwoFactorPairingScreenProps> = ({
   navigation,
   route,
 }) => {
@@ -128,13 +129,20 @@ const TwoFactorPairing: React.FC<TwoFactorPairingScreenProps> = ({
     onLoginSuccess,
   ]);
 
-  const onSubmit = handleSubmit(({code}) => {
-    if (!code) {
-      return;
-    }
+  const onSubmit = handleSubmit(
+    ({code}) => {
+      Keyboard.dismiss();
 
-    dispatch(BitPayIdEffects.startTwoFactorPairing(code));
-  });
+      if (!code) {
+        return;
+      }
+
+      dispatch(BitPayIdEffects.startTwoFactorPairing(code));
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   return (
     <AuthFormContainer>

--- a/src/navigation/card-activation/screens/ActivateScreen.tsx
+++ b/src/navigation/card-activation/screens/ActivateScreen.tsx
@@ -3,7 +3,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {t} from 'i18next';
-import {TextInput} from 'react-native';
+import {Keyboard, TextInput} from 'react-native';
 import * as yup from 'yup';
 import Button, {ButtonState} from '../../../components/button/Button';
 import BoxInput from '../../../components/form/BoxInput';
@@ -21,7 +21,10 @@ import AuthFormContainer, {
   AuthActionsContainer,
   AuthRowContainer,
 } from '../../auth/components/AuthFormContainer';
-import {CardActivationStackParamList} from '../CardActivationStack';
+import {
+  CardActivationScreens,
+  CardActivationStackParamList,
+} from '../CardActivationStack';
 
 export type ActivateScreenParamList = {
   card: Card;
@@ -117,8 +120,8 @@ const formatExpirationDateForBackend = (expirationDate: string) => {
   return `${expYear}${expMonth}`;
 };
 
-const ActivateScreen: React.FC<
-  StackScreenProps<CardActivationStackParamList, 'Activate'>
+const ActivateScreen: React.VFC<
+  StackScreenProps<CardActivationStackParamList, CardActivationScreens.ACTIVATE>
 > = ({navigation, route}) => {
   const {card} = route.params;
   const dispatch = useAppDispatch();
@@ -147,27 +150,34 @@ const ActivateScreen: React.FC<
   const initRef = useRef(init);
   initRef.current = init;
 
-  const onSubmit = handleSubmit(formData => {
-    setButtonState('loading');
-    const {cvv, expirationDate} = formData;
-    const payload: StartActivateCardParams = {
-      cvv: cvv,
-      expirationDate: formatExpirationDateForBackend(expirationDate),
-    };
+  const onSubmit = handleSubmit(
+    formData => {
+      Keyboard.dismiss();
 
-    if (isGalileoForm(formData)) {
-      const {lastFourDigits} = formData;
+      setButtonState('loading');
+      const {cvv, expirationDate} = formData;
+      const payload: StartActivateCardParams = {
+        cvv: cvv,
+        expirationDate: formatExpirationDateForBackend(expirationDate),
+      };
 
-      payload.lastFourDigits = lastFourDigits;
-    } else if (isFirstViewForm(formData)) {
-      const {cardNumber} = formData;
+      if (isGalileoForm(formData)) {
+        const {lastFourDigits} = formData;
 
-      payload.cardNumber = cardNumber;
-      payload.lastFourDigits = cardNumber.slice(-4);
-    }
+        payload.lastFourDigits = lastFourDigits;
+      } else if (isFirstViewForm(formData)) {
+        const {cardNumber} = formData;
 
-    dispatch(CardEffects.startActivateCard(card.id, payload));
-  });
+        payload.cardNumber = cardNumber;
+        payload.lastFourDigits = cardNumber.slice(-4);
+      }
+
+      dispatch(CardEffects.startActivateCard(card.id, payload));
+    },
+    () => {
+      Keyboard.dismiss();
+    },
+  );
 
   useLayoutEffect(() => {
     initRef.current();

--- a/src/navigation/card/screens/settings/UpdateCardName.tsx
+++ b/src/navigation/card/screens/settings/UpdateCardName.tsx
@@ -1,7 +1,7 @@
 import {StackScreenProps} from '@react-navigation/stack';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {ScrollView} from 'react-native';
+import {Keyboard} from 'react-native';
 import styled from 'styled-components/native';
 import Button, {ButtonState} from '../../../../components/button/Button';
 import BoxInput from '../../../../components/form/BoxInput';
@@ -11,13 +11,13 @@ import {AppActions} from '../../../../store/app';
 import {CardActions, CardEffects} from '../../../../store/card';
 import {Card} from '../../../../store/card/card.models';
 import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
-import {CardStackParamList} from '../../CardStack';
+import {CardScreens, CardStackParamList} from '../../CardStack';
 
 export interface UpdateCardNameScreenParamList {
   card: Card;
 }
 
-const ContentContainer = styled.View`
+const ContentContainer = styled.ScrollView`
   padding: ${ScreenGutter};
 `;
 
@@ -42,8 +42,8 @@ const createErrorConfig = (
   ],
 });
 
-const UpdateCardNameScreen: React.FC<
-  StackScreenProps<CardStackParamList, 'UpdateCardName'>
+const UpdateCardNameScreen: React.VFC<
+  StackScreenProps<CardStackParamList, CardScreens.UPDATE_CARD_NAME>
 > = ({navigation, route}) => {
   const {card} = route.params;
   const dispatch = useAppDispatch();
@@ -55,6 +55,8 @@ const UpdateCardNameScreen: React.FC<
   const [buttonState, setButtonState] = useState<ButtonState>();
 
   const onUpdatePress = () => {
+    Keyboard.dismiss();
+
     setButtonState('loading');
 
     dispatch(CardEffects.START_UPDATE_CARD_NAME(card.id, newName));
@@ -85,21 +87,19 @@ const UpdateCardNameScreen: React.FC<
   }, [updateNameStatus, card.id, dispatch, navigation, t]);
 
   return (
-    <ScrollView>
-      <ContentContainer>
-        <FormContainer>
-          <BoxInput
-            label={t('Card Name')}
-            value={newName}
-            onChangeText={(text: string) => setNewName(text)}
-          />
-        </FormContainer>
+    <ContentContainer keyboardShouldPersistTaps={'handled'}>
+      <FormContainer>
+        <BoxInput
+          label={t('Card Name')}
+          value={newName}
+          onChangeText={(text: string) => setNewName(text)}
+        />
+      </FormContainer>
 
-        <Button state={buttonState} onPress={() => onUpdatePress()}>
-          {t('Update')}
-        </Button>
-      </ContentContainer>
-    </ScrollView>
+      <Button state={buttonState} onPress={() => onUpdatePress()}>
+        {t('Update')}
+      </Button>
+    </ContentContainer>
   );
 };
 

--- a/src/store/bitpay-id/bitpay-id.reducer.ts
+++ b/src/store/bitpay-id/bitpay-id.reducer.ts
@@ -214,7 +214,7 @@ export const bitPayIdReducer = (
     case BitPayIdActionTypes.UPDATE_TWO_FACTOR_PAIRING_STATUS:
       return {
         ...state,
-        twoFactorPairingStatus: 'success',
+        twoFactorPairingStatus: action.payload,
       };
 
     case BitPayIdActionTypes.SUCCESS_EMAIL_PAIRING:


### PR DESCRIPTION
Keyboard improvements:

- use `visible-password` input type on Android when show password is toggled, this prevents Android from switching to the normal text keyboard when password is visible
- use `keyboardShouldPersistTaps='handled'` on Auth and Card stack inputs so you can submit/toggle inputs while keyboard is open, also manually dismiss keyboard as needed
- fixed typo where 2fa pairing status was hardcoded to success