### PR TITLE
Fix Contacts crash

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as Svg from 'react-native-svg';
-import styled, {useTheme} from 'styled-components/native';
+import styled from 'styled-components/native';
 import {Action, LinkBlue, Midnight, White} from '../../styles/colors';
 import {BaseText} from '../styled/Text';
 import ProfileIcon from './ProfileIcon';

--- a/src/components/list/ContactRow.tsx
+++ b/src/components/list/ContactRow.tsx
@@ -55,7 +55,12 @@ const ContactRow = ({contact, onPress}: Props) => {
     <ContactContainer underlayColor={underlayColor} onPress={onPress}>
       <RowContainer>
         <ContactImageContainer>
-          <ContactIcon name={name} coin={coin} size={45} chain={chain} />
+          <ContactIcon
+            name={name}
+            coin={coin}
+            size={45}
+            chain={chain || coin}
+          />
         </ContactImageContainer>
         <ContactColumn>
           <H5>{name}</H5>

--- a/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
+++ b/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
@@ -304,7 +304,7 @@ const EnableTwoFactor: React.FC<EnableTwoFactorProps> = ({navigation}) => {
                 <CopyButton
                   height={50}
                   buttonStyle={'secondary'}
-                  onPress={() => copyToClipboard(twoFactorSetupCode)}>
+                  onPress={() => copyToClipboard(otpAuthKey!)}>
                   {t('Copy 2FA Setup Key')}
                 </CopyButton>
               </InstructionBox>

--- a/src/navigation/coinbase/screens/CoinbaseAccount.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseAccount.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components/native';
 import {FlatList, RefreshControl} from 'react-native';
 import {find} from 'lodash';
 import moment from 'moment';
-import {getCurrencyAbbreviation, sleep} from '../../../utils/helper-methods';
+import {sleep} from '../../../utils/helper-methods';
 import {useNavigation, useTheme} from '@react-navigation/native';
 import {formatFiatAmount, shouldScale} from '../../../utils/helper-methods';
 import {Hr, ScreenGutter} from '../../../components/styled/Containers';

--- a/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
@@ -291,7 +291,7 @@ const ContactsDetails = ({
             coin={getCurrencyAbbreviation(contact.coin, contact.chain)}
             size={100}
             name={contact.name}
-            chain={contact.chain}
+            chain={contact.chain || contact.coin}
           />
         </ContactImageHeader>
         <Details>

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -351,6 +351,7 @@ const Confirm = () => {
       recipientAddress: sendingTo.recipientAddress,
       img: recipient.type,
       recipientChain: recipient.chain,
+      recipientType: recipient.type,
     };
   } else {
     recipientData = sendingTo;

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -206,7 +206,7 @@ export const SendingTo: React.VFC<SendingToProps> = ({
             icon={
               copied ? (
                 <CopiedSvg width={18} />
-              ) : recipientType === 'contact' ? (
+              ) : recipientType === 'contact' || recipientEmail ? (
                 <ContactIcon name={description} size={20} />
               ) : (
                 <CurrencyImage img={img} size={18} badgeUri={badgeImg} />

--- a/src/store/wallet/utils/currency.ts
+++ b/src/store/wallet/utils/currency.ts
@@ -70,9 +70,11 @@ export const IsCustomERCToken = (
 
 export const IsERCToken = (
   currencyAbbreviation: string,
-  chain: string,
+  chain?: string,
 ): boolean => {
-  return currencyAbbreviation.toLowerCase() !== chain.toLowerCase();
+  return !!(
+    chain && currencyAbbreviation.toLowerCase() !== chain.toLowerCase()
+  );
 };
 
 export const GetBlockExplorerUrl =

--- a/src/utils/helper-methods.ts
+++ b/src/utils/helper-methods.ts
@@ -320,9 +320,9 @@ export const addTokenChainSuffix = (name: string, chain: string) => {
   return `${name.toLowerCase()}_${chain.charAt(0)}`;
 };
 
-export const getCurrencyAbbreviation = (name: string, chain: string) => {
-  return IsERCToken(name.toLowerCase(), chain.toLowerCase())
-    ? addTokenChainSuffix(name, chain)
+export const getCurrencyAbbreviation = (name: string, chain?: string) => {
+  return IsERCToken(name, chain)
+    ? addTokenChainSuffix(name, chain!)
     : name.toLowerCase();
 };
 


### PR DESCRIPTION
Old contacts saved in storage currently don't have a `chain` field (this field was added as part of the matic refactor). This PR ensures backwards compatibility with the old contacts schema (fixing a crash on app startup for users who have contacts without a `chain` field set)