### PR TITLE
Refactor rate storage

### DIFF
--- a/src/components/amount/Amount.tsx
+++ b/src/components/amount/Amount.tsx
@@ -102,7 +102,7 @@ const Amount: React.VFC<AmountProps> = ({
   const dispatch = useAppDispatch();
   const {t} = useTranslation();
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const allRates = useAppSelector(({WALLET}) => WALLET.rates);
+  const allRates = useAppSelector(({RATE}) => RATE.rates);
   const curValRef = useRef('');
 
   const fiatCurrency = useMemo(() => {

--- a/src/constants/rate.ts
+++ b/src/constants/rate.ts
@@ -1,0 +1,3 @@
+import {DateRanges} from '../store/rate/rate.models';
+
+export const DEFAULT_DATE_RANGE: number = DateRanges.Day;

--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -1,9 +1,6 @@
-import {DateRanges} from '../store/wallet/wallet.models';
-
 export const BALANCE_CACHE_DURATION = 10;
 export const RATES_CACHE_DURATION = 10;
 export const SOFT_CONFIRMATION_LIMIT: number = 12;
 export const DEFAULT_RBF_SEQ_NUMBER = 0xffffffff;
 export const SAFE_CONFIRMATIONS: number = 6;
-export const DEFAULT_DATE_RANGE: number = DateRanges.Day;
 export const HISTORIC_RATES_CACHE_DURATION = 5 * 60; // 5min

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -286,7 +286,7 @@ const BuyCryptoOffers: React.FC = () => {
   const [updateView, setUpdateView] = useState(false);
 
   const createdOn = useAppSelector(({WALLET}: RootState) => WALLET.createdOn);
-  const allRates = useAppSelector(({WALLET}: RootState) => WALLET.rates);
+  const allRates = useAppSelector(({RATE}: RootState) => RATE.rates);
 
   const getSimplexQuote = (): void => {
     logger.debug('Simplex getting quote');

--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -110,7 +110,7 @@ const HomeRoot = () => {
   }, [brazeDoMore, hasCards, themeType, defaultLanguage]);
 
   // Exchange Rates
-  const priceHistory = useAppSelector(({WALLET}) => WALLET.priceHistory);
+  const priceHistory = useAppSelector(({RATE}) => RATE.priceHistory);
   const memoizedExchangeRates: Array<ExchangeRateItemProps> = useMemo(
     () =>
       priceHistory.reduce((ratesList, history) => {

--- a/src/navigation/tabs/home/components/exchange-rates/ExchangeRateItem.tsx
+++ b/src/navigation/tabs/home/components/exchange-rates/ExchangeRateItem.tsx
@@ -75,7 +75,7 @@ const ExchangeRateItem = ({
   onPress: () => void;
   defaultAltCurrencyIsoCode: string;
 }) => {
-  const allRates = useAppSelector(({WALLET}) => WALLET.rates);
+  const allRates = useAppSelector(({RATE}) => RATE.rates);
   let currentPriceToShow: number | undefined;
   const {img, currencyName, currentPrice, average, currencyAbbreviation} = item;
 

--- a/src/navigation/wallet-connect/screens/WalletConnectIntro.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectIntro.tsx
@@ -35,7 +35,7 @@ const WalletConnectIntro = () => {
   const showWalletSelector = () => setWalletSelectorModalVisible(true);
   const hideWalletSelector = () => setWalletSelectorModalVisible(false);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const rates = useAppSelector(({WALLET}) => WALLET.rates);
+  const rates = useAppSelector(({RATE}) => RATE.rates);
   const allKeys = useAppSelector(({WALLET}) => WALLET.keys);
   let allEthWallets: WalletRowProps[] = [];
   Object.entries(allKeys).map(([_, value]) => {

--- a/src/navigation/wallet/components/RangeDateSelector.tsx
+++ b/src/navigation/wallet/components/RangeDateSelector.tsx
@@ -11,7 +11,7 @@ import {
 import {ActiveOpacity} from '../../../components/styled/Containers';
 import {titleCasing} from '../../../utils/helper-methods';
 import haptic from '../../../components/haptic-feedback/haptic';
-import {DateRanges} from '../../../store/wallet/wallet.models';
+import {DateRanges} from '../../../store/rate/rate.models';
 
 interface Props {
   onPress: (dateRange: DateRanges) => void;

--- a/src/navigation/wallet/screens/AddWallet.tsx
+++ b/src/navigation/wallet/screens/AddWallet.tsx
@@ -183,7 +183,7 @@ const AddWallet: React.FC<AddWalletScreenProps> = ({navigation, route}) => {
   const [isTestnet, setIsTestnet] = useState(false);
   const [singleAddress, setSingleAddress] = useState(false);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const rates = useAppSelector(({WALLET}) => WALLET.rates);
+  const rates = useAppSelector(({RATE}) => RATE.rates);
   const [customTokenAddress, setCustomTokenAddress] = useState<
     string | undefined
   >('');

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -31,7 +31,8 @@ import {
   toggleHideKeyBalance,
   updatePortfolioBalance,
 } from '../../../store/wallet/wallet.actions';
-import {Wallet, Status, Rates} from '../../../store/wallet/wallet.models';
+import {Wallet, Status} from '../../../store/wallet/wallet.models';
+import {Rates} from '../../../store/rate/rate.models';
 import {
   LightBlack,
   NeutralSlate,
@@ -337,7 +338,8 @@ const KeyOverview: React.FC<KeyOverviewScreenProps> = ({navigation, route}) => {
   const [showKeyOptions, setShowKeyOptions] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const {id, context} = route.params;
-  const {keys, rates} = useAppSelector(({WALLET}) => WALLET);
+  const {keys} = useAppSelector(({WALLET}) => WALLET);
+  const {rates} = useAppSelector(({RATE}) => RATE);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
   const [showKeyDropdown, setShowKeyDropdown] = useState(false);
   const key = keys[id];

--- a/src/navigation/wallet/screens/KeySettings.tsx
+++ b/src/navigation/wallet/screens/KeySettings.tsx
@@ -120,7 +120,7 @@ const KeySettings = () => {
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const {rates} = useAppSelector(({WALLET}) => WALLET);
+  const {rates} = useAppSelector(({RATE}) => RATE);
 
   const _wallets = key.wallets;
   const coins = _wallets.filter(wallet => !wallet.credentials.token);

--- a/src/navigation/wallet/screens/PriceCharts.tsx
+++ b/src/navigation/wallet/screens/PriceCharts.tsx
@@ -41,7 +41,7 @@ import {
   VictoryGroup,
   VictoryTooltip,
 } from 'victory-native';
-import {DateRanges} from '../../../store/wallet/wallet.models';
+import {DateRanges} from '../../../store/rate/rate.models';
 import {Defs, Stop, LinearGradient} from 'react-native-svg';
 import _ from 'lodash';
 import GainArrow from '../../../../assets/img/home/exchange-rates/increment-arrow.svg';
@@ -165,9 +165,6 @@ const PriceCharts = () => {
     params: {item},
   } = useRoute<RouteProp<WalletStackParamList, 'PriceCharts'>>();
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const user = useAppSelector(
-    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
-  );
 
   const {
     average,

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -50,7 +50,6 @@ import {
   LightBlack,
   LuckySevens,
   SlateDark,
-  Action,
   White,
 } from '../../../styles/colors';
 import {shouldScale, sleep} from '../../../utils/helper-methods';
@@ -281,7 +280,8 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
   const [showWalletOptions, setShowWalletOptions] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const {walletId, skipInitializeHistory} = route.params;
-  const {keys, rates} = useAppSelector(({WALLET}) => WALLET);
+  const {keys} = useAppSelector(({WALLET}) => WALLET);
+  const {rates} = useAppSelector(({RATE}) => RATE);
 
   const wallets = Object.values(keys).flatMap(k => k.wallets);
 

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -131,7 +131,7 @@ const Confirm = () => {
     ({WALLET}) => WALLET.enableReplaceByFee,
   );
   const customizeNonce = useAppSelector(({WALLET}) => WALLET.customizeNonce);
-  const rates = useAppSelector(({WALLET}) => WALLET.rates);
+  const rates = useAppSelector(({RATE}) => RATE.rates);
   const {isoCode} = useAppSelector(({APP}) => APP.defaultAltCurrency);
 
   const key = allKeys[wallet?.keyId!];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -86,6 +86,12 @@ import {
   CoinbaseReduxPersistBlackList,
   CoinbaseState,
 } from './coinbase/coinbase.reducer';
+import {
+  rateReducer,
+  rateReduxPersistBlackList,
+  RateState,
+} from './rate/rate.reducer';
+import {RateActionType} from './rate/rate.types';
 
 const basePersistConfig = {
   storage: AsyncStorage,
@@ -171,6 +177,14 @@ const reducers = {
       blacklist: walletReduxPersistBlackList,
     },
     walletReducer,
+  ),
+  RATE: persistReducer<RateState, RateActionType>(
+    {
+      ...basePersistConfig,
+      key: 'RATE',
+      blacklist: rateReduxPersistBlackList,
+    },
+    rateReducer,
   ),
   CONTACT: persistReducer<ContactState, ContactActionType>(
     {

--- a/src/store/rate/rate.actions.ts
+++ b/src/store/rate/rate.actions.ts
@@ -1,0 +1,41 @@
+import {
+  CacheKeys,
+  DateRanges,
+  PriceHistory,
+  Rates,
+  RatesByDateRange,
+} from './rate.models';
+import {RateActionType, RateActionTypes} from './rate.types';
+
+export const successGetRates = (payload: {
+  rates?: Rates;
+  ratesByDateRange?: RatesByDateRange;
+  lastDayRates?: Rates;
+  dateRange?: number;
+}): RateActionType => ({
+  type: RateActionTypes.SUCCESS_GET_RATES,
+  payload,
+});
+
+export const failedGetRates = (): RateActionType => ({
+  type: RateActionTypes.FAILED_GET_RATES,
+});
+
+export const updateCacheKey = (payload: {
+  cacheKey: CacheKeys;
+  dateRange?: DateRanges;
+}): RateActionType => ({
+  type: RateActionTypes.UPDATE_CACHE_KEY,
+  payload,
+});
+
+export const successGetPriceHistory = (
+  payload: Array<PriceHistory>,
+): RateActionType => ({
+  type: RateActionTypes.SUCCESS_GET_PRICE_HISTORY,
+  payload,
+});
+
+export const failedGetPriceHistory = (): RateActionType => ({
+  type: RateActionTypes.FAILED_GET_PRICE_HISTORY,
+});

--- a/src/store/rate/rate.models.ts
+++ b/src/store/rate/rate.models.ts
@@ -1,0 +1,39 @@
+export interface Rate {
+  code: string;
+  fetchedOn: number;
+  name: string;
+  rate: number;
+  ts: number;
+}
+
+export interface HistoricRate {
+  fetchedOn: number;
+  rate: number;
+  ts: number;
+}
+
+export type Rates = {
+  [key in string]: Rate[];
+};
+
+export type RatesByDateRange = {
+  [key in DateRanges]: Rate[];
+};
+
+export enum DateRanges {
+  Day = 1,
+  Week = 7,
+  Month = 30,
+}
+
+export interface PriceHistory {
+  coin: string;
+  priceDisplay: Array<number>;
+  percentChange: string;
+  currencyPair: string;
+  prices: Array<{price: number; time: string}>;
+}
+
+export enum CacheKeys {
+  RATES = 'ratesCacheKey',
+}

--- a/src/store/rate/rate.reducer.ts
+++ b/src/store/rate/rate.reducer.ts
@@ -1,0 +1,73 @@
+import {DateRanges, PriceHistory, Rates} from './rate.models';
+import {RateActionType, RateActionTypes} from './rate.types';
+import {DEFAULT_DATE_RANGE} from '../../constants/rate';
+
+type RateReduxPersistBlackList = string[];
+export const rateReduxPersistBlackList: RateReduxPersistBlackList = [];
+
+export interface RateState {
+  lastDayRates: Rates;
+  rates: Rates;
+  ratesByDateRange: {[key in DateRanges]: Rates};
+  priceHistory: Array<PriceHistory>;
+  balanceCacheKey: {[key in string]: number | undefined};
+  ratesCacheKey: {[key in number]: DateRanges | undefined};
+}
+
+const initialState: RateState = {
+  rates: {},
+  ratesByDateRange: {
+    1: {},
+    7: {},
+    30: {},
+  },
+  lastDayRates: {},
+  priceHistory: [],
+  balanceCacheKey: {},
+  ratesCacheKey: {},
+};
+
+export const rateReducer = (
+  state: RateState = initialState,
+  action: RateActionType,
+): RateState => {
+  switch (action.type) {
+    case RateActionTypes.SUCCESS_GET_RATES: {
+      const {
+        rates,
+        ratesByDateRange,
+        lastDayRates,
+        dateRange = DEFAULT_DATE_RANGE,
+      } = action.payload;
+
+      return {
+        ...state,
+        rates: {...state.rates, ...rates},
+        ratesByDateRange: {
+          ...state.ratesByDateRange,
+          [dateRange]: {...ratesByDateRange},
+        },
+        ratesCacheKey: {...state.ratesCacheKey, [dateRange]: Date.now()},
+        lastDayRates: {...state.lastDayRates, ...lastDayRates},
+      };
+    }
+
+    case RateActionTypes.UPDATE_CACHE_KEY: {
+      const {cacheKey, dateRange = DEFAULT_DATE_RANGE} = action.payload;
+      return {
+        ...state,
+        [cacheKey]: {...state.ratesCacheKey, [dateRange]: Date.now()},
+      };
+    }
+
+    case RateActionTypes.SUCCESS_GET_PRICE_HISTORY: {
+      return {
+        ...state,
+        priceHistory: action.payload,
+      };
+    }
+
+    default:
+      return state;
+  }
+};

--- a/src/store/rate/rate.types.ts
+++ b/src/store/rate/rate.types.ts
@@ -1,0 +1,53 @@
+import {
+  CacheKeys,
+  DateRanges,
+  PriceHistory,
+  Rates,
+  RatesByDateRange,
+} from './rate.models';
+
+export enum RateActionTypes {
+  SUCCESS_GET_RATES = 'RATE/SUCCESS_GET_RATES',
+  FAILED_GET_RATES = 'RATE/FAILED_GET_RATES',
+  SUCCESS_GET_PRICE_HISTORY = 'RATE/SUCCESS_GET_PRICE_HISTORY',
+  FAILED_GET_PRICE_HISTORY = 'RATE/FAILED_GET_PRICE_HISTORY',
+  UPDATE_CACHE_KEY = 'RATE/UPDATE_CACHE_KEY',
+}
+
+interface successGetRates {
+  type: typeof RateActionTypes.SUCCESS_GET_RATES;
+  payload: {
+    rates?: Rates;
+    ratesByDateRange?: RatesByDateRange;
+    lastDayRates?: Rates;
+    dateRange?: DateRanges;
+  };
+}
+
+interface failedGetRates {
+  type: typeof RateActionTypes.FAILED_GET_RATES;
+}
+
+interface updateCacheKey {
+  type: typeof RateActionTypes.UPDATE_CACHE_KEY;
+  payload: {
+    cacheKey: CacheKeys;
+    dateRange?: DateRanges;
+  };
+}
+
+interface successGetPriceHistory {
+  type: typeof RateActionTypes.SUCCESS_GET_PRICE_HISTORY;
+  payload: Array<PriceHistory>;
+}
+
+interface failedGetPriceHistory {
+  type: typeof RateActionTypes.FAILED_GET_PRICE_HISTORY;
+}
+
+export type RateActionType =
+  | successGetRates
+  | failedGetRates
+  | updateCacheKey
+  | successGetPriceHistory
+  | failedGetPriceHistory;

--- a/src/store/wallet/effects/currencies/currencies.ts
+++ b/src/store/wallet/effects/currencies/currencies.ts
@@ -10,7 +10,7 @@ import {Currencies, CurrencyOpts} from '../../../../constants/currencies';
 import {LogActions} from '../../../log';
 
 export const startGetTokenOptions =
-  (): Effect<Promise<void>> => async (dispatch, getState) => {
+  (): Effect<Promise<void>> => async dispatch => {
     try {
       dispatch(LogActions.info('starting [startGetTokenOptions]'));
       const {

--- a/src/store/wallet/effects/rates/rates.ts
+++ b/src/store/wallet/effects/rates/rates.ts
@@ -8,21 +8,21 @@ import {
   PriceHistory,
   Rate,
   Rates,
-} from '../../wallet.models';
+} from '../../../rate/rate.models';
 import {isCacheKeyStale} from '../../utils/wallet';
 import {
-  DEFAULT_DATE_RANGE,
   HISTORIC_RATES_CACHE_DURATION,
   RATES_CACHE_DURATION,
 } from '../../../../constants/wallet';
+import {DEFAULT_DATE_RANGE} from '../../../../constants/rate';
 import {
   failedGetPriceHistory,
   failedGetRates,
   successGetPriceHistory,
   successGetRates,
   updateCacheKey,
-} from '../../wallet.actions';
-import {CacheKeys} from '../../wallet.models';
+} from '../../../rate/rate.actions';
+import {CacheKeys} from '../../../rate/rate.models';
 import moment from 'moment';
 import {addAltCurrencyList} from '../../../app/app.actions';
 import {AltCurrenciesRowProps} from '../../../../components/list/AltCurrenciesRow';
@@ -73,7 +73,7 @@ export const startGetRates =
     return new Promise(async resolve => {
       dispatch(LogActions.info('starting [startGetRates]'));
       const {
-        WALLET: {ratesCacheKey, rates: cachedRates},
+        RATE: {ratesCacheKey, rates: cachedRates},
       } = getState();
       if (
         !isCacheKeyStale(
@@ -161,7 +161,7 @@ export const startGetRates =
         }
         dispatch(failedGetRates());
         dispatch(LogActions.error(`failed [startGetRates]: ${errorStr}`));
-        resolve(getState().WALLET.rates); // Return cached rates
+        resolve(getState().RATE.rates); // Return cached rates
       }
     });
   };
@@ -307,7 +307,7 @@ export const fetchHistoricalRates =
   async (dispatch, getState) => {
     return new Promise(async (resolve, reject) => {
       const {
-        WALLET: {ratesCacheKey, ratesByDateRange: cachedRates},
+        RATE: {ratesCacheKey, ratesByDateRange: cachedRates},
       } = getState();
 
       if (

--- a/src/store/wallet/effects/status/status.ts
+++ b/src/store/wallet/effects/status/status.ts
@@ -1,7 +1,6 @@
 import {Effect} from '../../../index';
 import {
   Wallet,
-  Rates,
   Key,
   WalletBalance,
   WalletStatus,
@@ -12,6 +11,7 @@ import {
   CryptoBalance,
   FiatBalance,
 } from '../../wallet.models';
+import {Rates} from '../../../rate/rate.models';
 import {
   failedUpdateAllKeysAndStatus,
   failedUpdateKey,
@@ -158,8 +158,9 @@ export const startUpdateWalletStatus =
 
       try {
         const {
-          WALLET: {rates, lastDayRates, balanceCacheKey},
+          WALLET: {balanceCacheKey},
           APP: {defaultAltCurrency},
+          RATE: {rates, lastDayRates},
         } = getState();
 
         const {
@@ -265,9 +266,10 @@ export const startUpdateAllWalletStatusForKeys =
         dispatch(
           LogActions.info('starting [startUpdateAllWalletStatusForKeys]'),
         );
-        const {APP, WALLET} = getState();
+        const {APP, RATE, WALLET} = getState();
         const {defaultAltCurrency} = APP;
-        const {rates, lastDayRates, balanceCacheKey} = WALLET;
+        const {balanceCacheKey} = WALLET;
+        const {rates, lastDayRates} = RATE;
 
         const keyUpdatesPromises: Promise<{
           keyId: string;
@@ -742,7 +744,7 @@ const buildFiatBalance =
     lastDayRates: Rates;
     cryptoBalance: CryptoBalance;
   }): Effect<FiatBalance> =>
-  (dispatch, getState) => {
+  dispatch => {
     const {
       currencyAbbreviation,
       credentials: {network},
@@ -864,7 +866,8 @@ export const FormatKeyBalances = (): Effect => async (dispatch, getState) => {
   return new Promise(async (resolve, reject) => {
     try {
       const {
-        WALLET: {keys, rates, lastDayRates},
+        WALLET: {keys},
+        RATE: {rates, lastDayRates},
         APP: {defaultAltCurrency},
       } = getState();
 

--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -1,10 +1,5 @@
-import {
-  HistoricRate,
-  Rates,
-  Wallet,
-  TransactionProposal,
-  Utxo,
-} from '../../wallet.models';
+import {Wallet, TransactionProposal, Utxo} from '../../wallet.models';
+import {HistoricRate, Rates} from '../../../rate/rate.models';
 import {FormatAmountStr} from '../amount/amount';
 import {BwcProvider} from '../../../../lib/bwc';
 import uniqBy from 'lodash.uniqby';

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -1,12 +1,12 @@
 import {
   Key,
   KeyMethods,
-  Rates,
   Token,
   Wallet,
   WalletBalance,
   WalletObj,
 } from '../wallet.models';
+import {Rates} from '../../rate/rate.models';
 import {Credentials} from 'bitcore-wallet-client/ts_build/lib/credentials';
 import {SUPPORTED_CURRENCIES} from '../../../constants/currencies';
 import {CurrencyListIcons} from '../../../constants/SupportedCurrencyOptions';
@@ -503,7 +503,7 @@ export const BuildPayProWalletSelectorList =
   (dispatch, getState) => {
     const {COINBASE} = getState();
     const {
-      WALLET: {rates},
+      RATE: {rates},
     } = getState();
     const coinbaseAccounts = COINBASE.accounts[COINBASE_ENV];
     const coinbaseUser = COINBASE.user[COINBASE_ENV];

--- a/src/store/wallet/wallet.actions.ts
+++ b/src/store/wallet/wallet.actions.ts
@@ -1,14 +1,9 @@
 import {WalletActionType, WalletActionTypes} from './wallet.types';
 import {
-  CacheKeys,
-  DateRanges,
   Key,
-  PriceHistory,
-  Rates,
   Token,
   Wallet,
   TransactionProposal,
-  RatesByDateRange,
   CacheFeeLevel,
   CryptoBalance,
 } from './wallet.models';
@@ -61,39 +56,6 @@ export const failedImport = (): WalletActionType => ({
 export const setBackupComplete = (keyId: string): WalletActionType => ({
   type: WalletActionTypes.SET_BACKUP_COMPLETE,
   payload: keyId,
-});
-
-export const successGetRates = (payload: {
-  rates?: Rates;
-  ratesByDateRange?: RatesByDateRange;
-  lastDayRates?: Rates;
-  dateRange?: number;
-}): WalletActionType => ({
-  type: WalletActionTypes.SUCCESS_GET_RATES,
-  payload,
-});
-
-export const failedGetRates = (): WalletActionType => ({
-  type: WalletActionTypes.FAILED_GET_RATES,
-});
-
-export const updateCacheKey = (payload: {
-  cacheKey: CacheKeys;
-  dateRange?: DateRanges;
-}): WalletActionType => ({
-  type: WalletActionTypes.UPDATE_CACHE_KEY,
-  payload,
-});
-
-export const successGetPriceHistory = (
-  payload: Array<PriceHistory>,
-): WalletActionType => ({
-  type: WalletActionTypes.SUCCESS_GET_PRICE_HISTORY,
-  payload,
-});
-
-export const failedGetPriceHistory = (): WalletActionType => ({
-  type: WalletActionTypes.FAILED_GET_PRICE_HISTORY,
 });
 
 export const successEncryptOrDecryptPassword = (payload: {

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -113,14 +113,6 @@ export interface WalletObj {
   network: Network;
 }
 
-export interface PriceHistory {
-  coin: string;
-  priceDisplay: Array<number>;
-  percentChange: string;
-  currencyPair: string;
-  prices: Array<{price: number; time: string}>;
-}
-
 export interface KeyOptions {
   keyId: any;
   name: any;
@@ -156,34 +148,6 @@ export interface Token {
   logoURI?: string;
 }
 
-export interface Rate {
-  code: string;
-  fetchedOn: number;
-  name: string;
-  rate: number;
-  ts: number;
-}
-
-export interface HistoricRate {
-  fetchedOn: number;
-  rate: number;
-  ts: number;
-}
-
-export type Rates = {
-  [key in string]: Rate[];
-};
-
-export type RatesByDateRange = {
-  [key in DateRanges]: Rate[];
-};
-
-export enum DateRanges {
-  Day = 1,
-  Week = 7,
-  Month = 30,
-}
-
 export interface Balance {
   availableAmount: number;
   availableConfirmedAmount: number;
@@ -210,7 +174,6 @@ export interface Status {
 
 export enum CacheKeys {
   RATES = 'ratesCacheKey',
-  BALANCE = 'balanceCacheKey',
 }
 
 export interface Recipient {

--- a/src/store/wallet/wallet.reducer.ts
+++ b/src/store/wallet/wallet.reducer.ts
@@ -1,7 +1,6 @@
-import {DateRanges, Key, PriceHistory, Rates, Token} from './wallet.models';
+import {Key, Token} from './wallet.models';
 import {WalletActionType, WalletActionTypes} from './wallet.types';
 import {FeeLevels} from './effects/fee/fee';
-import {DEFAULT_DATE_RANGE} from '../../constants/wallet';
 import {CurrencyOpts} from '../../constants/currencies';
 
 type WalletReduxPersistBlackList = string[];
@@ -14,10 +13,6 @@ export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [
 export interface WalletState {
   createdOn: number;
   keys: {[key in string]: Key};
-  lastDayRates: Rates;
-  rates: Rates;
-  ratesByDateRange: {[key in DateRanges]: Rates};
-  priceHistory: Array<PriceHistory>;
   tokenOptions: {[key in string]: Token};
   tokenData: {[key in string]: CurrencyOpts};
   tokenOptionsByAddress: {[key in string]: Token};
@@ -31,7 +26,6 @@ export interface WalletState {
     previous: number;
   };
   balanceCacheKey: {[key in string]: number | undefined};
-  ratesCacheKey: {[key in number]: DateRanges | undefined};
   feeLevel: {[key in string]: FeeLevels};
   useUnconfirmedFunds: boolean;
   customizeNonce: boolean;
@@ -42,14 +36,6 @@ export interface WalletState {
 const initialState: WalletState = {
   createdOn: Date.now(),
   keys: {},
-  rates: {},
-  ratesByDateRange: {
-    1: {},
-    7: {},
-    30: {},
-  },
-  lastDayRates: {},
-  priceHistory: [],
   tokenOptions: {},
   tokenData: {},
   tokenOptionsByAddress: {},
@@ -63,7 +49,6 @@ const initialState: WalletState = {
     previous: 0,
   },
   balanceCacheKey: {},
-  ratesCacheKey: {},
   feeLevel: {
     btc: FeeLevels.NORMAL,
     eth: FeeLevels.NORMAL,
@@ -97,41 +82,6 @@ export const walletReducer = (
       return {
         ...state,
         keys: {...state.keys, [id]: updatedKey},
-      };
-    }
-
-    case WalletActionTypes.SUCCESS_GET_RATES: {
-      const {
-        rates,
-        ratesByDateRange,
-        lastDayRates,
-        dateRange = DEFAULT_DATE_RANGE,
-      } = action.payload;
-
-      return {
-        ...state,
-        rates: {...state.rates, ...rates},
-        ratesByDateRange: {
-          ...state.ratesByDateRange,
-          [dateRange]: {...ratesByDateRange},
-        },
-        ratesCacheKey: {...state.ratesCacheKey, [dateRange]: Date.now()},
-        lastDayRates: {...state.lastDayRates, ...lastDayRates},
-      };
-    }
-
-    case WalletActionTypes.UPDATE_CACHE_KEY: {
-      const {cacheKey, dateRange = DEFAULT_DATE_RANGE} = action.payload;
-      return {
-        ...state,
-        [cacheKey]: {...state.ratesCacheKey, [dateRange]: Date.now()},
-      };
-    }
-
-    case WalletActionTypes.SUCCESS_GET_PRICE_HISTORY: {
-      return {
-        ...state,
-        priceHistory: action.payload,
       };
     }
 

--- a/src/store/wallet/wallet.types.ts
+++ b/src/store/wallet/wallet.types.ts
@@ -1,14 +1,9 @@
 import {CurrencyOpts} from '../../constants/currencies';
 import {
-  CacheKeys,
-  DateRanges,
   Key,
-  PriceHistory,
-  Rates,
   Token,
   Wallet,
   TransactionProposal,
-  RatesByDateRange,
   CacheFeeLevel,
   CryptoBalance,
 } from './wallet.models';
@@ -24,11 +19,6 @@ export enum WalletActionTypes {
   SUCCESS_IMPORT = 'WALLET/SUCCESS_IMPORT',
   FAILED_IMPORT = 'WALLET/FAILED_IMPORT',
   SET_BACKUP_COMPLETE = 'WALLET/SET_BACKUP_COMPLETE',
-  SUCCESS_GET_RATES = 'WALLET/SUCCESS_GET_RATES',
-  FAILED_GET_RATES = 'WALLET/FAILED_GET_RATES',
-  UPDATE_CACHE_KEY = 'WALLET/UPDATE_CACHE_KEY',
-  SUCCESS_GET_PRICE_HISTORY = 'WALLET/SUCCESS_GET_PRICE_HISTORY',
-  FAILED_GET_PRICE_HISTORY = 'WALLET/FAILED_GET_PRICE_HISTORY',
   DELETE_KEY = 'WALLET/DELETE_KEY',
   SUCCESS_ENCRYPT_OR_DECRYPT_PASSWORD = 'WALLET/SUCCESS_ENCRYPT_OR_DECRYPT_PASSWORD',
   SUCCESS_GET_TOKEN_OPTIONS = 'WALLET/SUCCESS_GET_TOKEN_OPTIONS',
@@ -115,37 +105,6 @@ interface failedImport {
 interface setBackupComplete {
   type: typeof WalletActionTypes.SET_BACKUP_COMPLETE;
   payload: string;
-}
-
-interface successGetRates {
-  type: typeof WalletActionTypes.SUCCESS_GET_RATES;
-  payload: {
-    rates?: Rates;
-    ratesByDateRange?: RatesByDateRange;
-    lastDayRates?: Rates;
-    dateRange?: DateRanges;
-  };
-}
-
-interface failedGetRates {
-  type: typeof WalletActionTypes.FAILED_GET_RATES;
-}
-
-interface updateCacheKey {
-  type: typeof WalletActionTypes.UPDATE_CACHE_KEY;
-  payload: {
-    cacheKey: CacheKeys;
-    dateRange?: DateRanges;
-  };
-}
-
-interface successGetPriceHistory {
-  type: typeof WalletActionTypes.SUCCESS_GET_PRICE_HISTORY;
-  payload: Array<PriceHistory>;
-}
-
-interface failedGetPriceHistory {
-  type: typeof WalletActionTypes.FAILED_GET_PRICE_HISTORY;
 }
 
 interface successEncryptOrDecryptPassword {
@@ -344,11 +303,6 @@ export type WalletActionType =
   | successImport
   | failedImport
   | setBackupComplete
-  | successGetRates
-  | failedGetRates
-  | updateCacheKey
-  | successGetPriceHistory
-  | failedGetPriceHistory
   | deleteKey
   | successEncryptOrDecryptPassword
   | successGetTokenOptions


### PR DESCRIPTION
Moves rates out of the `WALLET` storage key to a new dedicated `RATE` key to ensure that only the minimum amount of data is stored in the `WALLET` key to avoid running into OS-specific per-key storage limits.