### PR TITLE
Fix: added required "android:exported" for new targetSdkVersion (31)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:theme="@style/AppTheme"
             android:networkSecurityConfig="@xml/network_security_config">
 
-        <activity android:name=".LaunchActivity">
+        <activity android:name=".LaunchActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Getting error:

```
Manifest merger failed : Apps targeting Android 12 and higher are 
required to specify an explicit value for `android:exported` when 
the corresponding component has an intent filter defined. 
See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```

