### PR TITLE
Fix/add physical card

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1146,5 +1146,6 @@
   "InvalidInvitationCode": "Invalid invitation code",
   "MustBeLessThanArgCharacters": "Must be less than {{max}} characters",
   "MustBeGreaterThanArgCharacters": "Must be greater than {{min}} characters",
-  "IAgreeToTheArgAndArg": "I agree to the <0>{{0}}</0> and <1>{{1}}</1>."
+  "IAgreeToTheArgAndArg": "I agree to the <0>{{0}}</0> and <1>{{1}}</1>.",
+  "OrderPhysicalCard": "Order Physical Card"
 }

--- a/src/navigation/card/components/CardSettingsList.tsx
+++ b/src/navigation/card/components/CardSettingsList.tsx
@@ -2,7 +2,6 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Linking, Platform, View} from 'react-native';
-import styled from 'styled-components/native';
 import {Br, Hr} from '../../../components/styled/Containers';
 import {Link, Smallest} from '../../../components/styled/Text';
 import {URL} from '../../../constants';
@@ -53,11 +52,6 @@ const LINKS: {
     },
   ],
 };
-
-// TODO: update theme.colors.link if this is a universal change
-const CardSettingsTextLink = styled(Link)`
-  color: ${({theme}) => (theme.dark ? '#4989ff' : theme.colors.link)};
-`;
 
 const SettingsList: React.FC<SettingsListProps> = props => {
   const dispatch = useAppDispatch();
@@ -303,11 +297,9 @@ const SettingsList: React.FC<SettingsListProps> = props => {
           {links.map((link, idx) => {
             return (
               <React.Fragment key={link.labelKey}>
-                <CardSettingsTextLink
-                  onPress={() => openUrl(link.url, link.download)}
-                  style={{}}>
+                <Link onPress={() => openUrl(link.url, link.download)}>
                   {t(link.labelKey)}
-                </CardSettingsTextLink>
+                </Link>
 
                 {idx < links.length - 1 ? <Br /> : null}
               </React.Fragment>

--- a/src/navigation/card/screens/CardSettings.tsx
+++ b/src/navigation/card/screens/CardSettings.tsx
@@ -201,7 +201,11 @@ const CardSettings: React.FC<CardSettingsProps> = ({navigation, route}) => {
               key={c.id}
               entering={transitionEnter}
               exiting={transitionLeave}>
-              <SettingsList card={c} navigation={navigation} />
+              <SettingsList
+                card={c}
+                orderPhysical={isVirtual && !physicalCard}
+                navigation={navigation}
+              />
             </Animated.View>
           ) : null;
         })}


### PR DESCRIPTION
This PR adds the `Order Physical Card` link in card settings.

Testing:
Should ONLY be visible if no valid physical card exists. 
Should open the IAB (NOT the WebView, so should see Chrome/Safari custom tabs within the app) and request authentication
After authenticating, should be redirected to the order physical flow as usual