### PR TITLE
fix/custom raw deeplinks

### DIFF
--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -176,10 +176,11 @@ export const useDeeplinks = () => {
         const urlParams = urlObj.searchParams;
 
         if (!handled) {
-          // true if should be handled by AppsFlyer SDK
           const isAppsFlyerDeeplink = urlParams.get('af_deeplink') === 'true';
+          const hasEmbeddedDeepLink = !!urlParams.get('deep_link_value');
 
-          handled = !!isAppsFlyerDeeplink;
+          // true if should be handled by AppsFlyer SDK
+          handled = !!(isAppsFlyerDeeplink && hasEmbeddedDeepLink);
         }
 
         if (!handled) {


### PR DESCRIPTION
This PR fixes an issue where custom raw deeplinks not handled on Android.

Testing:  
All types of deeplinks should be handled, and handled by only 1 listener (either `Linking` or `AppsFlyer`, not both). 

1) raw deeplink (simply maps to a page, handled by ReactNavigation)
`bitpay://wallet-card`

2) raw custom deeplink (handled by our handler that requires custom logic, not a simple page map)
`bitpay://shoponline?category=charities%20%26%20nonprofits`

3) OneLink (Universal Deep Link) with embedded deeplink (should go to shoponline)
`https://bitpay.onelink.me/Cenw/craphkq7`

4) OneLink without embedded deeplink (should use fallback, bitpay://wallet-card)
`https://bitpay.onelink.me/Cenw/53onrc42`

