### PR TITLE
Feat: buyCrypto deeplink handling

### DIFF
--- a/src/navigation/services/buy-crypto/BuyCryptoStack.tsx
+++ b/src/navigation/services/buy-crypto/BuyCryptoStack.tsx
@@ -9,22 +9,14 @@ import {HeaderTitle} from '../../../components/styled/Text';
 import BuyCryptoRoot, {
   BuyCryptoRootScreenParams,
 } from './screens/BuyCryptoRoot';
-import BuyCryptoOffers from './screens/BuyCryptoOffers';
+import BuyCryptoOffers, {
+  BuyCryptoOffersScreenParams,
+} from './screens/BuyCryptoOffers';
 import {useTranslation} from 'react-i18next';
-import {BuyCryptoConfig} from '../../../store/external-services/external-services.types';
 
 export type BuyCryptoStackParamList = {
   BuyCryptoRoot: BuyCryptoRootScreenParams;
-  BuyCryptoOffers: {
-    amount: number;
-    fiatCurrency: string;
-    coin: string;
-    chain: string;
-    country: string;
-    selectedWallet: any;
-    paymentMethod: any;
-    buyCryptoConfig: BuyCryptoConfig | undefined;
-  };
+  BuyCryptoOffers: BuyCryptoOffersScreenParams;
 };
 
 export enum BuyCryptoScreens {

--- a/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
+++ b/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
@@ -8,6 +8,8 @@ import {
   ModalHeaderRight,
 } from '../styled/BuyCryptoModals';
 import {
+  BuyCryptoExchangeKey,
+  BuyCryptoSupportedExchanges,
   getEnabledPaymentMethods,
   isPaymentMethodSupported,
 } from '../utils/buy-crypto-utils';
@@ -33,6 +35,7 @@ interface PaymentMethodsModalProps {
   coin?: string;
   chain?: string;
   currency?: string;
+  preSetPartner?: BuyCryptoExchangeKey | undefined;
 }
 
 const PaymentMethodCard = styled.TouchableOpacity`
@@ -88,6 +91,7 @@ const PaymentMethodsModal = ({
   coin,
   currency,
   chain,
+  preSetPartner,
 }: PaymentMethodsModalProps) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
@@ -99,6 +103,7 @@ const PaymentMethodsModal = ({
     coin,
     chain,
     locationData?.countryShortCode || 'US',
+    preSetPartner,
   );
 
   const showOtherPaymentMethodsInfoSheet = (
@@ -127,6 +132,23 @@ const PaymentMethodsModal = ({
         ],
       }),
     );
+  };
+
+  const getPartnerLogo = (
+    exchange: BuyCryptoExchangeKey,
+  ): JSX.Element | null => {
+    switch (exchange) {
+      case 'moonpay':
+        return <MoonpayLogo key={exchange} widthIcon={20} heightIcon={20} />;
+      case 'ramp':
+        return <RampLogo key={exchange} width={65} height={15} />;
+      case 'simplex':
+        return <SimplexLogo key={exchange} widthIcon={20} heightIcon={20} />;
+      case 'wyre':
+        return <WyreLogo key={exchange} width={60} height={15} />;
+      default:
+        return null;
+    }
   };
 
   return (
@@ -194,55 +216,24 @@ const PaymentMethodsModal = ({
                         </PaymentMethodProviderText>
                       </PaymentMethodProvider>
                       <PaymentMethodProvider style={{height: 30}}>
-                        {coin &&
-                        currency &&
-                        chain &&
-                        isPaymentMethodSupported(
-                          'moonpay',
-                          paymentMethod,
-                          coin,
-                          chain,
-                          currency,
-                          locationData?.countryShortCode || 'US',
-                        ) ? (
-                          <MoonpayLogo widthIcon={20} heightIcon={20} />
-                        ) : null}
-                        {coin &&
-                        currency &&
-                        chain &&
-                        isPaymentMethodSupported(
-                          'ramp',
-                          paymentMethod,
-                          coin,
-                          chain,
-                          currency,
-                        ) ? (
-                          <RampLogo width={65} height={15} />
-                        ) : null}
-                        {coin &&
-                        currency &&
-                        chain &&
-                        isPaymentMethodSupported(
-                          'simplex',
-                          paymentMethod,
-                          coin,
-                          chain,
-                          currency,
-                        ) ? (
-                          <SimplexLogo widthIcon={20} heightIcon={20} />
-                        ) : null}
-                        {coin &&
-                        currency &&
-                        chain &&
-                        isPaymentMethodSupported(
-                          'wyre',
-                          paymentMethod,
-                          coin,
-                          chain,
-                          currency,
-                        ) ? (
-                          <WyreLogo width={60} height={15} />
-                        ) : null}
+                        {preSetPartner &&
+                        BuyCryptoSupportedExchanges.includes(preSetPartner)
+                          ? getPartnerLogo(preSetPartner)
+                          : BuyCryptoSupportedExchanges.map(exchange => {
+                              return coin &&
+                                currency &&
+                                chain &&
+                                isPaymentMethodSupported(
+                                  exchange,
+                                  paymentMethod,
+                                  coin,
+                                  chain,
+                                  currency,
+                                  locationData?.countryShortCode || 'US',
+                                )
+                                ? getPartnerLogo(exchange)
+                                : null;
+                            })}
                       </PaymentMethodProvider>
                     </PaymentMethodCheckboxTexts>
                   </PaymentMethodCardContainer>

--- a/src/navigation/services/buy-crypto/constants/BuyCryptoConstants.tsx
+++ b/src/navigation/services/buy-crypto/constants/BuyCryptoConstants.tsx
@@ -6,9 +6,17 @@ import ApplePayIcon from '../../../../../assets/img/services/payment-methods/app
 import BankIcon from '../../../../../assets/img/services/payment-methods/icon-bank.svg';
 import CreditCardIcon from '../../../../../assets/img/services/payment-methods/icon-creditcard.svg';
 import DebitCardIcon from '../../../../../assets/img/services/payment-methods/icon-debitcard.svg';
+import {BuyCryptoExchangeKey} from '../utils/buy-crypto-utils';
+
+export type PaymentMethodKey =
+  | 'applePay'
+  | 'creditCard'
+  | 'debitCard'
+  | 'sepaBankTransfer'
+  | 'other';
 
 export type PaymentMethods = {
-  [key in string]: PaymentMethod;
+  [key in PaymentMethodKey]: PaymentMethod;
 };
 
 export interface PaymentMethod {
@@ -16,7 +24,7 @@ export interface PaymentMethod {
   method: string;
   imgSrc: JSX.Element;
   supportedExchanges: {
-    [key in string]: boolean;
+    [key in BuyCryptoExchangeKey]: boolean;
   };
   enabled: boolean;
 }

--- a/src/store/buy-crypto/buy-crypto.effects.ts
+++ b/src/store/buy-crypto/buy-crypto.effects.ts
@@ -8,6 +8,7 @@ import {Effect} from '../index';
 import {LogActions} from '../log';
 import {BuyCryptoLimits} from './buy-crypto.models';
 import {Analytics} from '../analytics/analytics.effects';
+import {BuyCryptoExchangeKey} from '../../navigation/services/buy-crypto/utils/buy-crypto-utils';
 
 export const calculateAltFiatToUsd =
   (
@@ -76,7 +77,10 @@ export const calculateUsdToAltFiat =
   };
 
 export const getBuyCryptoFiatLimits =
-  (exchange?: string, fiatCurrency?: string): Effect<BuyCryptoLimits> =>
+  (
+    exchange?: BuyCryptoExchangeKey,
+    fiatCurrency?: string,
+  ): Effect<BuyCryptoLimits> =>
   (dispatch, getState) => {
     const state = getState();
     const locationData = state.LOCATION.locationData;

--- a/src/store/wallet/utils/validations.ts
+++ b/src/store/wallet/utils/validations.ts
@@ -43,6 +43,11 @@ export const isValidWalletConnectUri = (data: string): boolean => {
   return !!/(wallet\/wc|wc:)/g.exec(data);
 };
 
+export const isValidBuyCryptoUri = (data: string): boolean => {
+  data = SanitizeUri(data);
+  return !!data?.includes('buyCrypto');
+};
+
 export const isValidMoonpayUri = (data: string): boolean => {
   data = SanitizeUri(data);
   return !!data?.includes('moonpay');


### PR DESCRIPTION
In this PR I add the deeplinks handler with the possibility of presetting a partner so that it is the only one to be displayed.
I also added the possibility of presetting amount and coin if necessary

Examples:
```
bitpay://buyCrypto?partner=moonpay&coin=usdc&chain=eth&amount=100
bitpay://buyCrypto?partner=ramp&coin=btc&amount=200
bitpay://buyCrypto?partner=simplex
bitpay://buyCrypto?partner=wyre&amount=500
```


