### PR TITLE
Ref: check threshold for Coinbase payments. Show message if no wallet available. Single request for Invoice data

### DIFF
--- a/src/navigation/wallet/screens/send/SendTo.tsx
+++ b/src/navigation/wallet/screens/send/SendTo.tsx
@@ -447,16 +447,21 @@ const SendTo = () => {
         if (selected) {
           const isValid = dispatch(checkCoinAndNetwork(selected, true));
           if (isValid) {
-            navigation.navigate('Wallet', {
-              screen: WalletScreens.PAY_PRO_CONFIRM,
-              params: {
-                payProOptions,
+            await sleep(0);
+            dispatch(
+              incomingData(text, {
                 wallet,
-              },
-            });
+                context,
+                name,
+                email,
+                destinationTag,
+              }),
+            );
           }
         } else {
-          // TODO: handle me
+          dispatch(
+            showBottomNotificationModal(Mismatch(onErrorMessageDismiss)),
+          );
         }
       } catch (err) {
         const formattedErrMsg = BWCErrorMessage(err);

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -115,16 +115,15 @@ const PayProConfirm = () => {
   };
 
   const createTxp = async (selectedWallet: Wallet) => {
-    dispatch(startOnGoingProcessModal('FETCHING_PAYMENT_INFO'));
+    dispatch(startOnGoingProcessModal('CREATING_TXP'));
     try {
-      const fetchedInvoice = await fetchInvoice(payProOptions.payProUrl);
       const {txDetails: newTxDetails, txp: newTxp} = await dispatch(
         await createPayProTxProposal({
           wallet: selectedWallet,
           paymentUrl: payProOptions.payProUrl,
           payProOptions,
           invoiceID: payProOptions.paymentId,
-          invoice: fetchedInvoice,
+          invoice,
         }),
       );
       setWallet(selectedWallet);
@@ -133,13 +132,12 @@ const PayProConfirm = () => {
       dispatch(dismissOnGoingProcessModal());
       updateTxDetails(newTxDetails);
       updateTxp(newTxp);
-      setInvoice(fetchedInvoice);
       setRecipient({address: newTxDetails.sendingTo.recipientAddress} as {
         address: string;
       });
       dispatch(
         Analytics.track('BitPay App - Start Merchant Purchase', {
-          merchantBrand: fetchedInvoice.merchantName,
+          merchantBrand: invoice.merchantName,
         }),
       );
     } catch (err: any) {
@@ -191,26 +189,14 @@ const PayProConfirm = () => {
     );
   };
 
-  const fetchInvoice = async (payProUrl: string) => {
-    const invoiceId = payProUrl.split('/').slice(-1)[0];
-    const getInvoiceResponse = await axios.get(
-      `https://${payProHost}/invoices/${invoiceId}`,
-    );
-    const {
-      data: {data: fetchedInvoice},
-    } = getInvoiceResponse as {data: {data: Invoice}};
-    return fetchedInvoice;
-  };
-
   const onCoinbaseAccountSelect = async (walletRowProps: WalletRowProps) => {
-    dispatch(startOnGoingProcessModal('FETCHING_PAYMENT_INFO'));
+    dispatch(startOnGoingProcessModal('CREATING_TXP'));
     const selectedCoinbaseAccount = walletRowProps.coinbaseAccount!;
     try {
-      const fetchedInvoice = await fetchInvoice(payProOptions.payProUrl);
       const rates = await dispatch(startGetRates({}));
       const newTxDetails = dispatch(
         buildTxDetails({
-          invoice: fetchedInvoice,
+          invoice,
           wallet: walletRowProps,
           rates,
           defaultAltCurrencyIsoCode: defaultAltCurrency.isoCode,
@@ -218,12 +204,11 @@ const PayProConfirm = () => {
       );
       updateTxDetails(newTxDetails);
       updateTxp(undefined);
-      setInvoice(fetchedInvoice);
       setCoinbaseAccount(selectedCoinbaseAccount);
       dispatch(dismissOnGoingProcessModal());
       dispatch(
         Analytics.track('BitPay App - Start Merchant Purchase', {
-          merchantBrand: fetchedInvoice.merchantName,
+          merchantBrand: invoice.merchantName,
         }),
       );
     } catch (err) {

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -59,6 +59,7 @@ export interface PayProConfirmParamList {
   txp?: TransactionProposal;
   txDetails?: TxDetails;
   payProOptions: PayProOptions;
+  invoice: Invoice;
 }
 
 const PayProConfirm = () => {
@@ -72,6 +73,7 @@ const PayProConfirm = () => {
     recipient: _recipient,
     txDetails: _txDetails,
     txp: _txp,
+    invoice: _invoice,
   } = route.params!;
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
@@ -81,7 +83,7 @@ const PayProConfirm = () => {
   const [key, setKey] = useState(keys[_wallet ? _wallet.keyId : '']);
   const [coinbaseAccount, setCoinbaseAccount] =
     useState<CoinbaseAccountProps>();
-  const [invoice, setInvoice] = useState<Invoice>();
+  const [invoice, setInvoice] = useState<Invoice>(_invoice);
   const [wallet, setWallet] = useState(_wallet);
   const [recipient, setRecipient] = useState(_recipient);
   const [txDetails, updateTxDetails] = useState(_txDetails);
@@ -101,9 +103,10 @@ const PayProConfirm = () => {
           keys,
           defaultAltCurrencyIsoCode: defaultAltCurrency.isoCode,
           payProOptions,
+          invoice,
         }),
       ),
-    [defaultAltCurrency.isoCode, dispatch, keys, payProOptions],
+    [defaultAltCurrency.isoCode, dispatch, keys, payProOptions, invoice],
   );
 
   const reshowWalletSelector = async () => {
@@ -303,7 +306,6 @@ const PayProConfirm = () => {
     updateTxDetails(undefined);
     updateTxp(undefined);
     setWallet(undefined);
-    setInvoice(undefined);
     setCoinbaseAccount(undefined);
     showError({
       error,

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -13,7 +13,13 @@ import {
   Row,
   ScreenGutter,
 } from '../../../../../components/styled/Containers';
-import React, {ReactChild, useCallback, useEffect, useState} from 'react';
+import React, {
+  ReactChild,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import styled from 'styled-components/native';
 import {Pressable, ScrollView, View} from 'react-native';
 import {CurrencyImage} from '../../../../../components/currency-image/CurrencyImage';
@@ -484,6 +490,7 @@ export const WalletSelector = ({
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
   const [selectorVisible, setSelectorVisible] = useState(false);
+  const [showNoWallets, setShowNoWallets] = useState(false);
   const [autoSelectSingleWallet, setAutoSelectSingleWallet] = useState(
     typeof autoSelectIfOnlyOneWallet === 'undefined'
       ? true
@@ -540,11 +547,32 @@ export const WalletSelector = ({
     ],
   );
 
+  useMemo(() => {
+    let hasWallets: boolean = false;
+    let hasCoinbase: boolean = false;
+    for (const keyWallet of walletsAndAccounts.keyWallets) {
+      if (keyWallet.wallets.length > 0) {
+        hasWallets = true;
+      }
+    }
+    for (const coinbaseWallet of walletsAndAccounts.coinbaseWallets) {
+      if (coinbaseWallet.wallets.length > 0) {
+        hasCoinbase = true;
+      }
+    }
+
+    if (!hasWallets && !hasCoinbase) {
+      setShowNoWallets(true);
+    }
+  }, [dispatch, navigation, walletsAndAccounts]);
+
   useEffect(() => {
-    isVisible
+    isVisible && !showNoWallets
       ? showSelector(autoSelectSingleWallet)
+      : showNoWallets
+      ? dispatch(showNoWalletsModal({navigation}))
       : setSelectorVisible(false);
-  }, [autoSelectSingleWallet, isVisible, showSelector]);
+  }, [isVisible, showNoWallets]);
 
   return (
     <SheetModal isVisible={selectorVisible} onBackdropPress={onBackdropPress}>

--- a/src/store/shop/shop.models.ts
+++ b/src/store/shop/shop.models.ts
@@ -172,6 +172,12 @@ export interface Invoice {
   expirationTime: number;
   merchantName: string;
   currency: string;
+  oauth?: {
+    coinbase?: {
+      enabled: boolean;
+      threshold: number;
+    };
+  };
 }
 
 export interface PhoneCountryInfo {


### PR DESCRIPTION
* Do not show Coinbase wallets if it's not enabled for pay BitPay Invoice
* Removes duplicated http request for BitPay Invoice
* Show generic message if there're no wallets for selected BitPay Invoice