### PR TITLE
Improve invoice web url scan handling

### DIFF
--- a/src/store/scan/scan.effects.ts
+++ b/src/store/scan/scan.effects.ts
@@ -90,9 +90,9 @@ export const incomingData =
 
     try {
       if (IsBitPayInvoiceWebUrl(data)) {
-        data = data
-          .replace('https://', 'https://link.')
-          .replace('/invoice?id=', '/i/');
+        const invoiceId = new URLSearchParams(data).get('id');
+        const origin = new URL(data).origin;
+        data = `${origin}/i/${invoiceId}`;
       }
       if (IsValidBitPayInvoice(data)) {
         dispatch(handleUnlock(data));

--- a/src/store/wallet/utils/validations.ts
+++ b/src/store/wallet/utils/validations.ts
@@ -21,7 +21,7 @@ const SanitizeUri = (data: string): string => {
 };
 
 export const IsBitPayInvoiceWebUrl = (data: string): boolean => {
-  return !!/^https:\/\/(www\.|link\.)?(test\.|staging\.)?bitpay\.com\/(invoice\?id=)\w+/.exec(
+  return !!/^https:\/\/(www\.|link\.)?(test\.|staging\.)?bitpay\.com\/(invoice\?)\w+/.exec(
     data,
   );
 };


### PR DESCRIPTION
Currently invoice web url scan handling only works if `id` is the first query param in the url. This PR ensures scan handling works regardless of the order the query params in the web url.