### PR TITLE
feat/upgrade braze sdk to 1 38 0

### DIFF
--- a/android/app/src/main/java/com/bitpay/wallet/CustomBroadcastReceiver.java
+++ b/android/app/src/main/java/com/bitpay/wallet/CustomBroadcastReceiver.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
-import com.appboy.Constants;
+import com.braze.Constants;
 import com.braze.push.BrazeNotificationUtils;
 import com.braze.support.BrazeLogger;
 import com.facebook.react.bridge.Arguments;
@@ -25,7 +25,7 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
 
         switch (action) {
             case Constants.BRAZE_PUSH_INTENT_NOTIFICATION_RECEIVED:
-                Bundle extras = intent.getBundleExtra(Constants.APPBOY_PUSH_EXTRAS_KEY);
+                Bundle extras = intent.getBundleExtra(Constants.BRAZE_PUSH_EXTRAS_KEY);
                 if (extras != null) {
                     WritableMap extraParams = Arguments.createMap();
                     for (String key : extras.keySet()) {

--- a/android/app/src/main/java/com/bitpay/wallet/MainApplication.java
+++ b/android/app/src/main/java/com/bitpay/wallet/MainApplication.java
@@ -19,7 +19,7 @@ import info.applike.advertisingid.RNAdvertisingIdPackage;
 import com.facebook.react.views.text.ReactFontManager;
 
 // Braze
-import com.appboy.AppboyLifecycleCallbackListener;
+import com.braze.BrazeActivityLifecycleCallbackListener;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -70,7 +70,7 @@ public class MainApplication extends Application implements ReactApplication {
     ReactFontManager.getInstance().addCustomFont(this, "Heebo", R.font.heebo);
 
     // Braze
-    registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener());
+    registerActivityLifecycleCallbacks(new BrazeActivityLifecycleCallbackListener());
   }
 
   /**

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,11 +4,12 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
         androidXAnnotation = "1.2.0"
         androidXBrowser = "1.3.0"
+        kotlin_version = "1.7.10"
     }
     repositories {
         google()
@@ -20,6 +21,7 @@ buildscript {
         // in the individual module build.gradle files
         classpath 'com.google.android.gms:strict-version-matcher-plugin:1.2.1'
         classpath 'com.google.gms:google-services:4.3.10'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - Analytics (4.1.6)
-  - Appboy-iOS-SDK (4.3.4):
-    - Appboy-iOS-SDK/UI (= 4.3.4)
-  - Appboy-iOS-SDK/ContentCards (4.3.4):
+  - Appboy-iOS-SDK (4.5.0):
+    - Appboy-iOS-SDK/UI (= 4.5.0)
+  - Appboy-iOS-SDK/ContentCards (4.5.0):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/Core (4.3.4)
-  - Appboy-iOS-SDK/InAppMessage (4.3.4):
+  - Appboy-iOS-SDK/Core (4.5.0)
+  - Appboy-iOS-SDK/InAppMessage (4.5.0):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/NewsFeed (4.3.4):
+  - Appboy-iOS-SDK/NewsFeed (4.5.0):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/UI (4.3.4):
+  - Appboy-iOS-SDK/UI (4.5.0):
     - Appboy-iOS-SDK/ContentCards
     - Appboy-iOS-SDK/Core
     - Appboy-iOS-SDK/InAppMessage
@@ -387,8 +387,8 @@ PODS:
     - glog
   - react-native-advertising-id-bp (1.0.13):
     - React
-  - react-native-appboy-sdk (1.34.1):
-    - Appboy-iOS-SDK (~> 4.3.4)
+  - react-native-appboy-sdk (1.38.0):
+    - Appboy-iOS-SDK (~> 4.5.0)
     - React
   - react-native-appsflyer (6.5.20):
     - AppsFlyerFramework (= 6.5.2)
@@ -516,7 +516,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.4.1):
     - React-Core
-  - RNInAppBrowser (3.6.3):
+  - RNInAppBrowser (3.7.0):
     - React-Core
   - RNLocalize (2.1.7):
     - React-Core
@@ -855,7 +855,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
-  Appboy-iOS-SDK: dd22a28a003c5a1331080ecec398eaa4d7ef4569
+  Appboy-iOS-SDK: 640c2d51cec128008da5c4c680df3d76e8c137bc
   AppsFlyerFramework: 9f304d91cc80b6579b1206a59220383056b58b47
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
@@ -908,7 +908,7 @@ SPEC CHECKSUMS:
   React-jsinspector: f4775ea9118cbe1f72b834f0f842baa7a99508d8
   React-logger: a1f028f6d8639a3f364ef80419e5e862e1115250
   react-native-advertising-id-bp: e14b0f4622895d3db1ecb1041f7eb262f8b53d4b
-  react-native-appboy-sdk: 17ffa89260876bf981a91b41239a8fc7e55622d9
+  react-native-appboy-sdk: fda756a8584dcb328be47c76a34d896dea84da91
   react-native-appsflyer: fac6d94b40ce52dc69a07c242317b83c7b9e0cc2
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
@@ -944,7 +944,7 @@ SPEC CHECKSUMS:
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 4f4986408310a43f1606c391f38f76e0d6e790d5
-  RNInAppBrowser: 3ff3a3b8f458aaf25aaee879d057352862edf357
+  RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNLocalize: f567ea0e35116a641cdffe6683b0d212d568f32a
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNPermissions: f7ebe52db07c00901127966ca080b4ec6a6ceb0a

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-i18next": "11.15.2",
     "react-native": "0.67.4",
     "react-native-advertising-id-bp": "1.0.13",
-    "react-native-appboy-sdk": "1.34.1",
+    "react-native-appboy-sdk": "1.38.0",
     "react-native-appsflyer": "6.5.20",
     "react-native-bootsplash": "3.2.6",
     "react-native-camera": "4.2.1",

--- a/src/navigation/card/components/CardOffers.tsx
+++ b/src/navigation/card/components/CardOffers.tsx
@@ -1,6 +1,6 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
-import ReactAppboy, {ContentCard} from 'react-native-appboy-sdk';
+import Braze, {ContentCard} from 'react-native-appboy-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import styled, {useTheme} from 'styled-components/native';
@@ -89,7 +89,7 @@ const CardOffers: React.VFC<CardOffersProps> = props => {
 
   const onPress = () => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardClicked(contentCard.id);
+      Braze.logContentCardClicked(contentCard.id);
 
       dispatch(
         Analytics.track('Clicked Card Offer', {
@@ -104,7 +104,7 @@ const CardOffers: React.VFC<CardOffersProps> = props => {
 
   useFocusEffect(() => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardImpression(contentCard.id);
+      Braze.logContentCardImpression(contentCard.id);
     }
   });
 

--- a/src/navigation/card/screens/CardHome.tsx
+++ b/src/navigation/card/screens/CardHome.tsx
@@ -10,7 +10,6 @@ import CardIntro from '../components/CardIntro';
 export type CardHomeScreenParamList =
   | {
       id: string | undefined | null;
-      action?: string | null;
     }
   | undefined;
 export type CardHomeScreenProps = StackScreenProps<

--- a/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
+++ b/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect, useLinkTo} from '@react-navigation/native';
 import React from 'react';
 import {ImageStyle, Linking, StyleProp} from 'react-native';
-import ReactAppboy, {ContentCard} from 'react-native-appboy-sdk';
+import Braze, {ContentCard} from 'react-native-appboy-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import {SvgProps} from 'react-native-svg';
 import styled, {useTheme} from 'styled-components/native';
@@ -107,7 +107,7 @@ const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
     haptic('impactLight');
 
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardClicked(contentCard.id);
+      Braze.logContentCardClicked(contentCard.id);
     }
 
     if (ctaOverride) {
@@ -165,7 +165,7 @@ const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
 
   useFocusEffect(() => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardImpression(contentCard.id);
+      Braze.logContentCardImpression(contentCard.id);
     }
   });
 

--- a/src/navigation/tabs/home/components/offers/OfferCard.tsx
+++ b/src/navigation/tabs/home/components/offers/OfferCard.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
 import {Linking} from 'react-native';
-import ReactAppboy, {ContentCard} from 'react-native-appboy-sdk';
+import Braze, {ContentCard} from 'react-native-appboy-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import haptic from '../../../../../components/haptic-feedback/haptic';
 import {
@@ -49,7 +49,7 @@ const OfferCard: React.FC<OfferCardProps> = props => {
 
   const _onPress = () => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardClicked(contentCard.id);
+      Braze.logContentCardClicked(contentCard.id);
     }
 
     if (!url) {
@@ -85,7 +85,7 @@ const OfferCard: React.FC<OfferCardProps> = props => {
 
   useFocusEffect(() => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardImpression(contentCard.id);
+      Braze.logContentCardImpression(contentCard.id);
     }
   });
 

--- a/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
+++ b/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
 import {Linking} from 'react-native';
-import ReactAppboy, {ContentCard} from 'react-native-appboy-sdk';
+import Braze, {ContentCard} from 'react-native-appboy-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import styled, {useTheme} from 'styled-components/native';
 import haptic from '../../../../../components/haptic-feedback/haptic';
@@ -97,7 +97,7 @@ const QuickLinksCard: React.FC<QuickLinksCardProps> = props => {
 
   const onPress = () => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardClicked(contentCard.id);
+      Braze.logContentCardClicked(contentCard.id);
     }
 
     if (ctaOverride) {
@@ -126,7 +126,7 @@ const QuickLinksCard: React.FC<QuickLinksCardProps> = props => {
 
   useFocusEffect(() => {
     if (!contentCard.id.startsWith('dev_')) {
-      ReactAppboy.logContentCardImpression(contentCard.id);
+      Braze.logContentCardImpression(contentCard.id);
     }
   });
 

--- a/src/navigation/tabs/settings/general/screens/LanguageSettings.tsx
+++ b/src/navigation/tabs/settings/general/screens/LanguageSettings.tsx
@@ -2,7 +2,7 @@ import i18n from 'i18next';
 import {sortBy} from 'lodash';
 import React, {useState} from 'react';
 import {View} from 'react-native';
-import ReactAppboy from 'react-native-appboy-sdk';
+import Braze from 'react-native-appboy-sdk';
 import Checkbox from '../../../../../components/checkbox/Checkbox';
 import {
   Hr,
@@ -23,7 +23,7 @@ const LanguageSettingsScreen: React.VFC = () => {
   const onSetLanguage = (lng: string) => {
     setSelected(lng);
     i18n.changeLanguage(lng);
-    ReactAppboy.setLanguage(lng);
+    Braze.setLanguage(lng);
     dispatch(AppActions.setDefaultLanguage(lng));
     dispatch(Analytics.track('Saved Language', {language: lng}));
   };

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -6,9 +6,7 @@ import i18n from 'i18next';
 import {debounce} from 'lodash';
 import {DeviceEventEmitter, Linking, Platform} from 'react-native';
 import AdID from 'react-native-advertising-id-bp';
-import ReactAppboy, {
-  NotificationSubscriptionTypes,
-} from 'react-native-appboy-sdk';
+import Braze, {NotificationSubscriptionTypes} from 'react-native-appboy-sdk';
 import AppsFlyer from 'react-native-appsflyer';
 import RNBootSplash from 'react-native-bootsplash';
 import InAppBrowser, {
@@ -280,8 +278,8 @@ export const initializeBrazeContent =
       const MAX_RETRIES = 3;
       let currentRetry = 0;
 
-      contentCardSubscription = ReactAppboy.addListener(
-        ReactAppboy.Events.CONTENT_CARDS_UPDATED,
+      contentCardSubscription = Braze.addListener(
+        Braze.Events.CONTENT_CARDS_UPDATED,
         async () => {
           const isInitializing = currentRetry < MAX_RETRIES;
 
@@ -295,7 +293,7 @@ export const initializeBrazeContent =
                 ),
           );
 
-          const contentCards = await ReactAppboy.getContentCards();
+          const contentCards = await Braze.getContentCards();
 
           if (contentCards.length) {
             currentRetry = MAX_RETRIES;
@@ -308,7 +306,7 @@ export const initializeBrazeContent =
                   `0 content cards found. Retrying... (${currentRetry} of ${MAX_RETRIES})`,
                 ),
               );
-              ReactAppboy.requestContentCardsRefresh();
+              Braze.requestContentCardsRefresh();
               return;
             }
           }
@@ -325,8 +323,8 @@ export const initializeBrazeContent =
       );
 
       if (user) {
-        ReactAppboy.changeUser(user.eid);
-        ReactAppboy.setEmail(user.email);
+        Braze.changeUser(user.eid);
+        Braze.setEmail(user.email);
         dispatch(setBrazeEid(user.eid));
       } else {
         let eid: string;
@@ -339,7 +337,7 @@ export const initializeBrazeContent =
           eid = uuid.v4().toString();
         }
 
-        ReactAppboy.changeUser(eid);
+        Braze.changeUser(eid);
         dispatch(setBrazeEid(eid));
       }
 
@@ -367,7 +365,7 @@ export const requestBrazeContentRefresh = (): Effect => async dispatch => {
   try {
     dispatch(LogActions.info('Refreshing Braze content...'));
 
-    ReactAppboy.requestContentCardsRefresh();
+    Braze.requestContentCardsRefresh();
   } catch (err) {
     const errMsg = 'Something went wrong while refreshing Braze content.';
 
@@ -750,10 +748,10 @@ export const setNotifications =
   (dispatch, getState) => {
     dispatch(setNotificationsAccepted(accepted));
     const value = accepted
-      ? ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED
-      : ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED;
+      ? Braze.NotificationSubscriptionTypes.SUBSCRIBED
+      : Braze.NotificationSubscriptionTypes.UNSUBSCRIBED;
 
-    ReactAppboy.setPushNotificationSubscriptionType(value);
+    Braze.setPushNotificationSubscriptionType(value);
     const {
       WALLET: {keys},
       APP,
@@ -784,11 +782,11 @@ export const setAnnouncementsNotifications =
   async dispatch => {
     dispatch(setAnnouncementsAccepted(accepted));
     if (accepted) {
-      ReactAppboy.addToSubscriptionGroup(OFFERS_AND_PROMOTIONS_GROUP_ID);
-      ReactAppboy.addToSubscriptionGroup(PRODUCTS_UPDATES_GROUP_ID);
+      Braze.addToSubscriptionGroup(OFFERS_AND_PROMOTIONS_GROUP_ID);
+      Braze.addToSubscriptionGroup(PRODUCTS_UPDATES_GROUP_ID);
     } else {
-      ReactAppboy.removeFromSubscriptionGroup(PRODUCTS_UPDATES_GROUP_ID);
-      ReactAppboy.removeFromSubscriptionGroup(OFFERS_AND_PROMOTIONS_GROUP_ID);
+      Braze.removeFromSubscriptionGroup(PRODUCTS_UPDATES_GROUP_ID);
+      Braze.removeFromSubscriptionGroup(OFFERS_AND_PROMOTIONS_GROUP_ID);
     }
   };
 
@@ -803,11 +801,11 @@ export const setEmailNotifications =
     dispatch(setEmailNotificationsAccepted(accepted, _email));
 
     if (agreedToMarketingCommunications) {
-      ReactAppboy.setEmailNotificationSubscriptionType(
+      Braze.setEmailNotificationSubscriptionType(
         NotificationSubscriptionTypes.OPTED_IN,
       );
     } else {
-      ReactAppboy.setEmailNotificationSubscriptionType(
+      Braze.setEmailNotificationSubscriptionType(
         NotificationSubscriptionTypes.SUBSCRIBED,
       );
     }

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -269,7 +269,7 @@ export const initializeBrazeContent =
       let contentCardSubscription = APP.brazeContentCardSubscription;
 
       if (contentCardSubscription) {
-        contentCardSubscription.subscriber.removeAllSubscriptions();
+        contentCardSubscription.subscriber?.removeAllSubscriptions();
         contentCardSubscription = null;
       }
 
@@ -938,7 +938,6 @@ export const incomingLink =
     const parsed = url.replace(APP_DEEPLINK_PREFIX, '');
 
     if (parsed === 'card/offers') {
-      handled = true;
       const {APP, CARD} = getState();
       const cards = CARD.cards[APP.network];
 

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -193,10 +193,6 @@ export const useDeeplinks = () => {
               path: 'wallet-card',
               screens: {
                 [CardScreens.PAIRING]: 'pairing',
-                [CardScreens.HOME]: {
-                  path: 'card/:action',
-                  exact: true,
-                },
               },
             },
             [TabsScreens.SETTINGS]: {

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -191,6 +191,7 @@ export const useDeeplinks = () => {
           screens: {
             [TabsScreens.CARD]: {
               path: 'wallet-card',
+              initialRouteName: CardScreens.HOME,
               screens: {
                 [CardScreens.PAIRING]: 'pairing',
               },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11577,10 +11577,10 @@ react-native-animatable@1.3.3:
   dependencies:
     prop-types "^15.7.2"
 
-react-native-appboy-sdk@1.34.1:
-  version "1.34.1"
-  resolved "https://registry.yarnpkg.com/react-native-appboy-sdk/-/react-native-appboy-sdk-1.34.1.tgz#656acd45960021f31ccc7fc74b3f66bea48568c3"
-  integrity sha512-IGmzz4wvro9Ghrq3qYBNrs02G5Rlr04oINQOP2L4IT1il0vmQ4/oE6a2wKXVjf14feHdtB0RSvuzXSktJ0+6Gw==
+react-native-appboy-sdk@1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/react-native-appboy-sdk/-/react-native-appboy-sdk-1.38.0.tgz#24c674e7e4c376849181f02b9c5fa6f2a39877e7"
+  integrity sha512-eqxWMmr3cwu3Z3zbykirOUyeqBKlLF6KipvD01pEYGKZbC2Pf0vJOd58uG5IOScfus/maxM/uMe05wnkJ1gUZA==
 
 react-native-appsflyer@6.5.20:
   version "6.5.20"


### PR DESCRIPTION
Upgraded Braze SDK from 1.34.1 => 1.38.0

Fixed bugs:
-  `card/offers` deeplink now works on iOS, added a setTimeout that seems to avoid some weirdness, also navigate directly to CardSettings to bypass the fetch on the Activity screen
- fixed undefined reference when Braze subscription exists but no subscriber
- configured CardHome to be the default stack screen when deeplinking to card