### PR TITLE
Revert "Removes Wyre integration from supported buy crypto exchanges"

### DIFF
--- a/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
+++ b/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
@@ -17,6 +17,7 @@ import {BaseText} from '../../../../components/styled/Text';
 import Button from '../../../../components/button/Button';
 import MoonpayLogo from '../../../../components/icons/external-services/moonpay/moonpay-logo';
 import SimplexLogo from '../../../../components/icons/external-services/simplex/simplex-logo';
+import WyreLogo from '../../../../components/icons/external-services/wyre/wyre-logo';
 import {Action, LightBlack, SlateDark, White} from '../../../../styles/colors';
 import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
 import {useTranslation} from 'react-i18next';
@@ -214,6 +215,18 @@ const PaymentMethodsModal = ({
                           currency,
                         ) ? (
                           <SimplexLogo widthIcon={20} heightIcon={20} />
+                        ) : null}
+                        {coin &&
+                        currency &&
+                        chain &&
+                        isPaymentMethodSupported(
+                          'wyre',
+                          paymentMethod,
+                          coin,
+                          chain,
+                          currency,
+                        ) ? (
+                          <WyreLogo width={60} height={15} />
                         ) : null}
                       </PaymentMethodProvider>
                     </PaymentMethodCheckboxTexts>

--- a/src/navigation/services/buy-crypto/components/terms/WyreTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/WyreTerms.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import {TouchableOpacity} from 'react-native';
+import {
+  ExchangeTermsContainer,
+  ExchangeTermsText,
+} from '../../styled/BuyCryptoTerms';
+import haptic from '../../../../../components/haptic-feedback/haptic';
+import {Link} from '../../../../../components/styled/Text';
+import {useAppDispatch} from '../../../../../utils/hooks';
+import {openUrlWithInAppBrowser} from '../../../../../store/app/app.effects';
+
+const WyreTerms: React.FC<{
+  country?: string;
+  fiatCurrency?: string;
+}> = ({country = 'US', fiatCurrency}) => {
+  const {t} = useTranslation();
+  const dispatch = useAppDispatch();
+
+  return (
+    <ExchangeTermsContainer>
+      <ExchangeTermsText>
+        {t('What service fees am I paying?')}
+      </ExchangeTermsText>
+      {country == 'US' ? (
+        <ExchangeTermsText>
+          {t(
+            '5 USD minimum fee or 2.9% of the amount + 0.30 USD, whichever is greater + Required miners fee.',
+          )}
+        </ExchangeTermsText>
+      ) : null}
+      {country != 'US' ? (
+        <ExchangeTermsText>
+          {t(
+            '5 USD minimum fee or 3.9% of the amount + 0.30 USD, whichever is greater + Required miners fee.',
+          )}
+        </ExchangeTermsText>
+      ) : null}
+      {fiatCurrency?.toUpperCase() != 'USD' ? (
+        <ExchangeTermsText>
+          {t('Or its equivalent in .', {
+            fiatCurrency: fiatCurrency?.toUpperCase(),
+          })}
+        </ExchangeTermsText>
+      ) : null}
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://support.sendwyre.com/hc/en-us/articles/360059565013-Wyre-card-processing-fees',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12, top: 2}}>{t('Read more')}</Link>
+      </TouchableOpacity>
+      <ExchangeTermsText style={{marginTop: 4}}>
+        {t(
+          'This service is provided by a third party, and you are subject to their',
+        )}
+        <TouchableOpacity
+          onPress={() => {
+            haptic('impactLight');
+            dispatch(
+              openUrlWithInAppBrowser(
+                'https://www.sendwyre.com/user-agreement/',
+              ),
+            );
+          }}>
+          <Link style={{fontSize: 12, top: 2}}>{t('User Agreement')}</Link>
+        </TouchableOpacity>
+      </ExchangeTermsText>
+    </ExchangeTermsContainer>
+  );
+};
+
+export default WyreTerms;

--- a/src/navigation/services/buy-crypto/constants/BuyCryptoConstants.tsx
+++ b/src/navigation/services/buy-crypto/constants/BuyCryptoConstants.tsx
@@ -29,6 +29,7 @@ export const PaymentMethodsAvailable: PaymentMethods = {
     supportedExchanges: {
       moonpay: true,
       simplex: true,
+      wyre: true,
     },
     enabled: Platform.OS === 'ios',
   },
@@ -39,6 +40,7 @@ export const PaymentMethodsAvailable: PaymentMethods = {
     supportedExchanges: {
       moonpay: true,
       simplex: true, // EU Only
+      wyre: false,
     },
     enabled: true,
   },
@@ -49,6 +51,7 @@ export const PaymentMethodsAvailable: PaymentMethods = {
     supportedExchanges: {
       moonpay: true,
       simplex: true,
+      wyre: false,
     },
     enabled: true,
   },
@@ -59,6 +62,7 @@ export const PaymentMethodsAvailable: PaymentMethods = {
     supportedExchanges: {
       moonpay: true,
       simplex: true,
+      wyre: true,
     },
     enabled: true,
   },
@@ -69,6 +73,7 @@ export const PaymentMethodsAvailable: PaymentMethods = {
     supportedExchanges: {
       moonpay: true,
       simplex: true,
+      wyre: false,
     },
     enabled: true,
   },

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -12,6 +12,7 @@ import {useLogger} from '../../../../utils/hooks/useLogger';
 import {BitpaySupportedCoins} from '../../../../constants/currencies';
 import MoonpayLogo from '../../../../components/icons/external-services/moonpay/moonpay-logo';
 import SimplexLogo from '../../../../components/icons/external-services/simplex/simplex-logo';
+import WyreLogo from '../../../../components/icons/external-services/wyre/wyre-logo';
 import {BuyCryptoExpandibleCard, ItemDivisor} from '../styled/BuyCryptoCard';
 import {Black, SlateDark, ProgressBlue, White} from '../../../../styles/colors';
 import {
@@ -20,6 +21,7 @@ import {
   simplexEnv,
   getSimplexCoinFormat,
 } from '../utils/simplex-utils';
+import {getWyreCoinFormat, wyreEnv} from '../utils/wyre-utils';
 import {RootState} from '../../../../store';
 import {GetPrecision} from '../../../../store/wallet/utils/currency';
 import {
@@ -54,6 +56,7 @@ import {useTranslation} from 'react-i18next';
 import {moonpayEnv} from '../utils/moonpay-utils';
 import MoonpayTerms from '../components/terms/MoonpayTerms';
 import SimplexTerms from '../components/terms/SimplexTerms';
+import WyreTerms from '../components/terms/WyreTerms';
 import {TermsContainer, TermsText} from '../styled/BuyCryptoTerms';
 
 export interface BuyCryptoOffersProps {
@@ -76,7 +79,7 @@ interface SimplexGetQuoteRequestData {
   payment_methods?: string[];
 }
 
-export type CryptoOfferKey = 'moonpay' | 'simplex';
+export type CryptoOfferKey = 'moonpay' | 'simplex' | 'wyre';
 
 export type CryptoOffer = {
   key: CryptoOfferKey;
@@ -227,6 +230,7 @@ const OfferDataRightContainer = styled.View`
 const offersDefault: {
   moonpay: CryptoOffer;
   simplex: CryptoOffer;
+  wyre: CryptoOffer;
 } = {
   moonpay: {
     key: 'moonpay',
@@ -259,6 +263,18 @@ const offersDefault: {
     errorMsg: undefined,
     outOfLimitMsg: undefined,
   },
+  wyre: {
+    key: 'wyre',
+    amountReceiving: '0',
+    showOffer: true,
+    logo: <WyreLogo width={70} height={20} />,
+    expanded: false,
+    fiatCurrency: 'USD',
+    fiatAmount: 0,
+    fiatMoney: undefined,
+    errorMsg: undefined,
+    outOfLimitMsg: undefined,
+  },
 };
 
 const BuyCryptoOffers: React.FC = () => {
@@ -279,7 +295,7 @@ const BuyCryptoOffers: React.FC = () => {
   const dispatch = useAppDispatch();
   const createdOn = useAppSelector(({WALLET}: RootState) => WALLET.createdOn);
 
-  const exchangesArray: CryptoOfferKey[] = ['moonpay', 'simplex'];
+  const exchangesArray: CryptoOfferKey[] = ['moonpay', 'simplex', 'wyre'];
   exchangesArray.forEach((exchange: CryptoOfferKey) => {
     if (offersDefault[exchange]) {
       offersDefault[exchange].fiatCurrency = getAvailableFiatCurrencies(
@@ -301,6 +317,7 @@ const BuyCryptoOffers: React.FC = () => {
   const [offers, setOffers] = useState(cloneDeep(offersDefault));
   const [finishedMoonpay, setFinishedMoonpay] = useState(false);
   const [finishedSimplex, setFinishedSimplex] = useState(false);
+  const [finishedWyre, setFinishedWyre] = useState(false);
   const [updateView, setUpdateView] = useState(false);
 
   const getMoonpayQuote = (): void => {
@@ -585,6 +602,152 @@ const BuyCryptoOffers: React.FC = () => {
     setUpdateView(!updateView);
   };
 
+  const getWyreQuote = async () => {
+    logger.debug('Wyre getting quote');
+
+    offers.wyre.fiatAmount =
+      offers.wyre.fiatCurrency === fiatCurrency
+        ? amount
+        : dispatch(calculateAltFiatToUsd(amount, fiatCurrency)) || amount;
+
+    offers.wyre.amountLimits = dispatch(
+      getBuyCryptoFiatLimits('wyre', offers.wyre.fiatCurrency),
+    );
+
+    if (
+      (offers.wyre.amountLimits.min &&
+        offers.wyre.fiatAmount < offers.wyre.amountLimits.min) ||
+      (offers.wyre.amountLimits.max &&
+        offers.wyre.fiatAmount > offers.wyre.amountLimits.max)
+    ) {
+      offers.wyre.outOfLimitMsg = t(
+        'There are no Wyre offers available, as the current purchase limits for this exchange must be between and',
+        {
+          min: offers.wyre.amountLimits.min,
+          max: offers.wyre.amountLimits.max,
+          fiatCurrency: offers.wyre.fiatCurrency,
+        },
+      );
+    } else {
+      let address: string = '';
+      try {
+        address = (await dispatch<any>(
+          createWalletAddress({wallet: selectedWallet, newAddress: false}),
+        )) as string;
+      } catch (err) {
+        console.error(err);
+        const reason = 'createWalletAddress Error';
+        showWyreError(err, reason);
+      }
+
+      const dest = setPrefix(
+        address,
+        selectedWallet.chain,
+        selectedWallet.network,
+      );
+
+      let walletType: string;
+      switch (paymentMethod.method) {
+        case 'applePay':
+          walletType = 'APPLE_PAY';
+          break;
+        default:
+          walletType = 'DEBIT_CARD';
+          break;
+      }
+
+      const requestData = {
+        sourceAmount: offers.wyre.fiatAmount.toString(),
+        sourceCurrency: offers.wyre.fiatCurrency.toUpperCase(),
+        destCurrency: getWyreCoinFormat(coin, selectedWallet.chain),
+        dest,
+        country,
+        amountIncludeFees: true, // If amountIncludeFees is true, use sourceAmount instead of amount
+        walletType,
+        env: wyreEnv,
+      };
+
+      selectedWallet
+        .wyreWalletOrderQuotation(requestData)
+        .then(data => {
+          if (data && (data.exceptionId || data.error)) {
+            const reason = 'wyreWalletOrderQuotation Error';
+            showWyreError(data, reason);
+            return;
+          }
+
+          offers.wyre.amountCost = data.sourceAmount; // sourceAmount = Total amount (including fees)
+          offers.wyre.buyAmount = data.sourceAmountWithoutFees;
+          offers.wyre.fee = data.sourceAmount - data.sourceAmountWithoutFees;
+
+          if (offers.wyre.fee < 0) {
+            const err =
+              t('Wyre has returned a wrong value for the fee. Fee: ') +
+              offers.wyre.fee;
+            const reason = 'Fee not included';
+            showWyreError(err, reason);
+            return;
+          }
+
+          offers.wyre.fiatMoney =
+            offers.wyre.buyAmount && data.destAmount
+              ? Number(offers.wyre.buyAmount / data.destAmount).toFixed(8)
+              : undefined;
+
+          offers.wyre.amountReceiving = data.destAmount.toFixed(8);
+
+          logger.debug('Wyre getting quote: SUCCESS');
+          setFinishedWyre(!finishedWyre);
+        })
+        .catch((err: any) => {
+          const reason = 'wyreWalletOrderQuotation Error';
+          showWyreError(err, reason);
+        });
+    }
+  };
+
+  const showWyreError = (err?: any, reason?: string) => {
+    let msg = t('Could not get crypto offer. Please try again later.');
+    if (err) {
+      if (typeof err === 'string') {
+        msg = err;
+      } else if (err.exceptionId && err.message) {
+        logger.error('Wyre error: ' + err.message);
+        if (err.errorCode) {
+          switch (err.errorCode) {
+            case 'validation.unsupportedCountry':
+              msg = t('Country not supported: ') + country;
+              break;
+            default:
+              msg = err.message;
+              break;
+          }
+        } else {
+          msg = err.message;
+        }
+      }
+    }
+
+    dispatch(
+      logSegmentEvent('track', 'Failed Buy Crypto', {
+        exchange: 'wyre',
+        context: 'BuyCryptoOffers',
+        reason: reason || 'unknown',
+        paymentMethod: paymentMethod.method || '',
+        amount: Number(offers.wyre.fiatAmount) || '',
+        coin: coin?.toLowerCase() || '',
+        chain: chain?.toLowerCase() || '',
+        fiatCurrency: offers.wyre.fiatCurrency || '',
+      }),
+    );
+
+    logger.error('Crypto offer error: ' + msg);
+    offers.wyre.errorMsg = msg;
+    offers.wyre.fiatMoney = undefined;
+    offers.wyre.expanded = false;
+    setUpdateView(!updateView);
+  };
+
   const setPrefix = (
     address: string,
     chain: string,
@@ -604,6 +767,10 @@ const BuyCryptoOffers: React.FC = () => {
 
       case 'simplex':
         goToSimplexBuyPage();
+        break;
+
+      case 'wyre':
+        goToWyreBuyPage();
         break;
     }
   };
@@ -785,6 +952,90 @@ const BuyCryptoOffers: React.FC = () => {
       });
   };
 
+  const goToWyreBuyPage = async () => {
+    let address: string = '';
+    try {
+      address = (await dispatch<any>(
+        createWalletAddress({wallet: selectedWallet, newAddress: false}),
+      )) as string;
+    } catch (err) {
+      console.error(err);
+      const reason = 'createWalletAddress Error';
+      showWyreError(err, reason);
+    }
+    let _paymentMethod: string;
+    switch (paymentMethod.method) {
+      case 'applePay':
+        _paymentMethod = 'apple-pay';
+        break;
+      default:
+        _paymentMethod = 'debit-card';
+        break;
+    }
+    const destinationChain = selectedWallet.chain;
+    const redirectUrl =
+      APP_DEEPLINK_PREFIX +
+      'wyre?walletId=' +
+      selectedWallet.id +
+      '&destAmount=' +
+      offers.wyre.amountReceiving +
+      '&destChain=' +
+      destinationChain;
+    const failureRedirectUrl = APP_DEEPLINK_PREFIX + 'wyreError';
+    const dest = setPrefix(
+      address,
+      selectedWallet.chain,
+      selectedWallet.network,
+    );
+    const requestData = {
+      sourceAmount: offers.wyre.fiatAmount.toString(),
+      dest,
+      destCurrency: getWyreCoinFormat(coin, destinationChain),
+      lockFields: ['dest', 'destCurrency', 'country'],
+      paymentMethod: _paymentMethod,
+      sourceCurrency: offers.wyre.fiatCurrency.toUpperCase(),
+      country,
+      amountIncludeFees: true, // If amountIncludeFees is true, use sourceAmount instead of amount
+      redirectUrl,
+      failureRedirectUrl,
+      env: wyreEnv,
+    };
+
+    selectedWallet
+      .wyreWalletOrderReservation(requestData)
+      .then((data: any) => {
+        if (data && (data.exceptionId || data.error)) {
+          const reason = 'wyreWalletOrderReservation Error';
+          showWyreError(data, reason);
+          return;
+        }
+
+        const {url} = data;
+        continueToWyre(url);
+      })
+      .catch((err: any) => {
+        const reason = 'wyreWalletOrderReservation Error';
+        showWyreError(err, reason);
+      });
+  };
+
+  const continueToWyre = async (paymentUrl: string) => {
+    const destinationChain = selectedWallet.chain;
+    dispatch(
+      logSegmentEvent('track', 'Requested Crypto Purchase', {
+        exchange: 'wyre',
+        fiatAmount: offers.wyre.fiatAmount,
+        fiatCurrency: offers.wyre.fiatCurrency,
+        paymentMethod: paymentMethod.method,
+        coin: selectedWallet.currencyAbbreviation.toLowerCase(),
+        chain: destinationChain?.toLowerCase(),
+      }),
+    );
+    dispatch(openUrlWithInAppBrowser(paymentUrl));
+    await sleep(500);
+    navigation.goBack();
+  };
+
   const expandCard = (offer: CryptoOffer) => {
     const key = offer.key;
     if (!offer.fiatMoney) {
@@ -803,11 +1054,14 @@ const BuyCryptoOffers: React.FC = () => {
     if (offers.simplex.showOffer) {
       getSimplexQuote();
     }
+    if (offers.wyre.showOffer) {
+      getWyreQuote();
+    }
   }, []);
 
   useEffect(() => {
     setOffers(offers);
-  }, [finishedMoonpay, finishedSimplex, updateView]);
+  }, [finishedMoonpay, finishedSimplex, finishedWyre, updateView]);
 
   return (
     <ScrollView>
@@ -985,6 +1239,12 @@ const BuyCryptoOffers: React.FC = () => {
                   ) : null}
                   {offer.key == 'simplex' ? (
                     <SimplexTerms paymentMethod={paymentMethod} />
+                  ) : null}
+                  {offer.key == 'wyre' ? (
+                    <WyreTerms
+                      country={country}
+                      fiatCurrency={offer.fiatCurrency}
+                    />
                   ) : null}
                 </>
               ) : null}

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
@@ -37,6 +37,7 @@ import SelectorArrowDown from '../../../../../assets/img/selector-arrow-down.svg
 import SelectorArrowRight from '../../../../../assets/img/selector-arrow-right.svg';
 import {getMoonpaySupportedCurrencies} from '../utils/moonpay-utils';
 import {getSimplexSupportedCurrencies} from '../utils/simplex-utils';
+import {getWyreSupportedCurrencies} from '../utils/wyre-utils';
 import {
   getBadgeImg,
   getCurrencyAbbreviation,
@@ -123,6 +124,7 @@ const BuyCryptoRoot: React.VFC<
     ...new Set([
       ...getMoonpaySupportedCurrencies(),
       ...getSimplexSupportedCurrencies(),
+      ...getWyreSupportedCurrencies(),
     ]),
   ]);
   const [buyCryptoSupportedCoinsFullObj, setBuyCryptoSupportedCoinsFullObj] =
@@ -238,13 +240,21 @@ const BuyCryptoRoot: React.VFC<
   const walletIsSupported = (wallet: Wallet): boolean => {
     return (
       wallet.credentials &&
-      wallet.network === 'livenet' &&
-      buyCryptoSupportedCoins.includes(
-        getCurrencyAbbreviation(
-          wallet.currencyAbbreviation.toLowerCase(),
-          wallet.chain,
-        ),
-      ) &&
+      ((wallet.network === 'livenet' &&
+        buyCryptoSupportedCoins.includes(
+          getCurrencyAbbreviation(
+            wallet.currencyAbbreviation.toLowerCase(),
+            wallet.chain,
+          ),
+        )) ||
+        (__DEV__ &&
+          wallet.network === 'testnet' &&
+          getWyreSupportedCurrencies().includes(
+            getCurrencyAbbreviation(
+              wallet.currencyAbbreviation.toLowerCase(),
+              wallet.chain,
+            ),
+          ))) &&
       wallet.isComplete() &&
       !wallet.hideWallet &&
       (!fromCurrencyAbbreviation ||
@@ -256,13 +266,21 @@ const BuyCryptoRoot: React.VFC<
   const setWallet = (wallet: Wallet) => {
     if (
       wallet.credentials &&
-      wallet.network === 'livenet' &&
-      buyCryptoSupportedCoins.includes(
-        getCurrencyAbbreviation(
-          wallet.currencyAbbreviation.toLowerCase(),
-          wallet.chain,
-        ),
-      )
+      ((wallet.network === 'livenet' &&
+        buyCryptoSupportedCoins.includes(
+          getCurrencyAbbreviation(
+            wallet.currencyAbbreviation.toLowerCase(),
+            wallet.chain,
+          ),
+        )) ||
+        (__DEV__ &&
+          wallet.network === 'testnet' &&
+          getWyreSupportedCurrencies().includes(
+            getCurrencyAbbreviation(
+              wallet.currencyAbbreviation.toLowerCase(),
+              wallet.chain,
+            ),
+          )))
     ) {
       if (wallet.isComplete()) {
         if (allKeys[wallet.keyId].backupComplete) {
@@ -378,6 +396,13 @@ const BuyCryptoRoot: React.VFC<
             selectedWallet.currencyAbbreviation,
             selectedWallet.chain,
             fiatCurrency,
+          ) ||
+          isPaymentMethodSupported(
+            'wyre',
+            PaymentMethodsAvailable.applePay,
+            selectedWallet.currencyAbbreviation,
+            selectedWallet.chain,
+            fiatCurrency,
           )
           ? PaymentMethodsAvailable.applePay
           : PaymentMethodsAvailable.debitCard,
@@ -408,6 +433,13 @@ const BuyCryptoRoot: React.VFC<
       ) ||
       isPaymentMethodSupported(
         'simplex',
+        selectedPaymentMethod,
+        selectedWallet.currencyAbbreviation,
+        selectedWallet.chain,
+        fiatCurrency,
+      ) ||
+      isPaymentMethodSupported(
+        'wyre',
         selectedPaymentMethod,
         selectedWallet.currencyAbbreviation,
         selectedWallet.chain,

--- a/src/navigation/services/buy-crypto/utils/buy-crypto-utils.ts
+++ b/src/navigation/services/buy-crypto/utils/buy-crypto-utils.ts
@@ -11,6 +11,10 @@ import {
   getSimplexSupportedCurrencies,
   simplexSupportedFiatCurrencies,
 } from './simplex-utils';
+import {
+  getWyreSupportedCurrencies,
+  wyreSupportedFiatCurrencies,
+} from './wyre-utils';
 import pickBy from 'lodash.pickby';
 import {CountryData} from '../../../../store/location/location.models';
 import {getCurrencyAbbreviation} from '../../../../utils/helper-methods';
@@ -29,7 +33,8 @@ export const getEnabledPaymentMethods = (
     return (
       method.enabled &&
       (isPaymentMethodSupported('moonpay', method, coin, chain, currency) ||
-        isPaymentMethodSupported('simplex', method, coin, chain, currency))
+        isPaymentMethodSupported('simplex', method, coin, chain, currency) ||
+        isPaymentMethodSupported('wyre', method, coin, chain, currency))
     );
   });
 
@@ -42,9 +47,14 @@ export const getAvailableFiatCurrencies = (exchange?: string): string[] => {
       return moonpaySupportedFiatCurrencies;
     case 'simplex':
       return simplexSupportedFiatCurrencies;
+    case 'wyre':
+      return wyreSupportedFiatCurrencies;
     default:
       const allSupportedFiatCurrencies = [
-        ...new Set([...simplexSupportedFiatCurrencies]),
+        ...new Set([
+          ...simplexSupportedFiatCurrencies,
+          ...wyreSupportedFiatCurrencies,
+        ]),
       ];
       return allSupportedFiatCurrencies;
   }
@@ -68,7 +78,8 @@ export const isPaymentMethodSupported = (
 export const isCoinSupportedToBuy = (coin: string, chain: string): boolean => {
   return (
     isCoinSupportedBy('moonpay', coin, chain) ||
-    isCoinSupportedBy('simplex', coin, chain)
+    isCoinSupportedBy('simplex', coin, chain) ||
+    isCoinSupportedBy('wyre', coin, chain)
   );
 };
 
@@ -86,6 +97,10 @@ const isCoinSupportedBy = (
       return getSimplexSupportedCurrencies().includes(
         getCurrencyAbbreviation(coin.toLowerCase(), chain.toLowerCase()),
       );
+    case 'wyre':
+      return getWyreSupportedCurrencies().includes(
+        getCurrencyAbbreviation(coin.toLowerCase(), chain.toLowerCase()),
+      );
     default:
       return false;
   }
@@ -100,6 +115,8 @@ const isFiatCurrencySupportedBy = (
       return moonpaySupportedFiatCurrencies.includes(currency.toUpperCase());
     case 'simplex':
       return simplexSupportedFiatCurrencies.includes(currency.toUpperCase());
+    case 'wyre':
+      return wyreSupportedFiatCurrencies.includes(currency.toUpperCase());
     default:
       return false;
   }

--- a/src/navigation/services/buy-crypto/utils/wyre-utils.ts
+++ b/src/navigation/services/buy-crypto/utils/wyre-utils.ts
@@ -1,4 +1,82 @@
+import {getCurrencyAbbreviation} from '../../../../utils/helper-methods';
+
 export const wyreEnv = __DEV__ ? 'sandbox' : 'production';
+export const wyreSupportedFiatCurrencies = ['AUD', 'CAD', 'EUR', 'GBP', 'USD'];
+
+export const wyreSupportedCoins = ['btc', 'eth', 'matic'];
+
+export const wyreSupportedErc20Tokens = [
+  'aave',
+  'bat',
+  'busd',
+  'comp',
+  'crv',
+  'dai',
+  'gusd',
+  'gyen',
+  'link',
+  'mkr',
+  'pax', // backward compatibility
+  'rai',
+  'snx',
+  'uma',
+  'uni',
+  'usdc',
+  'usdp',
+  'usds',
+  'usdt',
+  'wbtc',
+  'weth',
+  'yfi',
+  'zusd',
+];
+
+export const wyreSupportedMaticTokens = [
+  'usdc', // mUSDC
+];
+
+export const getWyreSupportedCurrencies = (): string[] => {
+  const wyreSupportedCurrencies = wyreSupportedCoins
+    .concat(
+      wyreSupportedErc20Tokens.map(ethToken => {
+        return getCurrencyAbbreviation(ethToken, 'eth');
+      }),
+    )
+    .concat(
+      wyreSupportedMaticTokens.map(maticToken => {
+        return getCurrencyAbbreviation(maticToken, 'matic');
+      }),
+    );
+  return wyreSupportedCurrencies;
+};
+
+export const getWyreCoinFormat = (coin: string, chain: string): string => {
+  let formattedCoin: string = coin.toUpperCase();
+  switch (chain) {
+    case 'matic':
+      if (coin.toLowerCase() === 'usdc') {
+        formattedCoin = 'mUSDC';
+      }
+      break;
+    default:
+      formattedCoin = coin.toUpperCase();
+  }
+  return formattedCoin;
+};
+
+export const getWyreFiatAmountLimits = (country?: string) => {
+  if (!country || country !== 'US') {
+    return {
+      min: 50,
+      max: 1000,
+    };
+  } else {
+    return {
+      min: 50,
+      max: 2500,
+    };
+  }
+};
 
 export const handleWyreStatus = (status: string): string => {
   switch (status) {

--- a/src/navigation/tabs/settings/components/ExternalServices.tsx
+++ b/src/navigation/tabs/settings/components/ExternalServices.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import styled from 'styled-components/native';
 import {useNavigation} from '@react-navigation/native';
 import haptic from '../../../../components/haptic-feedback/haptic';
@@ -13,9 +13,6 @@ import ChangellyLogo from '../../../../components/icons/external-services/change
 import MoonpayLogo from '../../../../components/icons/external-services/moonpay/moonpay-logo';
 import SimplexLogo from '../../../../components/icons/external-services/simplex/simplex-logo';
 import WyreLogo from '../../../../components/icons/external-services/wyre/wyre-logo';
-import {useAppSelector} from '../../../../utils/hooks';
-import {RootState} from '../../../../store';
-import {WyrePaymentData} from '../../../../store/buy-crypto/buy-crypto.models';
 
 const ExternalServicesItemContainer = styled.View`
   justify-content: flex-start;
@@ -30,19 +27,6 @@ const ExternalServicesIconContainer = styled.View`
 
 const ExternalServices = () => {
   const navigation = useNavigation();
-  const wyreHistory = useAppSelector(
-    ({BUY_CRYPTO}: RootState) => BUY_CRYPTO.wyre,
-  );
-  const [wyrePaymentRequests, setTransactions] = useState(
-    [] as WyrePaymentData[],
-  );
-
-  useEffect(() => {
-    const _wyrePaymentRequests = Object.values(wyreHistory).filter(
-      pr => pr.env === (__DEV__ ? 'dev' : 'prod'),
-    );
-    setTransactions(_wyrePaymentRequests);
-  }, []);
 
   return (
     <SettingsComponent>
@@ -93,26 +77,22 @@ const ExternalServices = () => {
         </ExternalServicesItemContainer>
         <AngleRight />
       </Setting>
-      {wyrePaymentRequests?.length > 0 ? (
-        <>
-          <Hr />
-          <Setting
-            onPress={() => {
-              haptic('impactLight');
-              navigation.navigate('ExternalServicesSettings', {
-                screen: 'WyreSettings',
-              });
-            }}>
-            <ExternalServicesItemContainer>
-              <ExternalServicesIconContainer>
-                <WyreLogo iconOnly={true} width={30} height={25} />
-              </ExternalServicesIconContainer>
-              <SettingTitle>Wyre</SettingTitle>
-            </ExternalServicesItemContainer>
-            <AngleRight />
-          </Setting>
-        </>
-      ) : null}
+      <Hr />
+      <Setting
+        onPress={() => {
+          haptic('impactLight');
+          navigation.navigate('ExternalServicesSettings', {
+            screen: 'WyreSettings',
+          });
+        }}>
+        <ExternalServicesItemContainer>
+          <ExternalServicesIconContainer>
+            <WyreLogo iconOnly={true} width={30} height={25} />
+          </ExternalServicesIconContainer>
+          <SettingTitle>Wyre</SettingTitle>
+        </ExternalServicesItemContainer>
+        <AngleRight />
+      </Setting>
     </SettingsComponent>
   );
 };

--- a/src/navigation/tabs/settings/external-services/screens/WyreSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/WyreSettings.tsx
@@ -34,7 +34,6 @@ import {
 } from '../../../../../store/app/app.actions';
 import {sleep} from '../../../../../utils/helper-methods';
 import {useTranslation} from 'react-i18next';
-import {AppActions} from '../../../../../store/app';
 
 export interface WyreSettingsProps {
   incomingPaymentRequest?: WyrePaymentData;
@@ -54,25 +53,6 @@ const WyreSettings: React.FC = () => {
   const {incomingPaymentRequest, paymentRequestError} = route.params || {};
 
   useEffect(() => {
-    const showWyreWarning = async () => {
-      await sleep(600);
-      dispatch(
-        AppActions.showBottomNotificationModal({
-          title: t('Warning'),
-          message: t('Please note that Wyre is out of service.'),
-          type: 'warning',
-          actions: [
-            {
-              text: t('OK'),
-              action: () => {},
-            },
-          ],
-          enableBackdropDismiss: true,
-          onBackdropDismiss: () => {},
-        }),
-      );
-    };
-
     const handlePaymentError = async () => {
       await sleep(600);
       dispatch(
@@ -112,8 +92,6 @@ const WyreSettings: React.FC = () => {
     }
     if (paymentRequestError) {
       handlePaymentError();
-    } else {
-      showWyreWarning();
     }
   }, []);
 

--- a/src/store/buy-crypto/buy-crypto.effects.ts
+++ b/src/store/buy-crypto/buy-crypto.effects.ts
@@ -1,5 +1,6 @@
 import {getMoonpayFiatAmountLimits} from '../../navigation/services/buy-crypto/utils/moonpay-utils';
 import {getSimplexFiatAmountLimits} from '../../navigation/services/buy-crypto/utils/simplex-utils';
+import {getWyreFiatAmountLimits} from '../../navigation/services/buy-crypto/utils/wyre-utils';
 import {Effect} from '../index';
 import {LogActions} from '../log';
 import {BuyCryptoLimits} from './buy-crypto.models';
@@ -93,16 +94,22 @@ export const getBuyCryptoFiatLimits =
         baseFiatArray = ['USD'];
         limits = getSimplexFiatAmountLimits();
         break;
+      case 'wyre':
+        baseFiatArray = ['USD', 'EUR'];
+        limits = getWyreFiatAmountLimits(country?.shortCode || 'US');
+        break;
       default:
         baseFiatArray = ['USD', 'EUR'];
         limits = {
           min: Math.min(
             getMoonpayFiatAmountLimits().min,
             getSimplexFiatAmountLimits().min,
+            getWyreFiatAmountLimits(country?.shortCode || 'US').min,
           ),
           max: Math.max(
             getMoonpayFiatAmountLimits().max,
             getSimplexFiatAmountLimits().max,
+            getWyreFiatAmountLimits(country?.shortCode || 'US').max,
           ),
         };
         break;


### PR DESCRIPTION
Reverts bitpay/bitpay-app#622

It was recently decided that the Wyre integration will continue to work in our app, since it will continue to provide its services