### PR TITLE
Do not persist token data to device storage

### DIFF
--- a/src/store/wallet/wallet.reducer.ts
+++ b/src/store/wallet/wallet.reducer.ts
@@ -4,8 +4,12 @@ import {FeeLevels} from './effects/fee/fee';
 import {DEFAULT_DATE_RANGE} from '../../constants/wallet';
 import {CurrencyOpts} from '../../constants/currencies';
 
-type WalletReduxPersistBlackList = [];
-export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [];
+type WalletReduxPersistBlackList = string[];
+export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [
+  'tokenData',
+  'tokenOptions',
+  'tokenOptionsByAddress',
+];
 
 export interface WalletState {
   createdOn: number;


### PR DESCRIPTION
Reduces the amount of `WALLET` key data stored in `AsyncStorage` by ~90%.