### PR TITLE
Fix json copayer name

### DIFF
--- a/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
@@ -37,7 +37,7 @@ import {findWalletById} from '../../../store/wallet/utils/wallet';
 import {useTranslation} from 'react-i18next';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import {startGetRates} from '../../../store/wallet/effects';
-import {startUpdateAllKeyAndWalletStatus} from '../../../store/wallet/effects/status/status';
+import {startUpdateAllWalletStatusForKeys} from '../../../store/wallet/effects/status/status';
 import {
   dismissOnGoingProcessModal,
   showBottomNotificationModal,
@@ -429,12 +429,25 @@ const TransactionProposalNotifications = () => {
     );
   };
 
+  const updateWalletsWithProposals = async () => {
+    const walletIdsWithProposals = _.uniq(pendingTxps.map(txp => txp.walletId));
+    const keyIdsWithProposals = walletIdsWithProposals.map(
+      walletIdString => findWalletById(wallets, walletIdString)!.keyId,
+    );
+    const keyIds = _.uniq(keyIdsWithProposals);
+    await dispatch(
+      startUpdateAllWalletStatusForKeys({
+        keys: keyIds.map(keyIdString => keys[keyIdString]),
+      }),
+    );
+  };
+
   const onRefresh = async () => {
     setRefreshing(true);
     await sleep(1000);
     try {
       await dispatch(startGetRates({force: true}));
-      await dispatch(startUpdateAllKeyAndWalletStatus());
+      await updateWalletsWithProposals();
     } catch (err) {
       dispatch(showBottomNotificationModal(BalanceUpdateError()));
     }


### PR DESCRIPTION
How to reproduce the bug fixed by this PR:

1. Create a multisig proposal on the current master branch
2. Navigate to key overview
3. Tap the proposal notifications icon
4. Wait a while for the `isCacheKeyStale` check to return `true` (or comment out those lines in the code to force the logic to skipped)
5. Pull to refresh the proposal notifications screen (you’ll now see that the “created by” field will become a json object)

This PR fixes the issue and also ensures that only the statuses of keys with pending proposals are refreshed (not all keys)