### PR TITLE
[REF] better handle of unsent transactions

### DIFF
--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -77,7 +77,7 @@ const HomeRoot = () => {
   const wallets = Object.values(keys).flatMap(k => k.wallets);
   let pendingTxps: any = [];
   each(wallets, x => {
-    if (x.pendingTxps && x.credentials.n > 1) {
+    if (x.pendingTxps) {
       pendingTxps = pendingTxps.concat(x.pendingTxps);
     }
   });

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -357,7 +357,7 @@ const KeyOverview: React.FC<KeyOverviewScreenProps> = ({navigation, route}) => {
     Object.values(keys).filter(k => k.backupComplete).length > 1;
   let pendingTxps: any = [];
   _.each(key?.wallets, x => {
-    if (x.pendingTxps && x.credentials.n > 1) {
+    if (x.pendingTxps) {
       pendingTxps = pendingTxps.concat(x.pendingTxps);
     }
   });

--- a/src/navigation/wallet/screens/TransactionProposalDetails.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalDetails.tsx
@@ -394,7 +394,8 @@ const TransactionProposalDetails = () => {
           {txs &&
           !txs.removed &&
           txs.pendingForUs &&
-          !txs.multisigContractAddress ? (
+          !txs.multisigContractAddress &&
+          wallet.credentials.n > 1 ? (
             <Button
               onPress={rejectPaymentProposal}
               buttonType={'link'}

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -446,20 +446,19 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
         copayerId: fullWalletObj.credentials.copayerId,
       });
 
-      if (fullWalletObj.credentials.n > 1) {
-        if ((!action || action.type === 'failed') && txp.status === 'pending') {
-          txpsPending.push(txp);
-        }
-
-        if (action && txp.status === 'accepted') {
-          txpsPending.push(txp);
-        }
-
+      const setPendingTx = (_txp: TransactionProposal) => {
+        fullWalletObj.credentials.n > 1
+          ? txpsPending.push(_txp)
+          : txpsUnsent.push(_txp);
         setNeedActionPendingTxps(txpsPending);
-        // For unsent transactions
-      } else if (action && txp.status === 'accepted') {
-        txpsUnsent.push(txp);
         setNeedActionUnsentTxps(txpsUnsent);
+      };
+      if ((!action || action.type === 'failed') && txp.status === 'pending') {
+        setPendingTx(txp);
+      }
+      // unsent transactions
+      if (action && txp.status === 'accepted') {
+        setPendingTx(txp);
       }
     });
   };
@@ -1067,11 +1066,9 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
                         ? t('Pending Proposals')
                         : t('Unsent Transactions')}
                     </H5>
-                    {fullWalletObj.credentials.n > 1 ? (
-                      <ProposalBadgeContainer onPress={onPressTxpBadge}>
-                        <ProposalBadge>{pendingTxps.length}</ProposalBadge>
-                      </ProposalBadgeContainer>
-                    ) : null}
+                    <ProposalBadgeContainer onPress={onPressTxpBadge}>
+                      <ProposalBadge>{pendingTxps.length}</ProposalBadge>
+                    </ProposalBadgeContainer>
                   </TransactionSectionHeaderContainer>
                   {fullWalletObj.credentials.n > 1 ? (
                     <FlatList

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -317,6 +317,8 @@ export interface TransactionProposal {
   canBeRemoved: boolean;
   recipientCount: number;
   hasMultiplesOutputs: boolean;
+  requiredSignatures: number;
+  requiredRejections: number;
 }
 
 export interface ProposalErrorHandlerProps {


### PR DESCRIPTION
Include again all types of transaction proposals in badge count

new `Unsent Transactions` header that includes read only wallets txs (no sign available for this) and 1-1 transactions that need a sign ( created by a readonly wallet in another device)

![iPhone_13](https://user-images.githubusercontent.com/10999037/199345746-fda340b4-1f32-4b1c-a5ed-6bab83dcd89a.png)

Failed paypro transactions are listed in `Rejected` ( no sign available for this )

![iPhone_13](https://user-images.githubusercontent.com/10999037/199346346-e24c4c15-26b0-49de-89ba-f48045af7942.png)

![iPhone_13](https://user-images.githubusercontent.com/10999037/199346366-2309f414-9b04-437a-bea1-069cca3361cc.png)

