### PR TITLE
Backwards compatible deeplinks

### DIFF
--- a/src/navigation/services/buy-crypto/BuyCryptoStack.tsx
+++ b/src/navigation/services/buy-crypto/BuyCryptoStack.tsx
@@ -6,20 +6,14 @@ import {
   baseScreenOptions,
 } from '../../../constants/NavigationOptions';
 import {HeaderTitle} from '../../../components/styled/Text';
-import BuyCryptoRoot from './screens/BuyCryptoRoot';
+import BuyCryptoRoot, {
+  BuyCryptoRootScreenParams,
+} from './screens/BuyCryptoRoot';
 import BuyCryptoOffers from './screens/BuyCryptoOffers';
 import {useTranslation} from 'react-i18next';
 
 export type BuyCryptoStackParamList = {
-  BuyCryptoRoot:
-    | {
-        amount: number;
-        fromWallet?: any;
-        buyCryptoOpts?: any;
-        currencyAbbreviation?: string; // used from charts.
-        chain?: string; // used from charts.
-      }
-    | undefined;
+  BuyCryptoRoot: BuyCryptoRootScreenParams;
   BuyCryptoOffers: {
     amount: number;
     fiatCurrency: string;

--- a/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
+++ b/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
@@ -100,7 +100,7 @@ const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
     }
   }
 
-  const onPress = () => {
+  const onPress = async () => {
     haptic('impactLight');
 
     if (!contentCard.id.startsWith('dev_')) {
@@ -124,7 +124,7 @@ const AdvertisementCard: React.FC<AdvertisementCardProps> = props => {
 
     if (url.startsWith(APP_DEEPLINK_PREFIX)) {
       try {
-        const handled = urlEventHandler({url});
+        const handled = await urlEventHandler({url});
         if (!handled) {
           const path = '/' + url.replace(APP_DEEPLINK_PREFIX, '');
           linkTo(path);

--- a/src/navigation/tabs/home/components/offers/OfferCard.tsx
+++ b/src/navigation/tabs/home/components/offers/OfferCard.tsx
@@ -47,7 +47,7 @@ const OfferCard: React.FC<OfferCardProps> = props => {
     }
   }
 
-  const _onPress = () => {
+  const _onPress = async () => {
     if (!contentCard.id.startsWith('dev_')) {
       Braze.logContentCardClicked(contentCard.id);
     }
@@ -59,7 +59,7 @@ const OfferCard: React.FC<OfferCardProps> = props => {
     haptic('impactLight');
 
     try {
-      const handled = urlEventHandler({url});
+      const handled = await urlEventHandler({url});
       const merchantName = getRouteParam(url, 'merchant');
       if (handled && merchantName) {
         dispatch(

--- a/src/navigation/wallet/screens/CurrencyTokenSelection.tsx
+++ b/src/navigation/wallet/screens/CurrencyTokenSelection.tsx
@@ -266,8 +266,7 @@ const CurrencyTokenSelectionScreen: React.VFC<
           ) : null}
           {index === tokenLength && searchFilter?.length === 0 ? (
             <TokensHeading>
-              {t('Other Tokens')} (
-              {tokens.length - tokenLength})
+              {t('Other Tokens')} ({tokens.length - tokenLength})
             </TokensHeading>
           ) : null}
           <TokenSelectionRow

--- a/src/store/scan/scan.effects.ts
+++ b/src/store/scan/scan.effects.ts
@@ -80,12 +80,14 @@ export const incomingData =
       email?: string;
       destinationTag?: number;
     },
-  ): Effect<Promise<void>> =>
+  ): Effect<Promise<boolean>> =>
   async dispatch => {
     // wait to close blur
     await sleep(200);
     const coin = opts?.wallet?.currencyAbbreviation?.toLowerCase();
     const chain = opts?.wallet?.credentials?.chain.toLowerCase();
+    let handled = true;
+
     try {
       if (IsValidBitPayInvoice(data)) {
         dispatch(handleUnlock(data));
@@ -163,12 +165,16 @@ export const incomingData =
         // Join multisig wallet
       } else if (IsValidJoinCode(data)) {
         dispatch(goToJoinWallet(data));
+      } else {
+        handled = false;
       }
     } catch (err) {
       dispatch(dismissOnGoingProcessModal());
       await sleep(300);
       throw err;
     }
+
+    return handled;
   };
 
 const getParameterByName = (name: string, url: string): string | undefined => {

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -1,5 +1,10 @@
-import {LinkingOptions} from '@react-navigation/native';
-import {useRef} from 'react';
+import {
+  getActionFromState,
+  getStateFromPath,
+  LinkingOptions,
+  PathConfig,
+} from '@react-navigation/native';
+import {useMemo, useRef} from 'react';
 import {Linking} from 'react-native';
 import AppsFlyer from 'react-native-appsflyer';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
@@ -13,15 +18,65 @@ import {CardScreens} from '../../navigation/card/CardStack';
 import {BuyCryptoScreens} from '../../navigation/services/buy-crypto/BuyCryptoStack';
 import {SwapCryptoScreens} from '../../navigation/services/swap-crypto/SwapCryptoStack';
 import {CoinbaseScreens} from '../../navigation/coinbase/CoinbaseStack';
-import {RootStackParamList, RootStacks} from '../../Root';
-import {TabsScreens} from '../../navigation/tabs/TabsStack';
+import {navigationRef, RootStackParamList, RootStacks} from '../../Root';
+import {TabsScreens, TabsStackParamList} from '../../navigation/tabs/TabsStack';
 import {SettingsScreens} from '../../navigation/tabs/settings/SettingsStack';
 import {incomingData} from '../../store/scan/scan.effects';
 import {showBlur} from '../../store/app/app.actions';
 import {incomingLink} from '../../store/app/app.effects';
 import useAppDispatch from './useAppDispatch';
 import {useLogger} from './useLogger';
-import {useMount} from './useMount';
+
+const getLinkingConfig = (): LinkingOptions<RootStackParamList>['config'] => ({
+  initialRouteName: RootStacks.TABS,
+  // configuration for associating screens with paths
+  screens: {
+    [RootStacks.DEBUG]: {
+      path: 'debug/:name',
+    },
+    [RootStacks.BITPAY_ID]: {
+      path: 'id',
+      screens: {
+        [BitpayIdScreens.PAIRING]: 'pair',
+        [BitpayIdScreens.RECEIVE_SETTINGS]: 'receive-settings',
+      },
+    },
+    [RootStacks.TABS]: {
+      screens: {
+        [TabsScreens.CARD]: {
+          path: 'wallet-card',
+          initialRouteName: CardScreens.HOME,
+          screens: {
+            [CardScreens.PAIRING]: 'pairing',
+          },
+        },
+        [TabsScreens.SETTINGS]: {
+          screens: {
+            [SettingsScreens.Root]: 'connections/:redirectTo',
+          },
+        },
+      },
+    } as PathConfig<TabsStackParamList>,
+    [RootStacks.GIFT_CARD_DEEPLINK]: 'giftcard',
+    [RootStacks.BUY_CRYPTO]: {
+      screens: {
+        [BuyCryptoScreens.ROOT]: {
+          path: 'buy/:amount?',
+        },
+      },
+    },
+    [RootStacks.SWAP_CRYPTO]: {
+      screens: {
+        [SwapCryptoScreens.ROOT]: 'swap',
+      },
+    },
+    [RootStacks.COINBASE]: {
+      screens: {
+        [CoinbaseScreens.ROOT]: 'coinbase',
+      },
+    },
+  },
+});
 
 const isUniversalLink = (url: string): boolean => {
   try {
@@ -49,7 +104,7 @@ export const useUrlEventHandler = () => {
   const dispatch = useAppDispatch();
   const logger = useLogger();
 
-  const urlEventHandler = ({url}: {url: string | null}) => {
+  const urlEventHandler = async ({url}: {url: string | null}) => {
     logger.debug(`[deeplink] received: ${url}`);
 
     if (url && (isDeepLink(url) || isUniversalLink(url) || isCryptoLink(url))) {
@@ -58,12 +113,33 @@ export const useUrlEventHandler = () => {
 
       let handled = false;
 
+      // check if the url maps to a navigational link
       if (!handled) {
         handled = dispatch(incomingLink(url));
       }
 
+      // check if the url contains payment data
       if (!handled) {
-        dispatch(incomingData(url));
+        handled = await dispatch(incomingData(url));
+      }
+
+      // check if the url can be handled by the NavigationContainer based on the linking config
+      if (!handled) {
+        // try to translate the path to a navigation state according to our linking config
+        const path = url.replace(APP_DEEPLINK_PREFIX, '/');
+        const state = getStateFromPath(path, getLinkingConfig());
+
+        if (state) {
+          const action = getActionFromState(state);
+
+          if (action !== undefined) {
+            navigationRef.dispatch(action);
+          } else {
+            navigationRef.reset(state);
+          }
+
+          handled = true;
+        }
       }
 
       try {
@@ -90,90 +166,52 @@ export const useDeeplinks = () => {
   const urlEventHandler = useUrlEventHandler();
   const logger = useLogger();
 
-  useMount(() => {
-    const subscribeLinkingEvent = Linking.addEventListener(
-      'url',
-      urlEventHandler,
-    );
+  const memoizedSubscribe = useMemo<
+    LinkingOptions<RootStackParamList>['subscribe']
+  >(
+    () => listener => {
+      const subscription = Linking.addEventListener('url', ({url}) =>
+        listener(url),
+      );
 
-    AppsFlyer.onDeepLink(udlData => {
-      const {data, deepLinkStatus, status} = udlData;
+      const appsFlyerUnsubscribe = AppsFlyer.onDeepLink(udlData => {
+        const {data, deepLinkStatus, status} = udlData;
 
-      if (status === 'failure' || deepLinkStatus === 'Error') {
-        logger.info('Failed to handle Universal Deep Link.');
-        return;
-      }
+        if (status === 'failure' || deepLinkStatus === 'Error') {
+          logger.info('Failed to handle Universal Deep Link.');
+          return;
+        }
 
-      if (deepLinkStatus === 'NOT_FOUND') {
-        logger.info('Universal Deep Link not recognized.');
-        return;
-      }
+        if (deepLinkStatus === 'NOT_FOUND') {
+          logger.info('Universal Deep Link not recognized.');
+          return;
+        }
 
-      if (deepLinkStatus === 'FOUND') {
-        const {deep_link_value} = data;
+        if (deepLinkStatus === 'FOUND') {
+          const {deep_link_value} = data;
 
-        urlEventHandler({url: deep_link_value});
-        return;
-      }
+          if (deep_link_value) {
+            urlEventHandler({url: deep_link_value});
+          }
 
-      logger.info(`Unrecognized deeplink status: ${deepLinkStatus}`);
-    });
+          return;
+        }
 
-    return () => subscribeLinkingEvent.remove();
-  });
+        logger.info(`Unrecognized deeplink status: ${deepLinkStatus}`);
+      });
+
+      return () => {
+        subscription.remove();
+        appsFlyerUnsubscribe();
+      };
+    },
+    [logger, urlEventHandler],
+  );
 
   const linkingOptions: LinkingOptions<RootStackParamList> = {
     prefixes: [APP_DEEPLINK_PREFIX],
-    config: {
-      initialRouteName: 'Tabs',
-      // configuration for associating screens with paths
-      screens: {
-        [RootStacks.DEBUG]: {
-          path: 'debug/:name',
-        },
-        [RootStacks.BITPAY_ID]: {
-          path: 'id',
-          screens: {
-            [BitpayIdScreens.PAIRING]: 'pair',
-            [BitpayIdScreens.RECEIVE_SETTINGS]: 'receive-settings',
-          },
-        },
-        [RootStacks.TABS]: {
-          screens: {
-            [TabsScreens.CARD]: {
-              path: 'wallet-card',
-              initialRouteName: CardScreens.HOME,
-              screens: {
-                [CardScreens.PAIRING]: 'pairing',
-              },
-            },
-            [TabsScreens.SETTINGS]: {
-              screens: {
-                [SettingsScreens.Root]: 'connections/:redirectTo',
-              },
-            },
-          },
-        },
-        [RootStacks.GIFT_CARD_DEEPLINK]: 'giftcard',
-        [RootStacks.BUY_CRYPTO]: {
-          screens: {
-            [BuyCryptoScreens.ROOT]: {
-              path: 'buy/:amount?',
-            },
-          },
-        },
-        [RootStacks.SWAP_CRYPTO]: {
-          screens: {
-            [SwapCryptoScreens.ROOT]: 'swap',
-          },
-        },
-        [RootStacks.COINBASE]: {
-          screens: {
-            [CoinbaseScreens.ROOT]: 'coinbase',
-          },
-        },
-      },
-    },
+    subscribe: memoizedSubscribe,
+    config: getLinkingConfig(),
   };
 
   return linkingOptions;

--- a/src/utils/hooks/useLogger.ts
+++ b/src/utils/hooks/useLogger.ts
@@ -1,3 +1,4 @@
+import {useRef} from 'react';
 import {useDispatch} from 'react-redux';
 import {LogActions} from '../../store/log';
 
@@ -12,7 +13,7 @@ interface Logger {
 export const useLogger: () => Logger = () => {
   const dispatch = useDispatch();
 
-  return {
+  const loggerRef = useRef({
     clear() {
       dispatch(LogActions.clear());
     },
@@ -28,7 +29,9 @@ export const useLogger: () => Logger = () => {
     error(message: string) {
       dispatch(LogActions.error(message));
     },
-  };
+  });
+
+  return loggerRef.current;
 };
 
 export default useLogger;


### PR DESCRIPTION
With the AppsFlyer SDK in place, we can now handle OneLink links, however any embedded deeplink inside a OneLink does not get handled by the Navigation Container and the linking configuration we have configured. Added logic so that if our custom handling doesn't handle the passed in URL, then default to the Navigation Container deeplinking.