### PR TITLE
Improve key import flow

### DIFF
--- a/src/navigation/wallet/components/RecoveryPhrase.tsx
+++ b/src/navigation/wallet/components/RecoveryPhrase.tsx
@@ -427,6 +427,8 @@ const RecoveryPhrase = () => {
   ): Promise<void> => {
     try {
       if (!derivationPathEnabled) {
+        startDeferredImport(importData, opts);
+        await sleep(500);
         dispatch(
           showBottomNotificationModal({
             type: 'wait',
@@ -438,9 +440,7 @@ const RecoveryPhrase = () => {
             actions: [
               {
                 text: t('GOT IT'),
-                action: () => {
-                  startDeferredImport(importData, opts);
-                },
+                action: () => {},
                 primary: true,
               },
             ],


### PR DESCRIPTION
1. Handles and displays key import errors along with the exact error code
2. Starts the import immediately (rather than waiting on the user to tap "GOT IT" on the "import in progress" action sheet)