### PR TITLE
[REF] remove current route from store

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -244,7 +244,6 @@ export default () => {
     ({APP}) => APP.checkingBiometricForSending,
   );
   const appColorScheme = useAppSelector(({APP}) => APP.colorScheme);
-  const cachedRoute = useAppSelector(({APP}) => APP.currentRoute);
   const appLanguage = useAppSelector(({APP}) => APP.defaultLanguage);
   const pinLockActive = useAppSelector(({APP}) => APP.pinLockActive);
   const failedAppInit = useAppSelector(({APP}) => APP.failedAppInit);
@@ -336,15 +335,6 @@ export default () => {
             const childRoute =
               parentRoute.state.routes[parentRoute.state.index || 0];
 
-            dispatch(
-              AppActions.setCurrentRoute([
-                parentRoute.name,
-                {
-                  screen: childRoute.name,
-                  params: childRoute.params,
-                },
-              ]),
-            );
             dispatch(
               LogActions.info(`Navigation event... ${parentRoute.name}`),
             );
@@ -581,18 +571,7 @@ export default () => {
           onReady={async () => {
             DeviceEventEmitter.emit(DeviceEmitterEvents.APP_NAVIGATION_READY);
 
-            // routing to previous route if onboarding
-            if (cachedRoute && !onboardingCompleted) {
-              const [cachedStack, cachedParams] = cachedRoute;
-              navigationRef.navigate(cachedStack, cachedParams);
-              dispatch(
-                LogActions.info(
-                  `Navigating to cached route... ${cachedStack} ${JSON.stringify(
-                    cachedParams,
-                  )}`,
-                ),
-              );
-            } else {
+            if (onboardingCompleted) {
               const getBrazeInitialUrl = async (): Promise<string> =>
                 new Promise(resolve =>
                   Braze.getInitialURL(deepLink => resolve(deepLink)),

--- a/src/store/app/app.actions.ts
+++ b/src/store/app/app.actions.ts
@@ -83,11 +83,6 @@ export const setColorScheme = (scheme: ColorSchemeName): AppActionType => ({
   payload: scheme,
 });
 
-export const setCurrentRoute = (route: any): AppActionType => ({
-  type: AppActionTypes.SET_CURRENT_ROUTE,
-  payload: route,
-});
-
 export const successGenerateAppIdentity = (
   network: Network,
   identity: AppIdentity,

--- a/src/store/app/app.reducer.ts
+++ b/src/store/app/app.reducer.ts
@@ -82,7 +82,6 @@ export interface AppState {
   onGoingProcessModalMessage: string | undefined;
   showBottomNotificationModal: boolean;
   bottomNotificationModalConfig: BottomNotificationConfig | undefined;
-  currentRoute: [keyof RootStackParamList, NavScreenParams] | undefined;
   notificationsAccepted: boolean;
   confirmedTxAccepted: boolean;
   announcementsAccepted: boolean;
@@ -157,7 +156,6 @@ const initialState: AppState = {
   onGoingProcessModalMessage: undefined,
   showBottomNotificationModal: false,
   bottomNotificationModalConfig: undefined,
-  currentRoute: undefined,
   notificationsAccepted: false,
   confirmedTxAccepted: false,
   announcementsAccepted: false,
@@ -296,12 +294,6 @@ export const appReducer = (
       return {
         ...state,
         colorScheme: action.payload,
-      };
-
-    case AppActionTypes.SET_CURRENT_ROUTE:
-      return {
-        ...state,
-        currentRoute: action.payload,
       };
 
     case AppActionTypes.SUCCESS_GENERATE_APP_IDENTITY:

--- a/src/store/app/app.types.ts
+++ b/src/store/app/app.types.ts
@@ -141,11 +141,6 @@ interface SetColorScheme {
   payload: ColorSchemeName;
 }
 
-interface SetCurrentRoute {
-  type: typeof AppActionTypes.SET_CURRENT_ROUTE;
-  payload: [keyof RootStackParamList, NavScreenParams];
-}
-
 interface SuccessGenerateAppIdentity {
   type: typeof AppActionTypes.SUCCESS_GENERATE_APP_IDENTITY;
   payload: {network: Network; identity: AppIdentity};
@@ -353,7 +348,6 @@ export type AppActionType =
   | DismissBottomNotificationModal
   | ResetBottomNotificationModalConfig
   | SetColorScheme
-  | SetCurrentRoute
   | SuccessGenerateAppIdentity
   | FailedGenerateAppIdentity
   | SetNotificationsAccepted


### PR DESCRIPTION
This definitely improves the app performance ( we were saving the currentRoute everytime we move to another view sometimes with huge params ) and fix the `data base or disk is full` for android
