### PR TITLE
get braze ios deep links working on app launch

### DIFF
--- a/ios/BitPayApp/AppDelegate.m
+++ b/ios/BitPayApp/AppDelegate.m
@@ -15,6 +15,7 @@
 #import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
 #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
 #import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+#import "AppboyReactUtils.h"
 
 #if RCT_DEV
 #import <React/RCTDevLoadingView.h>
@@ -63,6 +64,8 @@ static void InitializeFlipper(UIApplication *application) {
   [Appboy startWithApiKey:@"BRAZE_API_KEY_REPLACE_ME"
            inApplication:application
        withLaunchOptions:launchOptions];
+
+  [[AppboyReactUtils sharedInstance] populateInitialUrlFromLaunchOptions:launchOptions];
 
   return YES;
 }

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -6,6 +6,7 @@ import {
 } from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import debounce from 'lodash.debounce';
+import Braze from 'react-native-appboy-sdk';
 import React, {useEffect, useMemo, useState} from 'react';
 import {
   Appearance,
@@ -444,9 +445,16 @@ export default () => {
                 ),
               );
             } else {
-              const url = await Linking.getInitialURL();
+              const getBrazeInitialUrl = async (): Promise<string> =>
+                new Promise(resolve =>
+                  Braze.getInitialURL(deepLink => resolve(deepLink)),
+                );
+              const [url, brazeUrl] = await Promise.all([
+                Linking.getInitialURL(),
+                getBrazeInitialUrl(),
+              ]);
               await sleep(10);
-              urlEventHandler({url});
+              urlEventHandler({url: url || brazeUrl});
             }
 
             LogActions.info('QuickActions Initialized');


### PR DESCRIPTION
Currently, deep links from braze notifications are ignored on app launch (when the app is not yet running before a push notification is tapped). This PR fixes the issue.