### PR TITLE
[RN-661]: Adding crypto address with scanning closes the contacts screen

### DIFF
--- a/src/navigation/scan/screens/Scan.tsx
+++ b/src/navigation/scan/screens/Scan.tsx
@@ -70,7 +70,7 @@ const Scan = () => {
             }
           }
         },
-        500,
+        800,
         {
           leading: true,
           trailing: false,


### PR DESCRIPTION
on android devices 500 ms debounce time was not enough to avoid wrong behaviors