### PR TITLE
Clear wallet transaction history before saving keys to device storage

### DIFF
--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -9,43 +9,54 @@ const BWCProvider = BwcProvider.getInstance();
 
 export const bindWalletClient = createTransform(
   // transform state on its way to being serialized and persisted.
-  inboundState => inboundState,
-  // transform state being rehydrated
-  (_outboundState, key) => {
-    if (key === 'keys') {
-      const outboundState: {[key in string]: Key} = {};
-      // eslint-disable-next-line no-shadow
-      for (const [id, key] of Object.entries(
-        _outboundState as {[key in string]: Key},
-      )) {
-        const wallets = key.wallets.map(wallet => {
-          const {img, currencyAbbreviation} = wallet;
-          if (!img && SUPPORTED_CURRENCIES.includes(currencyAbbreviation)) {
-            wallet.img = CurrencyListIcons[currencyAbbreviation];
-          }
-          // reset transaction history
-          wallet.transactionHistory = {
-            transactions: [],
-            loadMore: true,
-            hasConfirmingTxs: false,
-          };
-          console.log(`bindWalletClient - ${wallet.id}`);
-          return merge(
-            BWCProvider.getClient(JSON.stringify(wallet.credentials)),
-            wallet,
-          );
-        });
-
-        outboundState[id] = {
-          ...key,
-          wallets,
-        };
-      }
-
-      return outboundState;
+  inboundState => {
+    const newInboundState: {[key in string]: any} = {};
+    for (const [id, key] of Object.entries(
+      inboundState as {[key in string]: Key},
+    )) {
+      const wallets = key.wallets.map(wallet => ({
+        ...wallet,
+        transactionHistory: undefined,
+      }));
+      newInboundState[id] = {
+        ...key,
+        wallets,
+      };
     }
-    return _outboundState;
+    return newInboundState;
   },
+  // transform state being rehydrated
+  _outboundState => {
+    const outboundState: {[key in string]: Key} = {};
+    for (const [id, key] of Object.entries(
+      _outboundState as {[key in string]: Key},
+    )) {
+      const wallets = key.wallets.map(wallet => {
+        const {img, currencyAbbreviation} = wallet;
+        if (!img && SUPPORTED_CURRENCIES.includes(currencyAbbreviation)) {
+          wallet.img = CurrencyListIcons[currencyAbbreviation];
+        }
+        // reset transaction history
+        wallet.transactionHistory = {
+          transactions: [],
+          loadMore: true,
+          hasConfirmingTxs: false,
+        };
+        console.log(`bindWalletClient - ${wallet.id}`);
+        return merge(
+          BWCProvider.getClient(JSON.stringify(wallet.credentials)),
+          wallet,
+        );
+      });
+
+      outboundState[id] = {
+        ...key,
+        wallets,
+      };
+    }
+    return outboundState;
+  },
+  {whitelist: ['keys']},
 );
 
 export const bindWalletKeys = createTransform(


### PR DESCRIPTION
Currently, wallet transactions are persisted to storage despite being wiped again after refetching keys in the outbound redux-persist transform (which bloats storage unnecessarily). This PR ensures transactions are never persisted to device storage.