### PR TITLE
Handle BitPay payment protocol URIs

### DIFF
--- a/src/store/wallet/utils/decode-uri.ts
+++ b/src/store/wallet/utils/decode-uri.ts
@@ -12,7 +12,7 @@ export const GetPayProUrl = (data: string): string => {
     url = data.replace(/link./, '');
   } else {
     url = data.replace(
-      /(bitcoin|bitcoincash|ethereum|ripple|matic|dogecoin|litecoin)?:\?r=/,
+      /(bitpay|bitcoin|bitcoincash|ethereum|ripple|matic|dogecoin|litecoin)?:\?r=/,
       '',
     );
   }

--- a/src/store/wallet/utils/validations.ts
+++ b/src/store/wallet/utils/validations.ts
@@ -28,7 +28,7 @@ export const IsValidBitPayInvoice = (data: string): boolean => {
 
 export const IsValidPayPro = (data: string): boolean => {
   data = SanitizeUri(data);
-  return !!/^(bitcoin|bitcoincash|bchtest|ethereum|ripple|matic|dogecoin|litecoin)?:\?r=[\w+]/.exec(
+  return !!/^(bitpay|bitcoin|bitcoincash|bchtest|ethereum|ripple|matic|dogecoin|litecoin)?:\?r=[\w+]/.exec(
     data,
   );
 };


### PR DESCRIPTION
Handle payment protocol URIs in the format: `bitpay:?r=https://bitpay.com/i/4brRCvJxXrhgaRvmVp7ghj` 

(and `bitpay:?r=https://test.bitpay.com/i/4brRCvJxXrhgaRvmVp7ghj` for testnet invoices)