### PR TITLE
Revert "Fix: speed up app startup using cached rates"

### DIFF
--- a/src/navigation/wallet/screens/CurrencySelection.tsx
+++ b/src/navigation/wallet/screens/CurrencySelection.tsx
@@ -53,7 +53,6 @@ import CurrencySelectionSearchInput from '../components/CurrencySelectionSearchI
 import CurrencySelectionNoResults from '../components/CurrencySelectionNoResults';
 import {orderBy} from 'lodash';
 import {Analytics} from '../../../store/analytics/analytics.effects';
-import {startGetTokenOptions} from '../../../store/wallet/effects/currencies/currencies';
 
 type CurrencySelectionScreenProps = StackScreenProps<
   WalletStackParamList,
@@ -780,10 +779,6 @@ const CurrencySelection: React.VFC<CurrencySelectionScreenProps> = ({
     },
     [memoizedOnToggle, memoizedOnViewAllPressed, selectionMode],
   );
-
-  useEffect(() => {
-    dispatch(startGetTokenOptions(true));
-  }, [dispatch]);
 
   return (
     <CurrencySelectionContainer accessibilityLabel="currency-selection-container">

--- a/src/store/wallet/effects/currencies/currencies.ts
+++ b/src/store/wallet/effects/currencies/currencies.ts
@@ -17,20 +17,14 @@ import {
   EVM_BLOCKCHAIN_ID,
 } from '../../../../constants/config';
 import {getCurrencyAbbreviation} from '../../../../utils/helper-methods';
-import {isEmpty} from 'lodash';
 
 export const startGetTokenOptions =
-  (force?: boolean): Effect<Promise<void>> =>
-  async (dispatch, getState) => {
+  (): Effect<Promise<void>> => async dispatch => {
     try {
       dispatch(LogActions.info('starting [startGetTokenOptions]'));
-      const {
-        WALLET: {tokenOptions, tokenOptionsByAddress, tokenData},
-      } = getState();
-      if (!force && !isEmpty(tokenData)) {
-        dispatch(LogActions.info('skipping [startGetTokenOptions]'));
-        return;
-      }
+      let tokenOptions: {[key in string]: Token} = {};
+      let tokenOptionsByAddress: {[key in string]: Token} = {};
+      let tokenData: {[key in string]: CurrencyOpts} = {};
       for await (const chain of SUPPORTED_EVM_COINS) {
         let {
           data: {tokens},

--- a/src/store/wallet/wallet.reducer.ts
+++ b/src/store/wallet/wallet.reducer.ts
@@ -5,7 +5,11 @@ import {CurrencyOpts} from '../../constants/currencies';
 import {AddLog} from '../log/log.types';
 
 type WalletReduxPersistBlackList = string[];
-export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [];
+export const walletReduxPersistBlackList: WalletReduxPersistBlackList = [
+  'tokenData',
+  'tokenOptions',
+  'tokenOptionsByAddress',
+];
 
 export type Keys = {
   [key in string]: Key;


### PR DESCRIPTION
Reverts bitpay/bitpay-app#747

In order to decrease the number of http requests that get a long list of tokens (no necessary all the time), we made this PR adding that information to the persist storage. But on Android there's a limit for storing data in the DB (6MB). We're getting this error: 

```
Error storing data [Error: database or disk is full (code 13 SQLITE_FULL[13])]
```

Solution would be doing the http request only where it's necessary. For the moment, we're going to keep doing request and no storing data in persist storage.

References:
https://github.com/react-native-async-storage/async-storage/issues/427