### PR TITLE
Feat: handle buy limits in Amount view

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1158,5 +1158,7 @@
   "MustBeGreaterThanArgCharacters": "Must be greater than {{min}} characters",
   "IAgreeToTheArgAndArg": "I agree to the <0>{{0}}</0> and <1>{{1}}</1>.",
   "OrderPhysicalCard": "Order Physical Card",
-  "WalletConnectBannerConfirm": "Before proceeding, verify the <0>{{peerName}}</0> request is still waiting for confirmation."
+  "WalletConnectBannerConfirm": "Before proceeding, verify the <0>{{peerName}}</0> request is still waiting for confirmation.",
+  "MinAmountWarnMsg": "{{min}} {{currency}} minimum",
+  "MaxAmountWarnMsg": "{{max}} {{currency}} maximum"
 }

--- a/src/navigation/card/components/CardDashboard.tsx
+++ b/src/navigation/card/components/CardDashboard.tsx
@@ -192,6 +192,7 @@ const CardDashboard: React.FC<CardDashboardProps> = props => {
                         },
                       });
                     },
+                    context: 'buyCrypto',
                   },
                 });
               },

--- a/src/navigation/services/buy-crypto/utils/buy-crypto-utils.ts
+++ b/src/navigation/services/buy-crypto/utils/buy-crypto-utils.ts
@@ -4,10 +4,12 @@ import {
   PaymentMethodsAvailable,
 } from '../constants/BuyCryptoConstants';
 import {
+  getSimplexFiatAmountLimits,
   getSimplexSupportedCurrencies,
   simplexSupportedFiatCurrencies,
 } from './simplex-utils';
 import {
+  getWyreFiatAmountLimits,
   getWyreSupportedCurrencies,
   wyreSupportedFiatCurrencies,
 } from './wyre-utils';

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -1001,9 +1001,7 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
                                 },
                               });
                             },
-                            opts: {
-                              context: 'buyCrypto',
-                            },
+                            context: 'buyCrypto',
                           },
                         });
                       },

--- a/src/store/buy-crypto/buy-crypto.models.ts
+++ b/src/store/buy-crypto/buy-crypto.models.ts
@@ -1,3 +1,8 @@
+export interface BuyCryptoLimits {
+  min?: number;
+  max?: number;
+}
+
 export interface simplexPaymentData {
   address: string;
   chain: string;


### PR DESCRIPTION
In this PR:
- Handle buy limits in Amount view
- Fix: reset real amount value when switch between currencies (Without this fix, you can enter a number, switch between currencies in the Amount view and the view will show 0, however the "Continue" button will still be enabled, since the actual value remains as it was)
- Fix: Added a warning message when trying to enter an amount bigger than max limit
- Fix: added translations to warning messages
- Fix: context: 'buyCrypto' from walletDetails and CardDashboard