### PR TITLE
Fix: create invoice for payments with Coinbase

### DIFF
--- a/src/api/coinbase/coinbase.constants.ts
+++ b/src/api/coinbase/coinbase.constants.ts
@@ -1,5 +1,6 @@
 import {
   CoinbaseEnvironment,
+  CoinbaseSupportedNetwork,
   ConfigApiProps,
   CredentialsProps,
 } from './coinbase.types';
@@ -52,3 +53,7 @@ export const COINBASE_INVOICE_URL: string =
 export const COINBASE_ENV: CoinbaseEnvironment = __DEV__
   ? CoinbaseEnvironment.sandbox
   : CoinbaseEnvironment.production;
+export const COINBASE_HOST_NETWORK = {
+  ethereum: CoinbaseSupportedNetwork.ethereum,
+  polygon: CoinbaseSupportedNetwork.polygon,
+};

--- a/src/api/coinbase/coinbase.types.ts
+++ b/src/api/coinbase/coinbase.types.ts
@@ -201,3 +201,8 @@ export enum CoinbaseEnvironment {
   sandbox = 'sandbox',
   production = 'production',
 }
+
+export enum CoinbaseSupportedNetwork {
+  ethereum = 'eth',
+  polygon = 'matic',
+}

--- a/src/navigation/wallet/screens/send/confirm/DebitCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/DebitCardConfirm.tsx
@@ -60,6 +60,7 @@ import {
 } from '../../../../../api/coinbase/coinbase.types';
 import {coinbasePayInvoice} from '../../../../../store/coinbase';
 import {useTranslation} from 'react-i18next';
+import {getTransactionCurrencyForPayInvoice} from '../../../../../store/coinbase/coinbase.effects';
 
 export interface DebitCardConfirmParamList {
   amount: number;
@@ -181,10 +182,15 @@ const Confirm = () => {
 
   const onCoinbaseAccountSelect = async (walletRowProps: WalletRowProps) => {
     const selectedCoinbaseAccount = walletRowProps.coinbaseAccount!;
+    const transactionCurrency = dispatch(
+      getTransactionCurrencyForPayInvoice(
+        selectedCoinbaseAccount.currency.code,
+      ),
+    );
     try {
       const {invoice: newInvoice} = await createTopUpInvoice({
         walletId: selectedCoinbaseAccount.id,
-        transactionCurrency: selectedCoinbaseAccount.currency.code,
+        transactionCurrency,
       });
       const rates = await dispatch(startGetRates({}));
       const newTxDetails = dispatch(

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -60,6 +60,7 @@ import {
   GiftCardScreens,
   GiftCardStackParamList,
 } from '../../../../tabs/shop/gift-card/GiftCardStack';
+import {getTransactionCurrencyForPayInvoice} from '../../../../../store/coinbase/coinbase.effects';
 
 export interface GiftCardConfirmParamList {
   amount: number;
@@ -207,10 +208,15 @@ const Confirm = () => {
 
   const onCoinbaseAccountSelect = async (walletRowProps: WalletRowProps) => {
     const selectedCoinbaseAccount = walletRowProps.coinbaseAccount!;
+    const transactionCurrency = dispatch(
+      getTransactionCurrencyForPayInvoice(
+        selectedCoinbaseAccount.currency.code,
+      ),
+    );
     try {
       const {invoice: newInvoice} = await createGiftCardInvoice({
         clientId: selectedCoinbaseAccount.id,
-        transactionCurrency: selectedCoinbaseAccount.currency.code,
+        transactionCurrency,
       });
       const rates = await dispatch(startGetRates({}));
       const newTxDetails = dispatch(

--- a/src/store/coinbase/coinbase.actions.ts
+++ b/src/store/coinbase/coinbase.actions.ts
@@ -3,6 +3,7 @@ import {
   CoinbaseEnvironment,
   CoinbaseErrorsProps,
   CoinbaseExchangeRatesProps,
+  CoinbaseHostNetwork,
   CoinbaseTokenProps,
   CoinbaseTransactionsProps,
   CoinbaseUserProps,
@@ -204,4 +205,11 @@ export const toggleHideCoinbaseTotalBalance = (
 ): CoinbaseActionType => ({
   type: CoinbaseActionTypes.TOGGLE_HIDE_TOTAL_BALANCE,
   payload: hideTotalBalance,
+});
+
+export const selectHostNetwork = (
+  selectedHostNetwork: CoinbaseHostNetwork,
+): CoinbaseActionType => ({
+  type: CoinbaseActionTypes.SELECTED_HOST_NETWORK,
+  payload: selectedHostNetwork,
 });

--- a/src/store/coinbase/coinbase.reducer.ts
+++ b/src/store/coinbase/coinbase.reducer.ts
@@ -4,10 +4,12 @@ import {
   CoinbaseEnvironment,
   CoinbaseErrorsProps,
   CoinbaseExchangeRatesProps,
+  CoinbaseSupportedNetwork,
   CoinbaseTokenProps,
   CoinbaseTransactionsByAccountProps,
   CoinbaseUserProps,
 } from '../../api/coinbase/coinbase.types';
+import {EVM_CHAINS} from '../../constants/currencies';
 import {
   ApiLoading,
   CoinbaseActionType,
@@ -62,6 +64,7 @@ export interface CoinbaseState {
   payInvoiceError: CoinbaseErrorsProps | null;
   exchangeRates: CoinbaseExchangeRatesProps | null;
   hideTotalBalance: boolean;
+  blockchainNetwork: EVM_CHAINS;
   token: {
     [key in CoinbaseEnvironment]: CoinbaseTokenProps | null;
   };
@@ -99,6 +102,8 @@ const initialState: CoinbaseState = {
   payInvoiceError: null,
   exchangeRates: null,
   hideTotalBalance: false,
+  // Other chain is not supported by Coinbase API
+  blockchainNetwork: CoinbaseSupportedNetwork.ethereum,
   token: {
     [CoinbaseEnvironment.production]: null,
     [CoinbaseEnvironment.sandbox]: null,
@@ -416,6 +421,12 @@ export const coinbaseReducer = (
       return {
         ...state,
         hideTotalBalance: action.payload,
+      };
+
+    case CoinbaseActionTypes.BLOCKCHAIN_NETWORK:
+      return {
+        ...state,
+        blockchainNetwork: action.payload,
       };
 
     default:

--- a/src/store/coinbase/coinbase.types.ts
+++ b/src/store/coinbase/coinbase.types.ts
@@ -7,6 +7,7 @@ import {
   CoinbaseTransactionsByAccountProps,
   CoinbaseEnvironment,
 } from '../../api/coinbase/coinbase.types';
+import {EVM_CHAINS} from '../../constants/currencies';
 
 export type ApiLoading = boolean;
 export type GetAccessTokenStatus = 'success' | 'failed' | null;
@@ -50,6 +51,7 @@ export enum CoinbaseActionTypes {
   PAY_INVOICE_SUCCESS = 'Coinbase/PAY_INVOICE_SUCCESS',
   PAY_INVOICE_FAILED = 'Coinbase/PAY_INVOICE_FAILED',
   TOGGLE_HIDE_TOTAL_BALANCE = 'Coinbase/TOGGLE_HIDE_TOTAL_BALANCE',
+  BLOCKCHAIN_NETWORK = 'Coinbase/BLOCKCHAIN_NETWORK',
 }
 
 // ------- Exchange Rate -------- //
@@ -219,6 +221,11 @@ interface ToggleHideCoinbaseTotalBalance {
   payload: boolean;
 }
 
+interface SetBlockchainNetwork {
+  type: typeof CoinbaseActionTypes.BLOCKCHAIN_NETWORK;
+  payload: EVM_CHAINS;
+}
+
 export type CoinbaseActionType =
   | ExchangeRatesPending
   | ExchangeRatesSuccess
@@ -250,4 +257,5 @@ export type CoinbaseActionType =
   | PayInvoiceSuccess
   | PayInvoiceFailed
   | ClearErrorStatus
-  | ToggleHideCoinbaseTotalBalance;
+  | ToggleHideCoinbaseTotalBalance
+  | SetBlockchainNetwork;

--- a/src/store/coinbase/index.ts
+++ b/src/store/coinbase/index.ts
@@ -29,6 +29,7 @@ export {
   payInvoicePending,
   payInvoiceSuccess,
   payInvoiceFailed,
+  selectHostNetwork,
 } from './coinbase.actions';
 export {
   isInvalidTokenError,


### PR DESCRIPTION
* Allow future support of Network selector (Coinbase: polygon or ethereum). For now, `ethereum` by default.
* Get correct `transactionCurrency` on creating Invoice for off-chain transactions.

Note 1: for Matic (Ethereum network) payments are disabled.
Note 2: Coinbase uses Ethereum network by default for all supported tokens.