### PR TITLE
Fix: remove listener for appStatusChange to avoid duplicated events

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@types/lodash.isequal": "4.5.5",
     "@types/lodash.merge": "4.6.6",
     "@types/lodash.throttle": "4.1.6",
-    "@types/react-native": "0.64.19",
+    "@types/react-native": "0.67.4",
     "@types/react-native-dotenv": "0.2.0",
     "@types/react-native-snap-carousel": "3.8.5",
     "@types/react-redux": "7.1.20",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -290,8 +290,13 @@ export default () => {
         }
       }
     }
-    AppState.addEventListener('change', onAppStateChange);
-    return () => AppState.removeEventListener('change', onAppStateChange);
+    const subscriptionAppStateChange = AppState.addEventListener(
+      'change',
+      onAppStateChange,
+    );
+    return () => {
+      subscriptionAppStateChange.remove();
+    };
   }, [
     dispatch,
     onboardingCompleted,

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -294,9 +294,7 @@ export default () => {
       'change',
       onAppStateChange,
     );
-    return () => {
-      subscriptionAppStateChange.remove();
-    };
+    return () => subscriptionAppStateChange.remove();
   }, [
     dispatch,
     onboardingCompleted,

--- a/src/navigation/tabs/settings/components/Notifications.tsx
+++ b/src/navigation/tabs/settings/components/Notifications.tsx
@@ -91,8 +91,11 @@ const Notifications = () => {
         setNotificationValue(notificationsState.pushNotifications);
       }
     }
-    AppState.addEventListener('change', onAppStateChange);
-    return () => AppState.removeEventListener('change', onAppStateChange);
+    const subscriptionAppStateChange = AppState.addEventListener(
+      'change',
+      onAppStateChange,
+    );
+    return () => subscriptionAppStateChange.remove();
   }, [dispatch, setNotificationValue, notificationsState]);
 
   useEffect(() => {

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -166,10 +166,11 @@ export const useDeeplinks = () => {
   const urlEventHandler = useUrlEventHandler();
 
   useEffect(() => {
-    Linking.addEventListener('url', urlEventHandler);
-    return () => {
-      Linking.removeEventListener('url', urlEventHandler);
-    };
+    const subscribeLinkingEvent = Linking.addEventListener(
+      'url',
+      urlEventHandler,
+    );
+    return () => subscribeLinkingEvent.remove();
   }, [dispatch, urlEventHandler]);
 
   const linkingOptions: LinkingOptions<RootStackParamList> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,10 +3316,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@0.64.19":
-  version "0.64.19"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.19.tgz#2b888c082ad293fa0fa6ae34c5e9457cfb38e50a"
-  integrity sha512-bT62QhaPvOKFGmlfURIC98ILjUDoIFrc2Bn5EzL3qciZrT91vHwkxFOkuEyQJy+DWaHCa2z3IrtIEJywkGu/Bg==
+"@types/react-native@0.67.4":
+  version "0.67.4"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.67.4.tgz#97a8d3cff2a7606f247008e93d9fe2a3879bc84e"
+  integrity sha512-L81CB6W1m0s7d+TH/loP318+VKPwwjWQBUTVYQ1+lQTWiE5jHxyihgCmd7JbwLICo708FRSDwJW7pJoiZHy6yg==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
This PR fixes FaceID loop.

https://reactnative.dev/docs/appstate#removeeventlistener

https://reactnative.dev/docs/linking#removeeventlistener