### PR TITLE
Fix: goToPaypro confirm when "Pay In Wallet" of an invoice is clicked

### DIFF
--- a/src/store/scan/scan.effects.ts
+++ b/src/store/scan/scan.effects.ts
@@ -334,7 +334,8 @@ const handleUnlock =
             });
           }
         } else {
-          dispatch(goToPayPro(data, undefined, invoice, wallet));
+          const _invoice = invoice?.invoice || invoice;
+          dispatch(goToPayPro(data, undefined, _invoice, wallet));
         }
         return;
       }


### PR DESCRIPTION
![iPhone_14_Pro_Max](https://github.com/bitpay/bitpay-app/assets/10983458/9da73f6f-86f7-4309-9291-1f7a01281d2b)
