### PR TITLE
Fix: importing a first wallet on new installation asks to accept TermsofUsers twice

### DIFF
--- a/src/store/wallet/effects/import/import.ts
+++ b/src/store/wallet/effects/import/import.ts
@@ -813,7 +813,6 @@ export const deferredImportMnemonic =
   ): Effect =>
   async (dispatch, getState): Promise<void> => {
     try {
-      const {WALLET} = getState();
       dispatch(updateDeferredImport({importData, opts}));
 
       await sleep(500);
@@ -835,6 +834,10 @@ export const deferredImportMnemonic =
         }),
       );
 
+      const {
+        WALLET: {walletTermsAccepted},
+      } = getState();
+
       dispatch(
         showBottomNotificationModal({
           type: 'success',
@@ -848,7 +851,7 @@ export const deferredImportMnemonic =
                 backupRedirect({
                   context,
                   navigation: navigationRef,
-                  walletTermsAccepted: WALLET.walletTermsAccepted,
+                  walletTermsAccepted: walletTermsAccepted,
                   key,
                 });
               },


### PR DESCRIPTION
After accept terms when importing a wallet and back to Home view. Waiting for the import finish... Click on "ok", instead to open the new imported key, it asks to accept terms again.


ERROR:


https://user-images.githubusercontent.com/237435/194414872-178e633d-057f-4a57-b8b6-aee70ab66b3c.mov



FIXED:


https://user-images.githubusercontent.com/237435/194414117-7ce4bd19-c0ed-4bf6-9cc6-555182f0ae6a.mov

