### PR TITLE
Ref:Reset EID and use only for push notifications

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -521,10 +521,6 @@ export default () => {
   // Silent Push Notifications
   useEffect(() => {
     function onMessageReceived(response: SilentPushEvent) {
-      console.log(
-        '##### Received Silent Push Notification',
-        JSON.stringify(response),
-      );
       dispatch(handleBwsEvent(response));
     }
     const eventEmitter = new NativeEventEmitter(NativeModules.SilentPushEvent);

--- a/src/navigation/tabs/settings/notifications/screens/PushNotifications.tsx
+++ b/src/navigation/tabs/settings/notifications/screens/PushNotifications.tsx
@@ -55,6 +55,9 @@ const PushNotifications = () => {
         DeviceEventEmitter.emit(DeviceEmitterEvents.PUSH_NOTIFICATIONS, {
           accepted,
         });
+        if (!accepted) {
+          dispatch(AppEffects.resetBrazeEid());
+        }
       },
     },
     {

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -1,4 +1,3 @@
-import {JsonMap} from '@segment/analytics-react-native';
 import BitAuth from 'bitauth';
 import i18n, {t} from 'i18next';
 import {debounce} from 'lodash';

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -58,7 +58,6 @@ export const startBitPayIdStoreInit =
         }
       }
 
-      dispatch(setBrazeEid(eid));
       dispatch(
         Analytics.identify(eid, {
           email,

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -26,7 +26,7 @@ import {getCoinAndChainFromCurrencyCode} from '../../navigation/bitpay-id/utils/
 import axios from 'axios';
 import {BASE_BITPAY_URLS} from '../../constants/config';
 import Braze from 'react-native-appboy-sdk';
-import {dismissOnGoingProcessModal, setBrazeEid} from '../app/app.actions';
+import {dismissOnGoingProcessModal} from '../app/app.actions';
 
 interface StartLoginParams {
   email: string;


### PR DESCRIPTION
* Turning off push notifications will generate new EID.
* If app get an error at init, reset EID.

Notes:

* Changing EID will stop receiving push notification since it has changed in Braze.
* Generate new EID if it doesn't exist and use it only for push notifications for logged and anonymous users.