### PR TITLE
fix/android deeplinks

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -94,7 +94,7 @@ import CoinbaseStack, {
 } from './navigation/coinbase/CoinbaseStack';
 import BpDevtools from './components/bp-devtools/BpDevtools';
 import {APP_ANALYTICS_ENABLED, DEVTOOLS_ENABLED} from './constants/config';
-import Blur from './components/blur/Blur';
+import {BlurContainer} from './components/blur/Blur';
 import DebugScreen, {DebugScreenParamList} from './navigation/Debug';
 import CardActivationStack, {
   CardActivationStackParamList,
@@ -227,7 +227,6 @@ export default () => {
   const cachedRoute = useAppSelector(({APP}) => APP.currentRoute);
   const appLanguage = useAppSelector(({APP}) => APP.defaultLanguage);
   const pinLockActive = useAppSelector(({APP}) => APP.pinLockActive);
-  const showBlur = useAppSelector(({APP}) => APP.showBlur);
   const failedAppInit = useAppSelector(({APP}) => APP.failedAppInit);
   const biometricLockActive = useAppSelector(
     ({APP}) => APP.biometricLockActive,
@@ -535,7 +534,7 @@ export default () => {
           <OnGoingProcessModal />
           <BottomNotificationModal />
           <DecryptEnterPasswordModal />
-          {showBlur && <Blur />}
+          <BlurContainer />
           <PinModal />
           <BiometricModal />
         </NavigationContainer>

--- a/src/components/blur/Blur.tsx
+++ b/src/components/blur/Blur.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
 import {BlurView} from '@react-native-community/blur';
+import React from 'react';
 import {useTheme} from 'styled-components/native';
+import {useAppSelector} from '../../utils/hooks';
 
-const Blur = () => {
+export const Blur = () => {
   const theme = useTheme();
+
   return (
     <BlurView
       style={{
@@ -18,6 +20,12 @@ const Blur = () => {
       reducedTransparencyFallbackColor="white"
     />
   );
+};
+
+export const BlurContainer = () => {
+  const showBlur = useAppSelector(({APP}) => APP.showBlur);
+
+  return showBlur ? <Blur /> : null;
 };
 
 export default Blur;

--- a/src/components/modal/base/sheet/SheetModal.tsx
+++ b/src/components/modal/base/sheet/SheetModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {useAppSelector} from '../../../../utils/hooks';
-import Blur from '../../../blur/Blur';
+import {BlurContainer} from '../../../blur/Blur';
 import {SheetParams} from '../../../styled/Containers';
 import BaseModal from '../BaseModal';
 
@@ -15,8 +14,6 @@ const SheetModal: React.FC<Props> = ({
   onBackdropPress,
   placement,
 }) => {
-  const showBlur = useAppSelector(({APP}) => APP.showBlur);
-
   return (
     <BaseModal
       id={'sheetModal'}
@@ -39,7 +36,7 @@ const SheetModal: React.FC<Props> = ({
       }}>
       <>
         {children}
-        {showBlur && <Blur />}
+        <BlurContainer />
       </>
     </BaseModal>
   );

--- a/src/components/modal/ongoing-process/OngoingProcess.tsx
+++ b/src/components/modal/ongoing-process/OngoingProcess.tsx
@@ -3,7 +3,7 @@ import {ActivityIndicator} from 'react-native';
 import styled from 'styled-components/native';
 import {LightBlack, SlateDark, White} from '../../../styles/colors';
 import {useAppSelector} from '../../../utils/hooks';
-import Blur from '../../blur/Blur';
+import {BlurContainer} from '../../blur/Blur';
 import {BaseText} from '../../styled/Text';
 import BaseModal from '../base/BaseModal';
 
@@ -68,7 +68,6 @@ const Message = styled(BaseText)`
 const OnGoingProcessModal: React.FC = () => {
   const message = useAppSelector(({APP}) => APP.onGoingProcessModalMessage);
   const isVisible = useAppSelector(({APP}) => APP.showOnGoingProcessModal);
-  const showBlur = useAppSelector(({APP}) => APP.showBlur);
 
   return (
     <BaseModal
@@ -90,7 +89,7 @@ const OnGoingProcessModal: React.FC = () => {
             <ActivityIndicator color={SlateDark} />
           </ActivityIndicatorContainer>
           <Message>{message}</Message>
-          {showBlur && <Blur />}
+          <BlurContainer />
         </Row>
       </OnGoingProcessContainer>
     </BaseModal>


### PR DESCRIPTION
This PR moves the `showBlur` flag into a dedicated container component around the `Blur` component to avoid triggering a Root re-render onStateChange. This was seemingly preventing deeplinks from being handled properly on Android.