### PR TITLE
Feat/register wrapped deeplinks

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,34 +1,41 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bitpay.wallet">
+    package="com.bitpay.wallet">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <permission android:name="com.bitpay.wallet.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
+
+    <permission
+        android:name="com.bitpay.wallet.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
     <uses-permission android:name="com.bitpay.wallet.permission.C2D_MESSAGE" />
 
     <application
-            android:name=".MainApplication"
-            android:label="@string/app_name"
-            android:icon="@mipmap/ic_launcher"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:allowBackup="false"
-            android:theme="@style/AppTheme"
-            android:networkSecurityConfig="@xml/network_security_config">
+        android:name=".MainApplication"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:allowBackup="false"
+        android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config">
 
-        <activity android:name=".LaunchActivity" android:exported="true">
+        <activity
+            android:name=".LaunchActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <receiver android:name=".CustomBroadcastReceiver" android:exported="false" >
+        <receiver
+            android:name=".CustomBroadcastReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.braze.push.intent.NOTIFICATION_OPENED" />
                 <action android:name="com.braze.push.intent.NOTIFICATION_RECEIVED" />
@@ -36,94 +43,311 @@
             </intent-filter>
         </receiver>
 
-        <service android:name="com.braze.push.BrazeFirebaseMessagingService"
+        <service
+            android:name="com.braze.push.BrazeFirebaseMessagingService"
             android:exported="false">
             <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
 
         <!-- Used by Dosh Android SDK -->
         <meta-data
-                android:name="com.google.android.geo.API_KEY"
-                android:value="GOOGLE_MAPS_API_KEY_REPLACE_ME"/>
+            android:name="com.google.android.geo.API_KEY"
+            android:value="GOOGLE_MAPS_API_KEY_REPLACE_ME" />
 
         <meta-data
-                android:name="com.google.android.gms.wallet.api.enabled"
-                android:value="true" />
+            android:name="com.google.android.gms.wallet.api.enabled"
+            android:value="true" />
 
         <activity
-                android:screenOrientation="portrait"
-                android:name=".MainActivity"
-                android:label="@string/app_name"
-                android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-                android:exported="true"
-                android:launchMode="singleTask"
-                android:windowSoftInputMode="stateAlwaysHidden|adjustPan">
+            android:screenOrientation="portrait"
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="stateAlwaysHidden|adjustPan">
             <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="bitpay"/>
-                <data android:scheme="bitcoin"/>
-                <data android:scheme="bitcoincash"/>
-                <data android:scheme="ethereum"/>
-                <data android:scheme="matic"/>
-                <data android:scheme="dogecoin"/>
-                <data android:scheme="litecoin"/>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="bitpay" />
+                <data android:scheme="bitcoin" />
+                <data android:scheme="bitcoincash" />
+                <data android:scheme="ethereum" />
+                <data android:scheme="matic" />
+                <data android:scheme="dogecoin" />
+                <data android:scheme="litecoin" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="bitpay.onelink.me" />
+            <intent-filter
+                android:autoVerify="true"
+                android:label="BitPay">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="bitpay.onelink.me" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="clicks.bitpay.com" android:pathPrefix="/uni/" />
+            <intent-filter
+                android:autoVerify="true"
+                android:label="BitPay">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="clicks.bitpay.com"
+                    android:pathPrefix="/uni/" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="email.bitpay.com" android:pathPrefix="/uni/" />
+            <intent-filter
+                android:autoVerify="true"
+                android:label="BitPay">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="email.bitpay.com"
+                    android:pathPrefix="/uni/" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="clicks.bitpay.com" android:pathPrefix="/f/uni/" />
+            <intent-filter
+                android:autoVerify="true"
+                android:label="BitPay">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="clicks.bitpay.com"
+                    android:pathPrefix="/f/uni/" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="email.bitpay.com" android:pathPrefix="/f/uni/" />
+            <intent-filter
+                android:autoVerify="true"
+                android:label="BitPay">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="email.bitpay.com"
+                    android:pathPrefix="/f/uni/" />
             </intent-filter>
-            <intent-filter android:autoVerify="true" android:label="BitPay">
-                <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/i/"
-                    android:scheme="https"/>
-                <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/wallet/wc"
-                    android:scheme="https"/>
-                <data android:host="link.test.bitpay.com" android:pathPattern="*" android:pathPrefix="/i/"
-                    android:scheme="https"/>
-                <data android:host="link.test.bitpay.com" android:pathPattern="*" android:pathPrefix="/wallet/wc"
-                    android:scheme="https"/>
-                <data android:host="link.staging.bitpay.com" android:pathPattern="*" android:pathPrefix="/i/"
-                    android:scheme="https"/>
-                <data android:host="link.staging.bitpay.com" android:pathPattern="*" android:pathPrefix="/wallet/wc"
-                    android:scheme="https"/>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.test.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPattern="*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPrefix="/i/" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="link.staging.bitpay.com"
+                    android:pathPrefix="/wallet/wc" />
             </intent-filter>
         </activity>
         <activity
-                android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
-                android:theme="@style/BootTheme"
-                android:launchMode="singleTask">
-        </activity>
+            android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
+            android:theme="@style/BootTheme"
+            android:launchMode="singleTask"></activity>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -141,18 +141,8 @@
                     android:host="email.bitpay.com"
                     android:pathPrefix="/f/uni/" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -163,7 +153,8 @@
                     android:host="link.bitpay.com"
                     android:pathPrefix="/i/" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -174,18 +165,8 @@
                     android:host="link.bitpay.com"
                     android:pathPrefix="/wallet/wc" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.test.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -196,7 +177,8 @@
                     android:host="link.test.bitpay.com"
                     android:pathPrefix="/i/" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -207,18 +189,8 @@
                     android:host="link.test.bitpay.com"
                     android:pathPrefix="/wallet/wc" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.staging.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -229,7 +201,8 @@
                     android:host="link.staging.bitpay.com"
                     android:pathPrefix="/i/" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -83,8 +83,7 @@
                 <data android:scheme="litecoin" />
             </intent-filter>
             <intent-filter
-                android:autoVerify="true"
-                android:label="BitPay">
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -95,8 +94,7 @@
                     android:host="bitpay.onelink.me" />
             </intent-filter>
             <intent-filter
-                android:autoVerify="true"
-                android:label="BitPay">
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -108,8 +106,7 @@
                     android:pathPrefix="/uni/" />
             </intent-filter>
             <intent-filter
-                android:autoVerify="true"
-                android:label="BitPay">
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -121,8 +118,7 @@
                     android:pathPrefix="/uni/" />
             </intent-filter>
             <intent-filter
-                android:autoVerify="true"
-                android:label="BitPay">
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -134,8 +130,7 @@
                     android:pathPrefix="/f/uni/" />
             </intent-filter>
             <intent-filter
-                android:autoVerify="true"
-                android:label="BitPay">
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -187,39 +182,6 @@
 
                 <data
                     android:scheme="https"
-                    android:host="link.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.bitpay.com"
-                    android:pathPrefix="/i/" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.bitpay.com"
-                    android:pathPrefix="/wallet/wc" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
                     android:host="link.test.bitpay.com"
                     android:pathPattern="*" />
             </intent-filter>
@@ -243,72 +205,6 @@
                 <data
                     android:scheme="https"
                     android:host="link.test.bitpay.com"
-                    android:pathPrefix="/wallet/wc" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.test.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.test.bitpay.com"
-                    android:pathPrefix="/i/" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.test.bitpay.com"
-                    android:pathPrefix="/wallet/wc" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.staging.bitpay.com"
-                    android:pathPattern="*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.staging.bitpay.com"
-                    android:pathPrefix="/i/" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="link.staging.bitpay.com"
                     android:pathPrefix="/wallet/wc" />
             </intent-filter>
             <intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -73,9 +73,12 @@
                 <data android:scheme="litecoin"/>
             </intent-filter>
             <intent-filter android:autoVerify="true" android:label="BitPay">
-                <data android:scheme="https"
-                    android:host="bitpay.onelink.me"
-                    android:pathPrefix="/K4yy" />
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="bitpay.onelink.me" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true" android:label="BitPay">
                 <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/i/"
                     android:scheme="https"/>
                 <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/wallet/wc"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@
                 <data android:scheme="dogecoin" />
                 <data android:scheme="litecoin" />
             </intent-filter>
+            <!-- Handle all BitPay OneLink URIs -->
             <intent-filter
                 android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -93,6 +94,7 @@
                     android:scheme="https"
                     android:host="bitpay.onelink.me" />
             </intent-filter>
+            <!-- Handle universal links wrapped by SendGrid -->
             <intent-filter
                 android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -105,6 +107,7 @@
                     android:host="clicks.bitpay.com"
                     android:pathPrefix="/uni/" />
             </intent-filter>
+            <!-- Handle universal links wrapped by SendGrid -->
             <intent-filter
                 android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -117,6 +120,7 @@
                     android:host="email.bitpay.com"
                     android:pathPrefix="/uni/" />
             </intent-filter>
+            <!-- Handle universal links wrapped by SparkPost (sent from Braze) -->
             <intent-filter
                 android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -127,18 +131,6 @@
                 <data
                     android:scheme="https"
                     android:host="clicks.bitpay.com"
-                    android:pathPrefix="/f/uni/" />
-            </intent-filter>
-            <intent-filter
-                android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="email.bitpay.com"
                     android:pathPrefix="/f/uni/" />
             </intent-filter>
             <intent-filter

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,30 @@
                 <data android:scheme="https" android:host="bitpay.onelink.me" />
             </intent-filter>
             <intent-filter android:autoVerify="true" android:label="BitPay">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="clicks.bitpay.com" android:pathPrefix="/uni/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true" android:label="BitPay">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="email.bitpay.com" android:pathPrefix="/uni/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true" android:label="BitPay">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="clicks.bitpay.com" android:pathPrefix="/f/uni/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true" android:label="BitPay">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="email.bitpay.com" android:pathPrefix="/f/uni/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true" android:label="BitPay">
                 <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/i/"
                     android:scheme="https"/>
                 <data android:host="link.bitpay.com" android:pathPattern="*" android:pathPrefix="/wallet/wc"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
+    "android:release": "react-native run-android --variant release",
     "ios": "react-native run-ios",
     "ios:device": "react-native run-ios --device",
     "ios:device:release": "react-native run-ios --configuration Release --device",

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -186,6 +186,23 @@ export const useDeeplinks = () => {
         }
       });
 
+      // Configure AppsFlyer to handle wrapped deeplinks.
+      // ie. resolve deeplinks with these hostnames to get the real deeplink
+      AppsFlyer.setResolveDeepLinkURLs(
+        ['clicks.bitpay.com', 'email.bitpay.com'],
+        () => {
+          logger.debug(
+            'Successfully configured AppsFlyer deeplink resolution.',
+          );
+        },
+        e => {
+          const errString = e instanceof Error ? e.message : JSON.stringify(e);
+          logger.debug(
+            `An error occurred trying to configure AppsFlyer deeplink resolution: ${errString}`,
+          );
+        },
+      );
+
       const appsFlyerUnsubscribe = AppsFlyer.onDeepLink(udlData => {
         const {data, deepLinkStatus, status} = udlData;
 


### PR DESCRIPTION
This PR adds configuration to handle wrapped deeplinks and Android app links.

- Added intent-filters for wrapped deeplinks (clicks.bitpay.com/uni/, email.bitpay.com/uni/, clicks.bitpay.com/f/uni/)
- Created separate intent-filters for each scheme/host/path combination to avoid issues due to attribute merging (https://developer.android.com/training/app-links/deep-linking#adding-filters) 
- Registered link wrappers with AppsFlyer SDK so it can resolve underlying deeplinks