### PR TITLE
[FIX] show bitpay supported tokens first

### DIFF
--- a/src/navigation/wallet/screens/CurrencySelection.tsx
+++ b/src/navigation/wallet/screens/CurrencySelection.tsx
@@ -57,6 +57,7 @@ import {BitpaySupportedTokenOpts} from '../../../constants/tokens';
 import {useTranslation} from 'react-i18next';
 import CurrencySelectionSearchInput from '../components/CurrencySelectionSearchInput';
 import CurrencySelectionNoResults from '../components/CurrencySelectionNoResults';
+import {orderBy} from 'lodash';
 
 type CurrencySelectionScreenProps = StackScreenProps<
   WalletStackParamList,
@@ -677,19 +678,12 @@ const CurrencySelection: React.VFC<CurrencySelectionScreenProps> = ({
         return;
       }
 
-      const sortedTokens = item.tokens.map(token => ({...token}));
-
       // sorted selected tokens to the top for ease of use
-      sortedTokens.sort((a, b) => {
-        if (a.selected && !b.selected) {
-          return -1;
-        }
-        if (b.selected && !a.selected) {
-          return 1;
-        }
-
-        return 0;
-      });
+      const sortedTokens = orderBy(
+        item.tokens.map(token => ({...token})),
+        'selected',
+        'desc',
+      );
 
       navigation.navigate('Wallet', {
         screen: WalletScreens.CURRENCY_TOKEN_SELECTION,


### PR DESCRIPTION
<img width="303" alt="iPhone_13 (3)" src="https://user-images.githubusercontent.com/10999037/190234453-b7983333-de7c-4f11-9daf-5695cd583a01.png">

with the fix: 
<img width="317" alt="iPhone_13" src="https://user-images.githubusercontent.com/10999037/190235066-c78c4205-fe53-4fa4-81fc-175f144f423b.png">
