### PR TITLE
Fix: show correct icon for recipients on Confirm Screen

### DIFF
--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -159,6 +159,7 @@ export const SendingTo: React.VFC<SendingToProps> = ({
     recipientFullAddress,
     recipientCoin,
     recipientChain,
+    recipientType,
   } = recipient;
 
   let badgeImg;
@@ -205,7 +206,7 @@ export const SendingTo: React.VFC<SendingToProps> = ({
             icon={
               copied ? (
                 <CopiedSvg width={18} />
-              ) : recipientName || recipientEmail ? (
+              ) : recipientType === 'contact' ? (
                 <ContactIcon name={description} size={20} />
               ) : (
                 <CurrencyImage img={img} size={18} badgeUri={badgeImg} />


### PR DESCRIPTION
![Screen Shot 2022-10-14 at 17 06 19](https://user-images.githubusercontent.com/237435/195933238-058075fd-a536-442f-8fa2-f919999a62ab.png)
