### PR TITLE
Implement gift card syncing

### DIFF
--- a/src/lib/gift-cards/gift-card.ts
+++ b/src/lib/gift-cards/gift-card.ts
@@ -113,7 +113,10 @@ export function sortByDisplayName(
   return aSortValue > bSortValue ? 1 : -1;
 }
 
-export function sortByDescendingDate(a: GiftCard, b: GiftCard) {
+export function sortByDescendingDate(
+  a: GiftCard | UnsoldGiftCard,
+  b: GiftCard | UnsoldGiftCard,
+) {
   return new Date(b.date).getTime() - new Date(a.date).getTime();
 }
 

--- a/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
@@ -182,7 +182,7 @@ export default ({
     () =>
       setPurchasedGiftCards(
         giftCards
-          .filter(c => c.status === 'SUCCESS')
+          .filter(c => ['PENDING', 'SUCCESS', 'SYNCED'].includes(c.status))
           .sort(
             (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
           ),

--- a/src/navigation/tabs/shop/components/MyGiftCards.tsx
+++ b/src/navigation/tabs/shop/components/MyGiftCards.tsx
@@ -58,7 +58,7 @@ const MyGiftCards = ({
   const giftCards = allGiftCards
     .filter(
       giftCard =>
-        giftCard.status === 'SUCCESS' ||
+        ['PENDING', 'SUCCESS', 'SYNCED'].includes(giftCard.status) ||
         redemptionFailuresLessThanADayOld(giftCard),
     )
     .sort(sortByDescendingDate);

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -39,7 +39,7 @@ import {AppActions} from '../../../../../store/app';
 import GiftCardDiscountText from '../../components/GiftCardDiscountText';
 import {formatFiatAmount, sleep} from '../../../../../utils/helper-methods';
 import {CustomErrorMessage} from '../../../../wallet/components/ErrorMessages';
-import {ShopActions} from '../../../../../store/shop';
+import {ShopActions, ShopEffects} from '../../../../../store/shop';
 import {APP_NETWORK} from '../../../../../constants/config';
 import {useAppSelector} from '../../../../../utils/hooks';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -9,7 +9,8 @@ import {
 } from 'react-native';
 import TimeAgo from 'react-native-timeago';
 import {StackScreenProps} from '@react-navigation/stack';
-import styled, {useTheme} from 'styled-components/native';
+import styled from 'styled-components/native';
+import {useTheme} from 'styled-components';
 import Button from '../../../../../components/button/Button';
 import {
   CtaContainer,
@@ -161,6 +162,18 @@ const GiftCardDetails = ({
     );
     return () => subscription.remove();
   }, []);
+
+  useEffect(() => {
+    const redeem = async () => {
+      const updatedGiftCard = await dispatch(
+        ShopEffects.startRedeemGiftCard(giftCard.invoiceId),
+      );
+      setGiftCard(updatedGiftCard);
+    };
+    if (giftCard.status === 'SYNCED') {
+      redeem();
+    }
+  }, [dispatch, giftCard.invoiceId, giftCard.status]);
 
   useEffect(() => {
     if (!giftCard.barcodeImage) {
@@ -401,9 +414,13 @@ const GiftCardDetails = ({
           </>
         ) : (
           <ClaimCodeBox>
-            {giftCard.status === 'PENDING' ? (
+            {['PENDING', 'SYNCED'].includes(giftCard.status) ? (
               <TextAlign align="center">
-                <Paragraph>{t('Awaiting payment to confirm')}</Paragraph>
+                <Paragraph>
+                  {giftCard.status === 'PENDING'
+                    ? t('Awaiting payment to confirm')
+                    : t('Fetching claim information...')}
+                </Paragraph>
               </TextAlign>
             ) : (
               <>

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -450,6 +450,7 @@ const startPairAndLoadUser =
       dispatch(startBitPayIdStoreInit(data.user));
       dispatch(CardEffects.startCardStoreInit(data.user));
       dispatch(ShopEffects.startFetchCatalog());
+      dispatch(ShopEffects.startSyncGiftCards());
     } catch (err) {
       let errMsg;
 

--- a/src/store/shop/shop.models.ts
+++ b/src/store/shop/shop.models.ts
@@ -75,7 +75,7 @@ export interface UnsoldGiftCard {
   accessKey: string;
   userEid?: string;
   totalDiscount?: number;
-  status: 'SUCCESS' | 'PENDING' | 'FAILURE' | 'UNREDEEMED';
+  status: 'SUCCESS' | 'PENDING' | 'FAILURE' | 'UNREDEEMED' | 'SYNCED';
 }
 
 export interface GiftCardBalanceEntry {


### PR DESCRIPTION
2 main scenarios to test:

1. On a fresh install, log in with a BitPay account that has gift card purchases associated with it (upon logging in, your associated gift cards will appear at the top of the shop tab)

2. While logged in with your BitPay account on one device, purchase a gift card on a different device (or in the BitPay browser extension) that is also logged in to the same BitPay account as the first device. Return to the first device, and pull to refresh on the shop tab. The gift card you purchased on the second device will now appear at the top of the shop tab on the first device.