### PR TITLE
[FIX] add tokens to preferences

### DIFF
--- a/src/store/wallet/effects/create/create.ts
+++ b/src/store/wallet/effects/create/create.ts
@@ -272,9 +272,6 @@ const createMultipleWallets =
       wallets.push(wallet);
       for (const token of tokens) {
         if (token.chain === coin.chain) {
-          wallet.preferences = wallet.preferences || {
-            tokenAddresses: [],
-          };
           const tokenWallet = await dispatch(
             createTokenWallet(
               wallet,
@@ -423,7 +420,11 @@ const createTokenWallet =
         wallet.tokens = wallet.tokens || [];
         wallet.tokens.push(tokenCredentials.walletId);
         // Add the token info to the ethWallet for BWC/BWS
-        wallet.preferences?.tokenAddresses?.push(
+
+        wallet.preferences = wallet.preferences || {
+          tokenAddresses: [],
+        };
+        wallet.preferences.tokenAddresses?.push(
           // @ts-ignore
           tokenCredentials.token.address,
         );


### PR DESCRIPTION
Tokens added from the `add wallet` option were not added to the wallet preferences, so when importing those tokens they were missing