### PR TITLE
[FIX] create topup invoice for matic tokens

### DIFF
--- a/src/navigation/wallet/screens/send/confirm/DebitCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/DebitCardConfirm.tsx
@@ -58,6 +58,7 @@ import {
 import {coinbasePayInvoice} from '../../../../../store/coinbase';
 import {useTranslation} from 'react-i18next';
 import {getTransactionCurrencyForPayInvoice} from '../../../../../store/coinbase/coinbase.effects';
+import {getCurrencyCodeFromCoinAndChain} from '../../../../bitpay-id/utils/bitpay-id-utils';
 
 export interface DebitCardConfirmParamList {
   amount: number;
@@ -205,7 +206,10 @@ const Confirm = () => {
     try {
       const {invoiceId, invoice: newInvoice} = await createTopUpInvoice({
         walletId: selectedWallet.id,
-        transactionCurrency: selectedWallet.currencyAbbreviation.toUpperCase(),
+        transactionCurrency: getCurrencyCodeFromCoinAndChain(
+          selectedWallet.currencyAbbreviation,
+          selectedWallet.chain,
+        ),
       });
       const baseUrl = BASE_BITPAY_URLS[network];
       const paymentUrl = `${baseUrl}/i/${invoiceId}`;


### PR DESCRIPTION
Selecting a matic token should create a matic invoice 

![IMG_8460](https://user-images.githubusercontent.com/10999037/229799452-4ed6a45a-23a9-4ff2-89b8-f292cfbe24f0.png)

![Flipper__0_184_0_](https://user-images.githubusercontent.com/10999037/229799468-e59b061c-ee0f-4f70-b6b7-ae03289a33a6.png)
