### PR TITLE
Fix: swap checkout publish and sign

### DIFF
--- a/src/navigation/services/swap-crypto/screens/ChangellyCheckout.tsx
+++ b/src/navigation/services/swap-crypto/screens/ChangellyCheckout.tsx
@@ -499,6 +499,9 @@ const ChangellyCheckout: React.FC = () => {
       );
       await sleep(400);
 
+      const broadcastedTx = (await dispatch<any>(
+        publishAndSign({txp: ctxp!, key, wallet: fromWalletSelected}),
+      )) as any;
       saveChangellyTx();
       dispatch(dismissOnGoingProcessModal());
       await sleep(400);


### PR DESCRIPTION
This portion of code was removed here by mistake apparently. So the swaps are not currently working: https://github.com/bitpay/bitpay-app/pull/303/files#diff-75567b38dc413b88bf0bfcd2f225e5bb12ffc0c2bc349405197b4b6cc2fe1f74L502