### PR TITLE
Feat: Moonpay getCurrencylimits implemented

### DIFF
--- a/src/store/buy-crypto/buy-crypto.models.ts
+++ b/src/store/buy-crypto/buy-crypto.models.ts
@@ -3,6 +3,14 @@ export interface BuyCryptoLimits {
   max?: number;
 }
 
+export interface MoonpayGetCurrencyLimitsRequestData {
+  env: 'sandbox' | 'production';
+  currencyAbbreviation: string;
+  baseCurrencyCode: string;
+  areFeesIncluded?: boolean;
+  paymentMethod?: string;
+}
+
 export interface MoonpayPaymentData {
   address: string;
   chain: string;

--- a/src/store/buy-crypto/effects/moonpay/moonpay.ts
+++ b/src/store/buy-crypto/effects/moonpay/moonpay.ts
@@ -1,6 +1,35 @@
 import axios from 'axios';
+import {BASE_BWS_URL} from '../../../../constants/config';
+import {MoonpayGetCurrencyLimitsRequestData} from '../../buy-crypto.models';
 
-const bwsUri = 'https://bws.bitpay.com/bws/api';
+const bwsUri = BASE_BWS_URL;
+
+export const moonpayGetCurrencyLimits = async (
+  requestData: MoonpayGetCurrencyLimitsRequestData,
+): Promise<any> => {
+  try {
+    const config = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const {data} = await axios.post(
+      bwsUri + '/v1/service/moonpay/currencyLimits',
+      requestData,
+      config,
+    );
+
+    if (data instanceof Array) {
+      return Promise.resolve(data[0]);
+    } else {
+      return Promise.resolve(data);
+    }
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};
 
 export const moonpayGetTransactionDetails = async (
   transactionId?: string,


### PR DESCRIPTION
By implementing this function, we will obtain the limits for the selected values, prior to performing the getQuote, thus avoiding reporting continuous error events when users want to buy limit amounts.

This PR needs: https://github.com/bitpay/bitcore/pull/3593