### PR TITLE
Fix: keep position for swapButton (Amount View)

### DIFF
--- a/src/components/amount/Amount.tsx
+++ b/src/components/amount/Amount.tsx
@@ -368,7 +368,9 @@ const Amount: React.VFC<AmountProps> = ({
                 <CurrencySymbol />
                 <ButtonText>MAX</ButtonText>
               </SwapButtonContainer>
-            ) : null}
+            ) : (
+              <Row />
+            )}
             {swapList.length > 1 ? (
               <SwapButton
                 swapList={swapList}


### PR DESCRIPTION
BEFORE

<img width="391" alt="Screen Shot 2022-10-10 at 16 43 52" src="https://user-images.githubusercontent.com/237435/194952278-73275516-2c2a-4417-a0c1-8ae679a56e1e.png">


AFTER

<img width="393" alt="Screen Shot 2022-10-10 at 18 03 01" src="https://user-images.githubusercontent.com/237435/194952302-19a6e3c0-a53c-4898-b12f-3bcfd2e05815.png">
