### PR TITLE
[FEAT] react-native-screens freeze

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ import getStore from './src/store';
 import {Provider} from 'react-redux';
 import {PersistGate} from 'redux-persist/integration/react';
 import 'react-native-url-polyfill/auto'; // https://github.com/facebook/react-native/issues/23922#issuecomment-648096619
+import {enableFreeze} from 'react-native-screens';
+enableFreeze(true);
 
 export const {store, persistor} = getStore();
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -492,8 +492,9 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (2.18.1):
+  - RNScreens (3.9.0):
     - React-Core
+    - React-RCTImage
   - RNSharedElement (0.8.4):
     - React-Core
   - RNSVG (12.3.0):
@@ -867,7 +868,7 @@ SPEC CHECKSUMS:
   RNRate: 94f57c773e155ca0d0aeeba9c10a32bce9030daf
   RNReactNativeHapticFeedback: b83bfb4b537bdd78eb4f6ffe63c6884f7b049ead
   RNReanimated: 190b6930d5d94832061278e1070bbe313e50c830
-  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
+  RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-native-restart": "0.0.24",
     "react-native-rounded-checkbox": "0.3.3",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "2.18.1",
+    "react-native-screens": "3.9.0",
     "react-native-shared-element": "0.8.4",
     "react-native-skeleton-placeholder": "5.0.0",
     "react-native-snap-carousel": "4.0.0-beta.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11979,10 +11979,13 @@ react-native-safe-area-context@3.3.2:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz#9549a2ce580f2374edb05e49d661258d1b8bcaed"
   integrity sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==
 
-react-native-screens@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.18.1.tgz#47b9991c6f762d00d0ed3233e5283d523e859885"
-  integrity sha512-r5WZLpmx2hHjC1RgMdPq5YpSU9tEhBpUaZ5M1SUtNIONyiLqQVxabhRCINdebIk4depJiIl7yw2Q85zJyeX6fw==
+react-native-screens@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.9.0.tgz#39b79f0e50b9d68ec822d333bc76e7aaee90f3fd"
+  integrity sha512-TP/kASLQ/2iGCz4/n9CHeveKC9urzbfYXFH+1TfBnqaBwjIszhVuadiIOQ0qWKdSs6qnBR2xPTp9U18sNoc34A==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-screens@^3.11.1:
   version "3.13.1"


### PR DESCRIPTION
This PR enables freeze mode for react-native-screens which freezes the subtree for screens that are not visible, improving performance. 

https://github.com/software-mansion/react-freeze#quick-start-with-react-navigation-react-native-

One way to test the performance gain is to try switching theme with the enableFreeze flag true and false.