### PR TITLE
Feat: Remote config for buy and swap

### DIFF
--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "Unvollständiges Wallet",
   "The selected wallet needs to be complete before being able to receive funds": "Das ausgewählte Wallet muss vollständig sein, bevor Sie Geld erhalten können",
   "No wallets": "Keine Wallets",
-  "No wallets available to receive funds.": "Keine {{coin}}-Wallets für den Empfang von Geldern verfügbar.",
+  "No coin wallets available to receive funds.": "Keine {{coin}}-Wallets für den Empfang von Geldern verfügbar.",
   "Not supported wallets": "Nicht unterstützte Wallets",
   "Your keys do not have wallets able to buy crypto": "Ihre Schlüssel haben keine {{coin}}-Wallets zum Kaufen von Krypto",
   "Your keys do not have supported wallets able to buy crypto": "Ihre Schlüssel haben keine unterstützten Wallets zum Kaufen von Krypto",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1242,7 +1242,7 @@
   "Incomplete Wallet": "Incomplete Wallet",
   "The selected wallet needs to be complete before being able to receive funds": "The selected wallet needs to be complete before being able to receive funds",
   "No wallets": "No wallets",
-  "No wallets available to receive funds.": "No {{coin}} wallets available to receive funds.",
+  "No coin wallets available to receive funds.": "No {{coin}} wallets available to receive funds.",
   "Not supported wallets": "Not supported wallets",
   "Your keys do not have wallets able to buy crypto": "Your keys do not have {{coin}} wallets able to buy crypto",
   "Your keys do not have supported wallets able to buy crypto": "Your keys do not have supported wallets able to buy crypto",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -1242,7 +1242,7 @@
   "Incomplete Wallet": "Billetera incompleta",
   "The selected wallet needs to be complete before being able to receive funds": "La billetera seleccionada necesita estar completa antes de poder recibir fondos",
   "No wallets": "No hay billeteras",
-  "No wallets available to receive funds.": "No hay billeteras {{coin}} disponibles para recibir fondos.",
+  "No coin wallets available to receive funds.": "No hay billeteras {{coin}} disponibles para recibir fondos.",
   "Not supported wallets": "Billeteras no soportadas",
   "Your keys do not have wallets able to buy crypto": "Sus claves no tienen billeteras {{coin}} compatibles para la compra de criptomonedas",
   "Your keys do not have supported wallets able to buy crypto": "Sus claves no tienen billeteras compatibles para la compra de criptomonedas",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "Portefeuille incomplet",
   "The selected wallet needs to be complete before being able to receive funds": "Le portefeuille sélectionné doit être complet avant de pouvoir recevoir des fonds",
   "No wallets": "Portefeuilles",
-  "No wallets available to receive funds.": "Pas de portefeuilles {{coin}} disponibles pour recevoir des fonds.",
+  "No coin wallets available to receive funds.": "Pas de portefeuilles {{coin}} disponibles pour recevoir des fonds.",
   "Not supported wallets": "Aucun portefeuille pris en charge",
   "Your keys do not have wallets able to buy crypto": "Vos clés n'ont pas de portefeuille {{coin}} capables d'acheter de la crypto",
   "Your keys do not have supported wallets able to buy crypto": "Vos clés n'ont pas de portefeuilles pris en charge permettant d'acheter des cryptomonnaies",

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "未完成のウォレット",
   "The selected wallet needs to be complete before being able to receive funds": "選択されたウォレットは資産を受け取る前に完成させる必要があります",
   "No wallets": "ウォレットがありません",
-  "No wallets available to receive funds.": "資産の受け取りに利用可能な {{coin}} ウォレットがありません。",
+  "No coin wallets available to receive funds.": "資産の受け取りに利用可能な {{coin}} ウォレットがありません。",
   "Not supported wallets": "サポートされたウォレットがありません",
   "Your keys do not have wallets able to buy crypto": "お客様の鍵には暗号資産（仮想通貨）を購入できる {{coin}} ウォレットがありません",
   "Your keys do not have supported wallets able to buy crypto": "お客様の鍵には暗号資産（仮想通貨）の購入が可能なサポートされたウォレットがありません",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "Onvoltooide wallet",
   "The selected wallet needs to be complete before being able to receive funds": "De geselecteerde wallet moet voltooid zijn om geld te kunnen ontvangen",
   "No wallets": "Geen wallets",
-  "No wallets available to receive funds.": "Geen {{coin}}-wallets beschikbaar om geld te ontvangen.",
+  "No coin wallets available to receive funds.": "Geen {{coin}}-wallets beschikbaar om geld te ontvangen.",
   "Not supported wallets": "Niet ondersteunde wallets",
   "Your keys do not have wallets able to buy crypto": "Uw keys hebben geen {{coin}}-wallets om crypto te kunnen kopen",
   "Your keys do not have supported wallets able to buy crypto": "Uw keys hebben geen ondersteunde wallets om crypto te kunnen kopen",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "Carteira incompleta",
   "The selected wallet needs to be complete before being able to receive funds": "A carteira selecionada tem de estar completa antes de poder receber fundos",
   "No wallets": "Nenhuma carteira",
-  "No wallets available to receive funds.": "Não tem carteiras {{coin}} disponíveis para receber fundos.",
+  "No coin wallets available to receive funds.": "Não tem carteiras {{coin}} disponíveis para receber fundos.",
   "Not supported wallets": "Nenhuma carteira suportada",
   "Your keys do not have wallets able to buy crypto": "As suas chaves não têm carteiras {{coin}} compatíveis com a compra de criptomoedas",
   "Your keys do not have supported wallets able to buy crypto": "As suas chaves não têm carteiras compatíveis com a compra de criptomoedas",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "Кошелек с незаполненным пулом соплательщиков",
   "The selected wallet needs to be complete before being able to receive funds": "Для получения средств необходимо заполнить пул соплательщиков для выбранного кошелька",
   "No wallets": "Нет кошельков",
-  "No wallets available to receive funds.": "Отсутствуют кошельки {{coin}}, на которые можно получать средства.",
+  "No coin wallets available to receive funds.": "Отсутствуют кошельки {{coin}}, на которые можно получать средства.",
   "Not supported wallets": "Нет поддерживаемых кошельков",
   "Your keys do not have wallets able to buy crypto": "Для ваших ключей отсутствуют кошельки {{coin}} для покупки криптовалюты",
   "Your keys do not have supported wallets able to buy crypto": "Для ваших ключей отсутствуют поддерживаемые кошельки для покупки криптовалюты",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -374,7 +374,7 @@
   "Incomplete Wallet": "钱包不完整",
   "The selected wallet needs to be complete before being able to receive funds": "所选钱包需要完整才能接收资金",
   "No wallets": "没有钱包",
-  "No wallets available to receive funds.": "没有可用于接收资金的 {{coin}} 钱包。",
+  "No coin wallets available to receive funds.": "没有可用于接收资金的 {{coin}} 钱包。",
   "Not supported wallets": "钱包不受支持",
   "Your keys do not have wallets able to buy crypto": "您的密钥没有能够购买加密货币的 {{coin}} 钱包",
   "Your keys do not have supported wallets able to buy crypto": "您的密钥没有能够购买加密货币的受支持的钱包",

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -61,7 +61,7 @@ import SimplexTerms from '../components/terms/SimplexTerms';
 import WyreTerms from '../components/terms/WyreTerms';
 import {TermsContainer, TermsText} from '../styled/BuyCryptoTerms';
 import {BuyCryptoConfig} from '../../../../store/external-services/external-services.types';
-import { BitpaySupportedCoins } from '../../../../constants/currencies';
+import {BitpaySupportedCoins} from '../../../../constants/currencies';
 
 export interface BuyCryptoOffersProps {
   amount: number;
@@ -635,6 +635,15 @@ const BuyCryptoOffers: React.FC = () => {
 
   const getWyreQuote = async () => {
     logger.debug('Wyre getting quote');
+
+    if (buyCryptoConfig?.wyre?.disabled) {
+      let err = buyCryptoConfig?.wyre?.disabledMessage
+        ? buyCryptoConfig?.wyre?.disabledMessage
+        : t("Can't get rates at this moment. Please try again later");
+      const reason = 'wyreGetQuote Error. Exchange disabled from config.';
+      showWyreError(err, reason);
+      return;
+    }
 
     offers.wyre.fiatAmount =
       offers.wyre.fiatCurrency === fiatCurrency

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -9,7 +9,6 @@ import haptic from '../../../../components/haptic-feedback/haptic';
 import {BaseText, H5, H7} from '../../../../components/styled/Text';
 import {CurrencyImage} from '../../../../components/currency-image/CurrencyImage';
 import {useLogger} from '../../../../utils/hooks/useLogger';
-import {BitpaySupportedCoins} from '../../../../constants/currencies';
 import MoonpayLogo from '../../../../components/icons/external-services/moonpay/moonpay-logo';
 import SimplexLogo from '../../../../components/icons/external-services/simplex/simplex-logo';
 import WyreLogo from '../../../../components/icons/external-services/wyre/wyre-logo';
@@ -61,6 +60,8 @@ import MoonpayTerms from '../components/terms/MoonpayTerms';
 import SimplexTerms from '../components/terms/SimplexTerms';
 import WyreTerms from '../components/terms/WyreTerms';
 import {TermsContainer, TermsText} from '../styled/BuyCryptoTerms';
+import {BuyCryptoConfig} from '../../../../store/external-services/external-services.types';
+import { BitpaySupportedCoins } from '../../../../constants/currencies';
 
 export interface BuyCryptoOffersProps {
   amount: number;
@@ -70,6 +71,7 @@ export interface BuyCryptoOffersProps {
   country: string;
   selectedWallet: Wallet;
   paymentMethod: PaymentMethod;
+  buyCryptoConfig: BuyCryptoConfig;
 }
 
 interface SimplexGetQuoteRequestData {
@@ -290,8 +292,10 @@ const BuyCryptoOffers: React.FC = () => {
       country,
       selectedWallet,
       paymentMethod,
+      buyCryptoConfig,
     },
-  } = useRoute<RouteProp<{params: BuyCryptoOffersProps}>>();
+  }: {params: BuyCryptoOffersProps} =
+    useRoute<RouteProp<{params: BuyCryptoOffersProps}>>();
   const {t} = useTranslation();
   const logger = useLogger();
   const navigation = useNavigation();
@@ -307,14 +311,16 @@ const BuyCryptoOffers: React.FC = () => {
         ? fiatCurrency
         : 'USD';
 
-      offersDefault[exchange].showOffer = isPaymentMethodSupported(
-        exchange,
-        paymentMethod,
-        coin,
-        chain,
-        offersDefault.simplex.fiatCurrency,
-        country,
-      );
+      offersDefault[exchange].showOffer =
+        isPaymentMethodSupported(
+          exchange,
+          paymentMethod,
+          coin,
+          chain,
+          offersDefault[exchange].fiatCurrency,
+          country,
+        ) &&
+        (!buyCryptoConfig?.[exchange] || !buyCryptoConfig?.[exchange]?.removed);
     }
   });
 
@@ -326,6 +332,15 @@ const BuyCryptoOffers: React.FC = () => {
 
   const getMoonpayQuote = (): void => {
     logger.debug('Moonpay getting quote');
+
+    if (buyCryptoConfig?.moonpay?.disabled) {
+      let err = buyCryptoConfig?.moonpay?.disabledMessage
+        ? buyCryptoConfig?.moonpay?.disabledMessage
+        : t("Can't get rates at this moment. Please try again later");
+      const reason = 'moonpayGetQuote Error. Exchange disabled from config.';
+      showMoonpayError(err, reason);
+      return;
+    }
 
     offers.moonpay.fiatAmount =
       offers.moonpay.fiatCurrency === fiatCurrency
@@ -472,6 +487,15 @@ const BuyCryptoOffers: React.FC = () => {
 
   const getSimplexQuote = (): void => {
     logger.debug('Simplex getting quote');
+
+    if (buyCryptoConfig?.simplex?.disabled) {
+      let err = buyCryptoConfig?.simplex?.disabledMessage
+        ? buyCryptoConfig?.simplex?.disabledMessage
+        : t("Can't get rates at this moment. Please try again later");
+      const reason = 'simplexGetQuote Error. Exchange disabled from config.';
+      showSimplexError(err, reason);
+      return;
+    }
 
     offers.simplex.fiatAmount =
       offers.simplex.fiatCurrency === fiatCurrency

--- a/src/store/external-services/external-services.effects.ts
+++ b/src/store/external-services/external-services.effects.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const uri = 'https://bws.bitpay.com/bws/api';
+
+export const getExternalServicesConfig = async () => {
+  try {
+    const config = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const {data} = await axios.get(uri + '/v1/services', config);
+
+    return Promise.resolve(data);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};

--- a/src/store/external-services/external-services.types.ts
+++ b/src/store/external-services/external-services.types.ts
@@ -1,0 +1,27 @@
+type ExchangeConfig = {
+  disabled?: boolean;
+  removed?: boolean;
+  disabledTitle?: string;
+  disabledMessage?: string;
+};
+
+export type BuyCryptoConfig = {
+  disabled?: boolean;
+  disabledTitle?: string;
+  disabledMessage?: string;
+  moonpay?: ExchangeConfig;
+  simplex?: ExchangeConfig;
+  wyre?: ExchangeConfig;
+};
+
+export type SwapCryptoConfig = {
+  disabled?: boolean;
+  disabledTitle?: string;
+  disabledMessage?: string;
+  changelly?: ExchangeConfig;
+};
+
+export type ExternalServicesConfig = {
+  buyCrypto?: BuyCryptoConfig;
+  swapCrypto?: SwapCryptoConfig;
+};

--- a/src/store/wallet/effects/errors/errors.ts
+++ b/src/store/wallet/effects/errors/errors.ts
@@ -32,7 +32,7 @@ export const showWalletError =
       case 'noWalletsAbleToBuy':
         title = t('No wallets');
         message = coin
-          ? t('No wallets available to receive funds.', {
+          ? t('No coin wallets available to receive funds.', {
               coin: coin.toUpperCase(),
             })
           : t('No wallets available to receive funds.');


### PR DESCRIPTION
Remote config example from BWS:

```   
services: {
      buyCrypto: {
        disabled: false,
        moonpay: {
          disabled: false,
          removed: false
        },
        simplex: {
          disabled: false,
          removed: true
        },
        wyre: {
          disabled: true,
          disabledMessage: 'Wyre is out of service.',
          removed: false
        }
      },
      swapCrypto: { 
        disabled: false,
        changelly: {
          disabled: false,
          removed: false
        }
      },
    },
   ```