### PR TITLE
Fix: prevent multiple redir after link Coinbase account (only Android)

### DIFF
--- a/android/app/src/main/java/com/bitpay/wallet/MainActivity.java
+++ b/android/app/src/main/java/com/bitpay/wallet/MainActivity.java
@@ -61,6 +61,10 @@ public class MainActivity extends ReactActivity {
   public void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
     setIntent(intent);
+    // Clear the intent data so that the next time the Activity is opened,
+    // it will not be opened with old deeplink
+    Intent clonedIntent = getIntent();
+    clonedIntent.setData(null);
   }
 
   @Override


### PR DESCRIPTION
It also happens with any deeplinks (BitPay Card link, etc)

https://stackoverflow.com/questions/45676629/how-can-we-remove-deep-link-data-from-intent