### PR TITLE
Ensure shop tab works well with new carousel package

### DIFF
--- a/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
@@ -61,6 +61,7 @@ const Curations = ({
             )}
             itemUnderlayColor={underlayColor}
             itemWidthInLastSlide={WIDTH}
+            itemHeight={85}
             maxItemsPerColumn={3}
             screenWidth={WIDTH}
             onItemPress={item => {

--- a/src/navigation/tabs/shop/components/ShopCarouselList.tsx
+++ b/src/navigation/tabs/shop/components/ShopCarouselList.tsx
@@ -37,6 +37,7 @@ export default ({
   items,
   itemComponent,
   itemWidth,
+  itemHeight,
   itemWidthInLastSlide,
   itemUnderlayColor,
   maxItemsPerColumn,
@@ -46,6 +47,7 @@ export default ({
   items: ShopCarouselItem[];
   itemComponent: (item: ShopCarouselItem) => JSX.Element;
   itemWidth?: number;
+  itemHeight: number;
   itemWidthInLastSlide?: number;
   itemUnderlayColor?: string;
   maxItemsPerColumn: number;
@@ -65,6 +67,7 @@ export default ({
   }, [] as any);
 
   const isSingleSlide = slides.length === 1;
+  const numRows = (slides[0] && slides[0].length) || 0;
 
   return (
     <Carousel
@@ -73,10 +76,13 @@ export default ({
       vertical={false}
       style={{width: screenWidth}}
       width={isSingleSlide ? screenWidth : carouselItemWidth}
-      height={isSingleSlide ? carouselItemWidth / 4 : carouselItemWidth * 1.3}
+      height={numRows * itemHeight}
       autoPlay={false}
       data={slides}
       scrollAnimationDuration={1000}
+      panGestureHandlerProps={{
+        activeOffsetX: [-10, 10],
+      }}
       enabled={!isSingleSlide}
       renderItem={({
         item,

--- a/src/navigation/tabs/shop/components/ShopOnline.tsx
+++ b/src/navigation/tabs/shop/components/ShopOnline.tsx
@@ -75,55 +75,58 @@ export const ShopOnline = ({
 
   const FullIntegrationsList = () => (
     <>
-      {categories.map(category => (
-        <View key={category.displayName}>
-          <SectionContainer>
-            <SectionHeaderContainer>
-              <SectionHeader>{category.displayName}</SectionHeader>
-              <TouchableWithoutFeedback
-                onPress={() => {
-                  navigation.navigate('Merchant', {
-                    screen: MerchantScreens.MERCHANT_CATEGORY,
-                    params: {
-                      category,
-                      integrations: category.integrations,
-                    },
-                  });
-                }}>
-                <SectionHeaderButton>{t('See all')}</SectionHeaderButton>
-              </TouchableWithoutFeedback>
-            </SectionHeaderContainer>
-          </SectionContainer>
-          <ShopCarouselList
-            items={category.integrations.slice(0, 5)}
-            itemComponent={(item: ShopCarouselItem) => {
-              const categoryHasDiscount = category.integrations.some(
-                merchant => !!merchant.discount,
-              );
-              const merchantItem = item as DirectIntegrationApiObject;
-              return (
-                <MerchantItem
-                  merchant={merchantItem}
-                  marginLeft={horizontalPadding}
-                  height={categoryHasDiscount ? 200 : 168}
-                  width={133}
-                />
-              );
-            }}
-            itemWidth={146}
-            maxItemsPerColumn={1}
-            screenWidth={WIDTH}
-            onItemPress={item =>
-              navigation.navigate('Merchant', {
-                screen: MerchantScreens.MERCHANT_DETAILS,
-                params: {
-                  directIntegration: item as DirectIntegrationApiObject,
-                },
-              })
-            }
-          />
-        </View>
-      ))}
+      {categories.map(category => {
+        const categoryHasDiscount = category.integrations.some(
+          merchant => !!merchant.discount,
+        );
+        return (
+          <View key={category.displayName}>
+            <SectionContainer>
+              <SectionHeaderContainer>
+                <SectionHeader>{category.displayName}</SectionHeader>
+                <TouchableWithoutFeedback
+                  onPress={() => {
+                    navigation.navigate('Merchant', {
+                      screen: MerchantScreens.MERCHANT_CATEGORY,
+                      params: {
+                        category,
+                        integrations: category.integrations,
+                      },
+                    });
+                  }}>
+                  <SectionHeaderButton>{t('See all')}</SectionHeaderButton>
+                </TouchableWithoutFeedback>
+              </SectionHeaderContainer>
+            </SectionContainer>
+            <ShopCarouselList
+              itemHeight={categoryHasDiscount ? 205 : 173}
+              items={category.integrations.slice(0, 5)}
+              itemComponent={(item: ShopCarouselItem) => {
+                const merchantItem = item as DirectIntegrationApiObject;
+                return (
+                  <MerchantItem
+                    merchant={merchantItem}
+                    marginLeft={horizontalPadding}
+                    height={categoryHasDiscount ? 200 : 168}
+                    width={133}
+                  />
+                );
+              }}
+              itemWidth={146}
+              maxItemsPerColumn={1}
+              screenWidth={WIDTH}
+              onItemPress={item =>
+                navigation.navigate('Merchant', {
+                  screen: MerchantScreens.MERCHANT_DETAILS,
+                  params: {
+                    directIntegration: item as DirectIntegrationApiObject,
+                  },
+                })
+              }
+            />
+          </View>
+        );
+      })}
     </>
   );
 

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -68,7 +68,10 @@ import {
 } from '../../../../constants/BiometricError';
 import {Platform} from 'react-native';
 import {Rates} from '../../../rate/rate.models';
-import {getCoinAndChainFromCurrencyCode} from '../../../../navigation/bitpay-id/utils/bitpay-id-utils';
+import {
+  getCoinAndChainFromCurrencyCode,
+  getCurrencyCodeFromCoinAndChain,
+} from '../../../../navigation/bitpay-id/utils/bitpay-id-utils';
 import {navigationRef} from '../../../../Root';
 import {WalletScreens} from '../../../../navigation/wallet/WalletStack';
 import {keyBackupRequired} from '../../../../navigation/tabs/home/components/Crypto';
@@ -354,13 +357,11 @@ export const getInvoiceEffectiveRate =
   (invoice: Invoice, coin: string, chain: string): Effect<number | undefined> =>
   dispatch => {
     const precision = dispatch(GetPrecision(coin, chain));
+    const invoiceCurrency = getCurrencyCodeFromCoinAndChain(coin, chain);
     return (
       precision &&
       invoice.price /
-        (invoice.paymentSubtotals[
-          invoice.buyerProvidedInfo!.selectedTransactionCurrency!
-        ] /
-          precision.unitToSatoshi)
+        (invoice.paymentSubtotals[invoiceCurrency] / precision.unitToSatoshi)
     );
   };
 
@@ -421,10 +422,11 @@ export const buildTxDetails =
     }
 
     const invoiceCurrency =
-      invoice?.buyerProvidedInfo!.selectedTransactionCurrency;
+      invoice?.buyerProvidedInfo!.selectedTransactionCurrency ||
+      wallet.currencyAbbreviation.toUpperCase();
 
     const isOffChain = !proposal;
-    if (invoiceCurrency) {
+    if (invoice && invoiceCurrency) {
       amount = isOffChain
         ? invoice.paymentSubtotals[invoiceCurrency]
         : invoice.paymentTotals[invoiceCurrency];


### PR DESCRIPTION
This PR restores the ability to vertically scroll the `gift cards` and `shop online` tabs and fixes some carousel spacing/height issues.

Also gets Coinbase payments working for invoices that don't yet have a transaction currency selected (e.g. mobile transfer).