### PR TITLE
Implement log persistence

### DIFF
--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -121,7 +121,7 @@ export const startAppInit = (): Effect => async (dispatch, getState) => {
     const {APP, BITPAY_ID, CONTACT, WALLET} = getState();
     const {network, pinLockActive, biometricLockActive, colorScheme} = APP;
 
-    WALLET.initLogs.forEach((log: string) => dispatch(LogActions.info(log)));
+    WALLET.initLogs.forEach(log => dispatch(log));
 
     dispatch(LogActions.debug(`Network: ${network}`));
     dispatch(LogActions.debug(`Theme: ${colorScheme || 'system'}`));

--- a/src/store/log/log.actions.ts
+++ b/src/store/log/log.actions.ts
@@ -1,4 +1,4 @@
-import {LogActionType, LogActionTypes} from './log.types';
+import {AddLog, LogActionType, LogActionTypes} from './log.types';
 import {LogEntry, LogLevel} from './log.models';
 
 export const clear = (): LogActionType => {
@@ -7,26 +7,27 @@ export const clear = (): LogActionType => {
   };
 };
 
-export const debug = (
-  ...messages: (string | null | undefined)[]
-): LogActionType => _log(LogLevel.Debug, ...messages);
+export const debug = (...messages: (string | null | undefined)[]): AddLog =>
+  _log(LogLevel.Debug, ...messages);
 
-export const info = (
-  ...messages: (string | null | undefined)[]
-): LogActionType => _log(LogLevel.Info, ...messages);
+export const info = (...messages: (string | null | undefined)[]): AddLog =>
+  _log(LogLevel.Info, ...messages);
 
-export const warn = (
-  ...messages: (string | null | undefined)[]
-): LogActionType => _log(LogLevel.Warn, ...messages);
+export const warn = (...messages: (string | null | undefined)[]): AddLog =>
+  _log(LogLevel.Warn, ...messages);
 
-export const error = (
-  ...messages: (string | null | undefined)[]
-): LogActionType => _log(LogLevel.Error, ...messages);
+export const error = (...messages: (string | null | undefined)[]): AddLog =>
+  _log(LogLevel.Error, ...messages);
+
+export const persistLog = ({payload}: AddLog): AddLog => ({
+  type: LogActionTypes.ADD_PERSISTED_LOG,
+  payload,
+});
 
 function _log(
   level: LogLevel,
   ...messages: (string | null | undefined)[]
-): LogActionType {
+): AddLog {
   if (__DEV__ && !!messages) {
     switch (LogLevel[level]) {
       case 'Debug':

--- a/src/store/log/log.reducer.ts
+++ b/src/store/log/log.reducer.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {LogEntry} from './log.models';
 import {LogActionType, LogActionTypes} from './log.types';
 
@@ -5,10 +6,12 @@ export const logReduxPersistBlackList = ['logs'];
 
 export interface LogState {
   logs: LogEntry[];
+  persistedLogs: LogEntry[];
 }
 
 const initialState: LogState = {
   logs: [] as LogEntry[],
+  persistedLogs: [] as LogEntry[],
 };
 
 export const logReducer = (
@@ -28,10 +31,27 @@ export const logReducer = (
         logs: [...state.logs, newLog],
       };
 
+    case LogActionTypes.ADD_PERSISTED_LOG:
+      const newPersistedLog = {
+        timestamp: action.payload.timestamp,
+        level: action.payload.level,
+        message: sanitizeLogMessage(action.payload.message),
+      };
+
+      return {
+        ...state,
+        logs: [...state.logs, newPersistedLog],
+        persistedLogs: [...state.persistedLogs, newPersistedLog],
+      };
+
     case LogActionTypes.CLEAR_LOGS:
+      const weekAgo = moment().subtract(7, 'day').toDate();
       return {
         ...state,
         logs: [],
+        persistedLogs: (state.persistedLogs || []).filter(
+          logEvent => new Date(logEvent.timestamp) > weekAgo,
+        ),
       };
 
     default:

--- a/src/store/log/log.types.ts
+++ b/src/store/log/log.types.ts
@@ -2,11 +2,12 @@ import {LogEntry} from './log.models';
 
 export enum LogActionTypes {
   ADD_LOG = 'LOG/ADD_LOG',
+  ADD_PERSISTED_LOG = 'LOG/ADD_PERSISTED_LOG',
   CLEAR_LOGS = 'LOG/CLEAR_LOGS',
 }
 
-interface AddLog {
-  type: typeof LogActionTypes.ADD_LOG;
+export interface AddLog {
+  type: typeof LogActionTypes.ADD_LOG | typeof LogActionTypes.ADD_PERSISTED_LOG;
   payload: LogEntry;
 }
 

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -9,8 +9,10 @@ import {
 import Flatted from 'flatted';
 import {buildWalletObj} from '../wallet/utils/wallet';
 import {ContactRowProps} from '../../components/list/ContactRow';
+import {AddLog} from '../log/log.types';
+import {LogActions} from '../log';
 const BWCProvider = BwcProvider.getInstance();
-const initLogs: string[] = [];
+const initLogs: AddLog[] = [];
 
 export const bindWalletClient = createTransform(
   // transform state on its way to being serialized and persisted.
@@ -57,12 +59,12 @@ export const bindWalletClient = createTransform(
               const errStr =
                 err instanceof Error ? err.message : JSON.stringify(err);
               const errorLog = `Failed to bindWalletClient - ${wallet.id} - ${errStr}`;
-              initLogs.push(errorLog);
+              initLogs.push(LogActions.persistLog(LogActions.error(errorLog)));
               console.error(errorLog);
               return undefined;
             }
             const successLog = `bindWalletClient - ${wallet.id}`;
-            initLogs.push(successLog);
+            initLogs.push(LogActions.info(successLog));
             console.log(successLog);
             // build wallet obj with bwc client credentials
             return merge(
@@ -113,12 +115,12 @@ export const bindWalletKeys = createTransform(
             const errStr =
               err instanceof Error ? err.message : JSON.stringify(err);
             const errorLog = `Failed to bindWalletKeys - ${id} - ${errStr}`;
-            initLogs.push(errorLog);
+            initLogs.push(LogActions.persistLog(LogActions.error(errorLog)));
             console.error(errorLog);
           }
         }
         const successLog = `bindKey - ${id}`;
-        initLogs.push(successLog);
+        initLogs.push(LogActions.info(successLog));
         console.log(successLog);
       }
       return outboundState;

--- a/src/store/wallet/wallet.reducer.ts
+++ b/src/store/wallet/wallet.reducer.ts
@@ -2,6 +2,7 @@ import {DeferredImport, Key, Token} from './wallet.models';
 import {WalletActionType, WalletActionTypes} from './wallet.types';
 import {FeeLevels} from './effects/fee/fee';
 import {CurrencyOpts} from '../../constants/currencies';
+import {AddLog} from '../log/log.types';
 
 type WalletReduxPersistBlackList = string[];
 export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [
@@ -32,7 +33,7 @@ export interface WalletState {
   queuedTransactions: boolean;
   enableReplaceByFee: boolean;
   deferredImport: null | DeferredImport;
-  initLogs: string[];
+  initLogs: AddLog[];
 }
 
 const initialState: WalletState = {


### PR DESCRIPTION
To persist a log for 7 days, wrap any logging call (e.g. `LogActions.error('message')`) in a `LogActions.persistLog()` call. Persisted logs appear in the new "Previous Sessions" section of the Session Log after the app is closed and reopened.

Example in the PR: https://github.com/bitpay/bitpay-app/pull/649/files#diff-26b3bdd77ae5fe7a321c95fab44e327692df02238a4928be27e73b55f4c815aaR62