### PR TITLE
[FIX] erc20 pending proposals view

### DIFF
--- a/src/navigation/wallet/screens/TransactionProposalDetails.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalDetails.tsx
@@ -240,8 +240,8 @@ const TransactionProposalDetails = () => {
   }, [transaction, wallet]);
 
   const getIcon = () => {
-    return SUPPORTED_CURRENCIES.includes(txs.coin) ? (
-      CurrencyListIcons[txs.coin]({width: 18, height: 18})
+    return SUPPORTED_CURRENCIES.includes(wallet.currencyAbbreviation) ? (
+      CurrencyListIcons[wallet.currencyAbbreviation]({width: 18, height: 18})
     ) : (
       <DefaultSvg width={18} height={18} />
     );


### PR DESCRIPTION
For showing the matic_eth wallet in the header we need bws changes. But, I think this way actually makes sense and lgtm ( showing the associated eth wallet )

![iPhone_14_Pro](https://user-images.githubusercontent.com/10999037/228955116-b937869b-a67e-45f0-b895-f878c234729a.png)
