### PR TITLE
FIX: use new Matic icon for matic_e after upgrade the app

### DIFF
--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -50,12 +50,12 @@ export const bindWalletClient = createTransform(
         // build wallet obj with bwc client credentials
         return merge(
           walletClient,
+          wallet,
           buildWalletObj({
             ...walletClient.credentials,
             currencyAbbreviation,
             currencyName,
           }),
-          wallet,
         );
       });
 


### PR DESCRIPTION
It's applied when users already have a Matic Token in their app.

BEFORE the upgrade

![Simulator Screen Shot - iPhone 13 - 2022-10-25 at 22 13 07](https://user-images.githubusercontent.com/237435/197915483-735b6e80-e25e-4256-8998-67bd09fe407f.png)


AFTER the upgrade
![Simulator Screen Shot - iPhone 13 - 2022-10-25 at 22 41 20](https://user-images.githubusercontent.com/237435/197915512-5e28d9d7-84fd-44ff-b2b7-7dbbafe422b0.png)

