### PR TITLE
[REF] change default for RBF flag

### DIFF
--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -142,7 +142,7 @@ const Confirm = () => {
   const [showPaymentSentModal, setShowPaymentSentModal] = useState(false);
   const [resetSwipeButton, setResetSwipeButton] = useState(false);
   const [showTransactionLevel, setShowTransactionLevel] = useState(false);
-  const [enableRBF, setEnableRBF] = useState(false);
+  const [enableRBF, setEnableRBF] = useState(enableReplaceByFee);
   const [showSendingERC20Modal, setShowSendingERC20Modal] = useState(true);
 
   const {
@@ -382,7 +382,7 @@ const Confirm = () => {
           />
           {enableReplaceByFee &&
           !selectInputs &&
-          currencyAbbreviation === 'btc' ? (
+          currencyAbbreviation.toLowerCase() === 'btc' ? (
             <>
               <Setting activeOpacity={1}>
                 <SettingTitle>{t('Enable Replace-By-Fee')}</SettingTitle>

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -108,6 +108,7 @@ export const createProposalAndBuildTxDetails =
             feeLevel: cachedFeeLevel,
             useUnconfirmedFunds,
             queuedTransactions,
+            enableReplaceByFee,
           },
         } = getState();
         const {
@@ -149,6 +150,13 @@ export const createProposalAndBuildTxDetails =
               ),
             });
           }
+        }
+
+        if (
+          currencyAbbreviation === 'btc' &&
+          !(context && ['paypro', 'selectInputs'].includes(context))
+        ) {
+          tx.enableRBF = tx.enableRBF || enableReplaceByFee;
         }
 
         const tokenFeeLevel = token ? cachedFeeLevel.eth : undefined;


### PR DESCRIPTION
Since we are creating the transaction proposal before moving to the confirm view ( the only view that had the RBF option ) now checking for the `enableReplaceByFee` flag is needed in `createProposalAndBuildTxDetails`