### PR TITLE
[RN-770]: fix fiat rate str in txp view 

### DIFF
--- a/src/navigation/tabs/settings/components/Notifications.tsx
+++ b/src/navigation/tabs/settings/components/Notifications.tsx
@@ -11,6 +11,7 @@ import {
 import {AppEffects} from '../../../../store/app';
 import {
   ActiveOpacity,
+  Hr,
   Setting,
   SettingTitle,
 } from '../../../../components/styled/Containers';
@@ -132,6 +133,7 @@ const Notifications = () => {
         <SettingTitle>{t('Push Notifications')}</SettingTitle>
         <AngleRight />
       </Setting>
+      <Hr />
 
       {/*----------------------------------------------------------------------*/}
 

--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -940,9 +940,7 @@ const UpdateFiatRate =
       fiatRateStr = dispatch(
         toFiat(amount, alternativeCurrency, currency, chain, rates),
       );
-      fiatRateStr =
-        formatFiatAmount(fiatRateStr, alternativeCurrency) +
-        alternativeCurrency;
+      fiatRateStr = formatFiatAmount(fiatRateStr, alternativeCurrency);
     }
     return fiatRateStr;
   };


### PR DESCRIPTION

<img width="438" alt="IMG_A48EA0E61F2A-1_jpeg" src="https://user-images.githubusercontent.com/10969512/204807743-c44f8e1b-268b-467d-b0c6-45c88aa14bd4.png">



and missing hr in settings...
<img width="384" alt="iPhone_13" src="https://user-images.githubusercontent.com/10969512/204808121-2cc395b8-ea24-40fc-a06f-a5950a84cb11.png">
