### PR TITLE
Fix: check if custom token and show historic rates

### DIFF
--- a/src/store/wallet/utils/currency.ts
+++ b/src/store/wallet/utils/currency.ts
@@ -67,7 +67,7 @@ export const IsCustomERCToken = (
   currencyAbbreviation: string,
   chain: string,
 ) => {
-  const currency = addTokenChainSuffix(currencyAbbreviation, chain);
+  const currency = getCurrencyAbbreviation(currencyAbbreviation, chain);
   return !BitpaySupportedCurrencies[currency.toLowerCase()];
 };
 


### PR DESCRIPTION
### Currently issue

For example if we pass btc to the function `IsCustomERCToken`. 
The `currency` variable returns `btc_b`.

The next function BitpaySupportedCurrencies[`btc_b`] returns `false` ... and finally it's `!`, so it returns `true`. 

Finally the function `IsCustomERCToken` will return `true` for `BTC`


![Screen Shot 2022-10-28 at 09 51 22](https://user-images.githubusercontent.com/237435/198593633-8c286b2a-8ca5-4e6d-b11c-1bb38d64e092.png)

FIXED

![Screen Shot 2022-10-28 at 09 54 48](https://user-images.githubusercontent.com/237435/198593707-1691a5a4-05f9-4e3d-8860-113041ccc927.png)
