### PR TITLE
Add domains for wrapped universal links (iOS)

### DIFF
--- a/ios/BitPayApp/BitPayAppDebug.entitlements
+++ b/ios/BitPayApp/BitPayAppDebug.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:clicks.bitpay.com</string>
+		<string>applinks:email.bitpay.com</string>
 		<string>applinks:link.bitpay.com</string>
 		<string>applinks:link.test.bitpay.com</string>
 		<string>applinks:link.staging.bitpay.com</string>

--- a/ios/BitPayApp/BitPayAppRelease.entitlements
+++ b/ios/BitPayApp/BitPayAppRelease.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:clicks.bitpay.com</string>
+		<string>applinks:email.bitpay.com</string>
 		<string>applinks:link.bitpay.com</string>
 		<string>applinks:link.test.bitpay.com</string>
 		<string>applinks:link.staging.bitpay.com</string>


### PR DESCRIPTION
This PR adds associated domains to the iOS entitlements to support wrapped universal links.