### PR TITLE
FIX[RN-801]: set input type to show keyboard in 2FA screen

### DIFF
--- a/src/components/form/BoxInput.tsx
+++ b/src/components/form/BoxInput.tsx
@@ -167,6 +167,7 @@ const BoxInput = React.forwardRef<
       error,
       type,
       disabled,
+      keyboardType,
       ...props
     },
     ref,
@@ -175,10 +176,10 @@ const BoxInput = React.forwardRef<
     const isSearch = type === 'search';
     const [isFocused, setIsFocused] = useState(false);
     const [isSecureTextEntry, setSecureTextEntry] = useState(isPassword);
-    const keyboardType: KeyboardTypeOptions | undefined =
+    const _keyboardType: KeyboardTypeOptions | undefined =
       isPassword && !isSecureTextEntry && IS_ANDROID
         ? 'visible-password'
-        : undefined;
+        : keyboardType || undefined;
 
     const _onFocus = () => {
       setIsFocused(true);
@@ -219,7 +220,7 @@ const BoxInput = React.forwardRef<
           {prefix ? <Prefix>{prefix()}</Prefix> : null}
 
           <Input
-            keyboardType={keyboardType}
+            keyboardType={_keyboardType}
             placeholderTextColor={Slate}
             {...props}
             editable={!disabled}

--- a/src/navigation/auth/screens/TwoFactor.Auth.tsx
+++ b/src/navigation/auth/screens/TwoFactor.Auth.tsx
@@ -142,7 +142,7 @@ const TwoFactorAuthentication: React.VFC<
               onChangeText={onChange}
               error={errors.code?.message}
               value={value}
-              keyboardType="numeric"
+              keyboardType={'numeric'}
               onSubmitEditing={onSubmit}
             />
           )}

--- a/src/navigation/auth/screens/TwoFactor.Pair.tsx
+++ b/src/navigation/auth/screens/TwoFactor.Pair.tsx
@@ -161,7 +161,7 @@ const TwoFactorPairing: React.VFC<TwoFactorPairingScreenProps> = ({
               onChangeText={onChange}
               error={errors.code?.message}
               value={value}
-              keyboardType="numeric"
+              keyboardType={'numeric'}
               onSubmitEditing={onSubmit}
             />
           )}


### PR DESCRIPTION
`keyboardType` was always undefined for iOS devices.