### PR TITLE
Fix/reset pin confirm

### DIFF
--- a/src/api/card/card.mutations.ts
+++ b/src/api/card/card.mutations.ts
@@ -20,7 +20,7 @@ type ActivateCardInputType = {
 };
 
 type GoogleProvisioningInputType = {
-  walletProvider: 'google',
+  walletProvider: 'google';
 };
 
 export const NAME_CARD = (
@@ -166,12 +166,34 @@ export const START_CREATE_GOOGLE_PAY_PROVISIONING_REQUEST = (
   };
 };
 
+const START_CONFIRM_PIN_CHANGE = (
+  token: string,
+  id: string,
+): GqlQueryParams => {
+  return {
+    query: `
+      mutation START_CONFIRM_PIN_CHANGE($token:String!, $csrf:String, $cardId:String!) {
+        user:bitpayUser(token:$token, csrf:$csrf) {
+          card:debitCard(cardId:$cardId) {
+            confirmPinChange
+          }
+        }
+      }
+    `,
+    variables: {
+      token,
+      cardId: id,
+    },
+  };
+};
+
 const CardMutations = {
   NAME_CARD,
   LOCK_CARD,
   ACTIVATE_CARD,
   START_CREATE_APPLE_WALLET_PROVISIONING_REQUEST,
   START_CREATE_GOOGLE_PAY_PROVISIONING_REQUEST,
+  START_CONFIRM_PIN_CHANGE,
 };
 
 export default CardMutations;

--- a/src/api/card/card.mutations.ts
+++ b/src/api/card/card.mutations.ts
@@ -19,6 +19,10 @@ type ActivateCardInputType = {
   lastFourDigits: string | undefined;
 };
 
+type GoogleProvisioningInputType = {
+  walletProvider: 'google',
+};
+
 export const NAME_CARD = (
   token: string,
   id: string,
@@ -139,7 +143,7 @@ export const START_CREATE_APPLE_WALLET_PROVISIONING_REQUEST = (
 export const START_CREATE_GOOGLE_PAY_PROVISIONING_REQUEST = (
   token: string,
   id: string,
-) => {
+): GqlQueryParams<GoogleProvisioningInputType> => {
   return {
     query: `
       mutation START_CREATE_PROVISIONING_REQUEST($token:String!, $csrf:String, $cardId:String!, $input:ProvisionInputType!) {

--- a/src/api/card/index.ts
+++ b/src/api/card/index.ts
@@ -257,6 +257,14 @@ const fetchPinChangeRequestInfo = async (token: string, id: string) => {
   return data;
 };
 
+const startConfirmPinChange = async (token: string, id: string) => {
+  const query = CardMutations.START_CONFIRM_PIN_CHANGE(token, id);
+
+  const {data} = await GraphQlApi.getInstance().request(query);
+
+  return data;
+};
+
 const CardApi = {
   activateCard,
   fetchAll,
@@ -267,10 +275,11 @@ const CardApi = {
   fetchReferredUsers,
   fetchSettledTransactions,
   fetchVirtualCardImageUrls,
-  updateCardLock,
-  updateCardName,
+  startConfirmPinChange,
   startCreateAppleWalletProvisioningRequest,
   startCreateGooglePayProvisioningRequest,
+  updateCardLock,
+  updateCardName,
 };
 
 export default CardApi;

--- a/src/store/card/card.actions.ts
+++ b/src/store/card/card.actions.ts
@@ -9,6 +9,7 @@ import {
 } from './card.models';
 import {
   ActivateCardStatus,
+  ConfirmPinChangeStatus,
   FetchCardsStatus,
   FetchOverviewStatus,
   FetchPinChangeRequestInfoStatus,
@@ -257,4 +258,25 @@ export const updateFetchPinChangeRequestInfoStatus = (
 export const resetPinChangeRequestInfo = (id: string): CardActionType => ({
   type: CardActionTypes.RESET_PIN_CHANGE_REQUEST_INFO,
   payload: {id},
+});
+
+export const confirmPinChangeSuccess = (id: string): CardActionType => ({
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_SUCCESS,
+  payload: {id},
+});
+
+export const confirmPinChangeError = (
+  id: string,
+  error: string,
+): CardActionType => ({
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_FAILED,
+  payload: {id, error},
+});
+
+export const confirmPinChangeStatusUpdated = (
+  id: string,
+  status: ConfirmPinChangeStatus,
+): CardActionType => ({
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_STATUS_UPDATED,
+  payload: {id, status},
 });

--- a/src/store/card/card.effects.ts
+++ b/src/store/card/card.effects.ts
@@ -661,3 +661,30 @@ export const startFetchPinChangeRequestInfo =
       );
     }
   };
+
+export const startConfirmPinChange =
+  (id: string): Effect =>
+  async (dispatch, getState) => {
+    dispatch(CardActions.confirmPinChangeStatusUpdated(id, null));
+
+    const {APP, BITPAY_ID} = getState();
+    const token = BITPAY_ID.apiToken[APP.network];
+
+    const res = await CardApi.startConfirmPinChange(token, id);
+
+    if (!res.data) {
+      let errMsg;
+
+      if (res.errors) {
+        errMsg = res.errors.map(e => e.message).join(', ');
+      } else {
+        errMsg =
+          t('An unexpected error occurred while confirming PIN change for') +
+          ` ${id}.`;
+      }
+
+      dispatch(CardActions.confirmPinChangeError(id, errMsg));
+    } else {
+      dispatch(CardActions.confirmPinChangeSuccess(id));
+    }
+  };

--- a/src/store/card/card.reducer.ts
+++ b/src/store/card/card.reducer.ts
@@ -29,6 +29,8 @@ export const cardReduxPersistBlacklist: Array<keyof CardState> = [
   'pinChangeRequestInfo',
   'pinChangeRequestInfoStatus',
   'pinChangeRequestInfoError',
+  'confirmPinChangeStatus',
+  'confirmPinChangeError',
 ];
 
 export type FetchCardsStatus = 'success' | 'failed' | null;
@@ -40,6 +42,7 @@ export type UpdateCardNameStatus = 'success' | 'failed' | null;
 export type referredUsersStatus = 'loading' | 'failed';
 export type ActivateCardStatus = 'success' | 'failed' | null;
 export type FetchPinChangeRequestInfoStatus = 'success' | 'failed' | null;
+export type ConfirmPinChangeStatus = 'success' | 'failed' | null;
 
 export interface CardState {
   lastUpdates: {
@@ -90,6 +93,8 @@ export interface CardState {
   pinChangeRequestInfo: Record<string, string | null>;
   pinChangeRequestInfoStatus: Record<string, FetchPinChangeRequestInfoStatus>;
   pinChangeRequestInfoError: Record<string, string | null>;
+  confirmPinChangeStatus: Record<string, ConfirmPinChangeStatus>;
+  confirmPinChangeError: Record<string, string | null>;
 }
 
 const initialState: CardState = {
@@ -120,6 +125,8 @@ const initialState: CardState = {
   pinChangeRequestInfo: {},
   pinChangeRequestInfoStatus: {},
   pinChangeRequestInfoError: {},
+  confirmPinChangeStatus: {},
+  confirmPinChangeError: {},
 };
 
 export const cardReducer = (
@@ -505,6 +512,38 @@ export const cardReducer = (
         pinChangeRequestInfoError: {
           ...state.pinChangeRequestInfoError,
           [action.payload.id]: null,
+        },
+      };
+    case CardActionTypes.CONFIRM_PIN_CHANGE_SUCCESS:
+      return {
+        ...state,
+        confirmPinChangeStatus: {
+          ...state.confirmPinChangeStatus,
+          [action.payload.id]: 'success',
+        },
+        confirmPinChangeError: {
+          ...state.confirmPinChangeError,
+          [action.payload.id]: null,
+        },
+      };
+    case CardActionTypes.CONFIRM_PIN_CHANGE_FAILED:
+      return {
+        ...state,
+        confirmPinChangeStatus: {
+          ...state.confirmPinChangeStatus,
+          [action.payload.id]: 'failed',
+        },
+        confirmPinChangeError: {
+          ...state.confirmPinChangeError,
+          [action.payload.id]: action.payload.error,
+        },
+      };
+    case CardActionTypes.CONFIRM_PIN_CHANGE_STATUS_UPDATED:
+      return {
+        ...state,
+        confirmPinChangeStatus: {
+          ...state.confirmPinChangeStatus,
+          [action.payload.id]: action.payload.status,
         },
       };
 

--- a/src/store/card/card.types.ts
+++ b/src/store/card/card.types.ts
@@ -17,6 +17,7 @@ import {
   UpdateCardLockStatus,
   referredUsersStatus,
   FetchPinChangeRequestInfoStatus,
+  ConfirmPinChangeStatus,
 } from './card.reducer';
 
 export const TTL = {
@@ -71,6 +72,9 @@ export enum CardActionTypes {
   FAILED_FETCH_PIN_CHANGE_REQUEST_INFO = 'CARD/FAILED_FETCH_PIN_CHANGE_REQUEST_INFO',
   UPDATE_FETCH_PIN_CHANGE_REQUEST_INFO_STATUS = 'CARD/UPDATE_FETCH_PIN_CHANGE_REQUEST_INFO_STATUS',
   RESET_PIN_CHANGE_REQUEST_INFO = 'CARD/RESET_PIN_CHANGE_REQUEST_INFO',
+  CONFIRM_PIN_CHANGE_SUCCESS = 'CARD/CONFIRM_PIN_CHANGE_SUCCESS',
+  CONFIRM_PIN_CHANGE_FAILED = 'CARD/CONFIRM_PIN_CHANGE_FAILED',
+  CONFIRM_PIN_CHANGE_STATUS_UPDATED = 'CARD/CONFIRM_PIN_CHANGE_STATUS_UPDATED',
 }
 
 interface SuccessInitializeStore {
@@ -241,6 +245,21 @@ interface ResetPinChangeRequestInfo {
   payload: {id: string};
 }
 
+interface ConfirmPinChangeSuccess {
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_SUCCESS;
+  payload: {id: string};
+}
+
+interface ConfirmPinChangeFailed {
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_FAILED;
+  payload: {id: string; error: string};
+}
+
+interface ConfirmPinChangeStatusUpdated {
+  type: CardActionTypes.CONFIRM_PIN_CHANGE_STATUS_UPDATED;
+  payload: {id: string; status: ConfirmPinChangeStatus};
+}
+
 export type CardActionType =
   | SuccessInitializeStore
   | SuccessFetchCards
@@ -273,4 +292,7 @@ export type CardActionType =
   | SuccessFetchPinChangeRequestInfo
   | FailedFetchPinChangeRequestInfo
   | UpdateFetchPinChangeRequestInfoStatus
-  | ResetPinChangeRequestInfo;
+  | ResetPinChangeRequestInfo
+  | ConfirmPinChangeSuccess
+  | ConfirmPinChangeFailed
+  | ConfirmPinChangeStatusUpdated;


### PR DESCRIPTION
This PR adds the missing confirm call to the reset PIN workflow.

Testing:
-- login with an account that has a physical Galileo card
-- navigate to card settings => reset PIN
-- UX should remain the same, so check logs to verify that PIN change was confirmed