### PR TITLE
[FEAT] pre-commit sensitive information warning file

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Check if it's a rebase or cherry-pick operation
+BRANCH_NAME=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ -z "$BRANCH_NAME" ]; then
+  echo "Skipping pre-commit hook during rebase or cherry-pick"
+  exit 0
+fi
+#
+# This hook will look for code comments marked 'no-commit'
+#    - case-insensitive
+noCommitCount=$(git diff --no-ext-diff --cached | egrep -i --count "no-commit")
+if [ "$noCommitCount" -ne "0" ]; then
+   echo "WARNING: You are attempting to commit changes which include a 'no-commit'. Make sure you are not including sensitive information."
+   echo "Please check the following files:"
+   git diff --no-ext-diff --cached --name-only -i -G"no-commit" | sed 's/^/   - /'
+   echo
+   echo "You can ignore this warning by running the commit command with '--no-verify'"
+   exit 1
+fi

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<!-- no-commit -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bitpay.wallet">
 
@@ -63,7 +64,7 @@
         
         <meta-data
             android:name="AllowedUrlPrefixes"
-            android:value="ALLOWED-URL-PREFIXES-REPLACE-ME" />
+            android:value="https://bitpay.com,https://test.bitpay.com,https://staging.bitpay.com,https://bws.bitpay.com,https://www.coinbase.com,https://api.coinbase.com,https://api.1inch.io/v4.0/,https://api.coingecko.com/api/v3/simple/token_price/,https://checkout.simplexcc.com,https://sandbox.test-simplexcc.com,https://api.testwyre.com,https://api.sendwyre.com,https://api.zenledger.io/bitpay/wallets/,https://rest.iad-05.braze.com,https://sdk.iad-05.braze.com,https://cdn-settings.segment.com,https://api.segment.io,https://cloudflare-eth.com/,https://polygon-rpc.com/,https://matic-mumbai.chainstacklabs.com," />
 
         <activity
             android:screenOrientation="portrait"

--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- no-commit -->
 <resources>
   <string name="com_braze_api_key">BRAZE_API_KEY_REPLACE_ME</string>
   <string translatable="false" name="com_braze_custom_endpoint">sdk.iad-05.braze.com</string>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <network-security-config>
   <!-- Set cleartextTrafficPermitted = true for development -->
-  <base-config cleartextTrafficPermitted="false" />
-  <domain-config cleartextTrafficPermitted="false">
+  <base-config cleartextTrafficPermitted="true" />
+  <domain-config cleartextTrafficPermitted="true">
     <domain includeSubdomains="true">localhost</domain>
     <!-- Add your local IP here. -->
     <!--<domain includeSubdomains="true">127.0.0.1</domain>-->

--- a/ios/BitPayApp.xcodeproj/project.pbxproj
+++ b/ios/BitPayApp.xcodeproj/project.pbxproj
@@ -577,7 +577,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 52C9C1EF81310A6432521118 /* Pods-BitPayApp.debug.xcconfig */;
 			buildSettings = {
-				ALLOWED_URL_PREFIXES = "ALLOWED-URL-PREFIXES-REPLACE-ME";
+				ALLOWED_URL_PREFIXES = "https://bitpay.com,https://test.bitpay.com,https://staging.bitpay.com,https://bws.bitpay.com,https://www.coinbase.com,https://api.coinbase.com,https://api.1inch.io/v4.0/,https://api.coingecko.com/api/v3/simple/token_price/,https://checkout.simplexcc.com,https://sandbox.test-simplexcc.com,https://api.testwyre.com,https://api.sendwyre.com,https://api.zenledger.io/bitpay/wallets/,https://rest.iad-05.braze.com,https://sdk.iad-05.braze.com,https://cdn-settings.segment.com,https://api.segment.io,https://cloudflare-eth.com/,https://polygon-rpc.com/,https://matic-mumbai.chainstacklabs.com,";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
@@ -615,7 +615,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D065F59A146578B215CD6FE6 /* Pods-BitPayApp.release.xcconfig */;
 			buildSettings = {
-				ALLOWED_URL_PREFIXES = "ALLOWED-URL-PREFIXES-REPLACE-ME";
+				ALLOWED_URL_PREFIXES = "https://bitpay.com,https://test.bitpay.com,https://staging.bitpay.com,https://bws.bitpay.com,https://www.coinbase.com,https://api.coinbase.com,https://api.1inch.io/v4.0/,https://api.coingecko.com/api/v3/simple/token_price/,https://checkout.simplexcc.com,https://sandbox.test-simplexcc.com,https://api.testwyre.com,https://api.sendwyre.com,https://api.zenledger.io/bitpay/wallets/,https://rest.iad-05.braze.com,https://sdk.iad-05.braze.com,https://cdn-settings.segment.com,https://api.segment.io,https://cloudflare-eth.com/,https://polygon-rpc.com/,https://matic-mumbai.chainstacklabs.com,";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;

--- a/ios/BitPayApp/AppDelegate.m
+++ b/ios/BitPayApp/AppDelegate.m
@@ -1,3 +1,4 @@
+// no-commit
 #import "AppDelegate.h"
 #import "../AllowedUrlPrefixProtocol.h"
 #import "../SilentPushEvent.h"

--- a/scripts/allowed-url-prefixes.js
+++ b/scripts/allowed-url-prefixes.js
@@ -51,20 +51,22 @@ const allowedUrlPrefixes = [
 
 const allowedUrlPrefixString = allowedUrlPrefixes.join(',');
 
-let replaceArgs = ['ALLOWED-URL-PREFIXES-REPLACE-ME', allowedUrlPrefixString];
+let replaceIosArgs = [/ALLOWED_URL_PREFIXES\s*=\s*("(ALLOWED-URL-PREFIXES-REPLACE-ME|https:\/\/.*?)")/g, `ALLOWED_URL_PREFIXES = "${allowedUrlPrefixString}"`];
+let replaceAndroidArgs = [/android:value="(ALLOWED-URL-PREFIXES-REPLACE-ME|https:\/\/.*?)"/g, `android:value="${allowedUrlPrefixString}"`];
 
 if (isReset) {
-  replaceArgs = [replaceArgs[1], replaceArgs[0]];
+  replaceIosArgs = [replaceIosArgs[1], replaceIosArgs[0]];
+  replaceAndroidArgs = [replaceAndroidArgs[1], replaceAndroidArgs[0]];
 }
 
 fs.writeFileSync(
   xcodeProjectPath,
-  xcodeProjectContent.replaceAll(...replaceArgs),
+  xcodeProjectContent.replaceAll(...replaceIosArgs),
 );
 
 fs.writeFileSync(
   androidManifestPath,
-  androidManifestContent.replaceAll(...replaceArgs),
+  androidManifestContent.replaceAll(...replaceAndroidArgs),
 );
 
 console.log(


### PR DESCRIPTION
By default, Git looks for hooks in the `.git/hooks` directory, which is not version-controlled. To tell Git to use the custom `.githooks` directory instead, run the following command in the terminal: 

```
git config core.hooksPath .githooks
```

example: 

```
> git commit -m "..."            
WARNING: You are attempting to commit changes which include a 'no-commit'. Make sure you are not including sensitive information.
Please check the following files:
   - android/app/src/main/AndroidManifest.xml
   - android/app/src/main/res/values/braze.xml
   - ios/BitPayApp/AppDelegate.m

You can ignore this warning by running the commit command with '--no-verify'
```

Also I added the `ALLOWED-URL-PREFIXES-REPLACE-ME` values since there is no sensitive information there, it's always the same and it's always needed for running the app.
Same for `<base-config cleartextTrafficPermitted="true" />` always needed for running the app in dev mode