### PR TITLE
Ref: show error for non compatible selected wallet

### DIFF
--- a/src/navigation/wallet/screens/send/SendTo.tsx
+++ b/src/navigation/wallet/screens/send/SendTo.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../../utils/helper-methods';
 import {Key} from '../../../../store/wallet/wallet.models';
 import {Rates} from '../../../../store/rate/rate.models';
+import {showNoSelectedWalletOnInvoiceModal} from '../../../../store/wallet/effects/send/send';
 import debounce from 'lodash.debounce';
 import {
   CheckIfLegacyBCH,
@@ -375,10 +376,7 @@ const SendTo = () => {
         dispatch(dismissOnGoingProcessModal());
         await sleep(500);
         const selected = payProOptions.paymentOptions.find(
-          (option: PayProPaymentOption) =>
-            option.selected &&
-            GetInvoiceCurrency(currencyAbbreviation).toUpperCase() ===
-              option.currency,
+          (option: PayProPaymentOption) => option.selected,
         );
         if (selected) {
           const isValid = dispatch(checkCoinAndNetwork(selected, true));
@@ -392,7 +390,7 @@ const SendTo = () => {
             });
           }
         } else {
-          // TODO: handle me
+          dispatch(showNoSelectedWalletOnInvoiceModal());
         }
       } catch (err) {
         const formattedErrMsg = BWCErrorMessage(err);
@@ -511,7 +509,11 @@ const SendTo = () => {
                         validateAndNavigateToConfirm(data);
                       }
                     } catch (err) {
-                      console.log(err);
+                      const errorStr =
+                        err instanceof Error
+                          ? err.message
+                          : JSON.stringify(err);
+                      logger.error('[SendTo] ' + errorStr);
                     }
                   },
                 },

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -1381,6 +1381,29 @@ export const getTx = (wallet: Wallet, txpid: string): Promise<any> => {
   });
 };
 
+export const showNoSelectedWalletOnInvoiceModal =
+  (): Effect<void> => async dispatch => {
+    dispatch(
+      showBottomNotificationModal({
+        type: 'error',
+        title: t('Error processing payment'),
+        message: t(
+          'This invoice has not a wallet selected to complete this payment.',
+        ),
+        enableBackdropDismiss: true,
+        actions: [
+          {
+            text: t('Got it'),
+            action: () => {
+              dispatch(dismissBottomNotificationModal());
+            },
+            primary: true,
+          },
+        ],
+      }),
+    );
+  };
+
 export const showNoWalletsModal =
   ({navigation}: {navigation: any}): Effect<void> =>
   async dispatch => {


### PR DESCRIPTION
If scan an invoice or address that no match with type of selected wallet, display an error.