### PR TITLE
Fix: auto adjust number pad to screen size

### DIFF
--- a/src/components/virtual-keyboard/VirtualKeyboard.tsx
+++ b/src/components/virtual-keyboard/VirtualKeyboard.tsx
@@ -3,8 +3,11 @@ import styled, {css, useTheme} from 'styled-components/native';
 import {SlateDark, White} from '../../styles/colors';
 import {BaseText} from '../styled/Text';
 import DeleteIcon from '../icons/delete/Delete';
+import {PixelRatio} from 'react-native';
 import VirtualKeyboardButtonAnimation from './VirtualKeyboardButtonAnimation';
-export const VIRTUAL_KEYBOARD_BUTTON_SIZE = 85;
+const PIXEL_DENSITY_LIMIT = 3;
+export const VIRTUAL_KEYBOARD_BUTTON_SIZE =
+  PixelRatio.get() < PIXEL_DENSITY_LIMIT ? 70 : 85;
 
 interface SymbolContainerProps {
   showLetters?: boolean;
@@ -24,12 +27,15 @@ const CellContainer = styled.View`
   align-items: center;
 `;
 
-const CellValue = styled(BaseText)<{darkModeOnly?: boolean}>`
-  font-size: 32.08px;
+const CellValue = styled(BaseText)<{
+  darkModeOnly?: boolean;
+  isSmallScreen?: boolean;
+}>`
+  font-size: ${({isSmallScreen}) => (isSmallScreen ? 26 : 32.08)}px;
   font-weight: 500;
   color: ${({theme, darkModeOnly}) =>
     darkModeOnly ? White : theme.colors.text};
-  line-height: 65px;
+  line-height: ${({isSmallScreen}) => (isSmallScreen ? 50 : 65)}px;
 `;
 
 const CellLetter = styled(BaseText)`
@@ -79,7 +85,13 @@ const Cell: React.FC<CellProps> = ({
         onPress={() => onCellPress?.(value)}
         backgroundColor={backgroundColor}>
         <>
-          <CellValue darkModeOnly={darkModeOnly}>{value}</CellValue>
+          <CellValue
+            darkModeOnly={darkModeOnly}
+            isSmallScreen={
+              PixelRatio.get() < PIXEL_DENSITY_LIMIT ? true : false
+            }>
+            {value}
+          </CellValue>
           {letters ? <CellLetter>{letters}</CellLetter> : null}
         </>
       </VirtualKeyboardButtonAnimation>


### PR DESCRIPTION
Docs: https://reactnative.dev/docs/pixelratio#get 

Device test: iPhone SE (Sim)

### Original:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-09-12 at 13 09 47](https://user-images.githubusercontent.com/237435/189703314-5a020f7e-0014-4e7d-80db-7c02b591d2cf.png)

### Fixed version:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-09-12 at 13 08 08](https://user-images.githubusercontent.com/237435/189703382-854fb4ab-74a8-4dac-afc1-3b20c845b26d.png)



