### PR TITLE
Fix Coinbase: BCH deposit not working due to new format BCH address

### DIFF
--- a/src/navigation/coinbase/screens/CoinbaseAccount.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseAccount.tsx
@@ -69,6 +69,7 @@ import {
   BitpaySupportedUtxoCoins,
   OtherBitpaySupportedCoins,
 } from '../../../constants/currencies';
+import {IsValidBitcoinCashAddress} from '../../../store/wallet/utils/validations';
 
 const AccountContainer = styled.View`
   flex: 1;
@@ -393,7 +394,10 @@ const CoinbaseAccount = ({
         if (!newAddress) {
           return;
         }
-        if (account?.currency.code === 'BCH') {
+        if (
+          account?.balance.currency === 'BCH' &&
+          !IsValidBitcoinCashAddress(newAddress)
+        ) {
           // Convert old format bch address to bch cash address
           newAddress = TranslateToBchCashAddress(newAddress);
           newAddress = ToCashAddress(newAddress, false);


### PR DESCRIPTION
Now Coinbase generates new BCH format address. 
So, it's not necessary to convert it from old format to new one, because bitcore returns error trying to do this function with a BCH address: 

```
Bitcore.Address(addressToTranslate)
``` 
