### PR TITLE
Fix: prevent swipe back action returns to Home tab

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -437,7 +437,7 @@ export default () => {
             />
             <Root.Screen
               options={{
-                gestureEnabled: true,
+                gestureEnabled: false,
               }}
               name={RootStacks.WALLET}
               component={WalletStack}

--- a/src/navigation/wallet/WalletStack.tsx
+++ b/src/navigation/wallet/WalletStack.tsx
@@ -289,7 +289,11 @@ const WalletStack = () => {
         />
         <Wallet.Screen name={WalletScreens.AMOUNT} component={AmountScreen} />
         <Wallet.Screen name={WalletScreens.SEND_TO} component={SendTo} />
-        <Wallet.Screen name={WalletScreens.CONFIRM} component={Confirm} />
+        <Wallet.Screen
+          options={{gestureEnabled: false}}
+          name={WalletScreens.CONFIRM}
+          component={Confirm}
+        />
         <Wallet.Screen
           options={{
             headerTitle: () => <HeaderTitle>{t('Add Funds')}</HeaderTitle>,

--- a/src/navigation/wallet/screens/SendToOptions.tsx
+++ b/src/navigation/wallet/screens/SendToOptions.tsx
@@ -255,7 +255,6 @@ const SendToOptions = () => {
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      gestureEnabled: false,
       headerTitle: () => <HeaderTitle>{params.title}</HeaderTitle>,
       headerTitleAlign: 'center',
     });


### PR DESCRIPTION
* Go to Create -> New Key -> Swipe back (it goes to Home instead `Select an option` screen)

After fix:

* Swipe back is disabled on the `Select Currencies` screen.