### PR TITLE
Fix: percentage of total amount on confirm screen

### DIFF
--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -458,7 +458,7 @@ const Confirm = () => {
           {gasLimit !== undefined ? (
             <SharedDetailRow
               description={t('Gas limit')}
-              value={gasLimit}
+              value={gasLimit.toLocaleString()}
               onPress={() => editValue(t('Edit gas limit'), 'gasLimit')}
               hr
             />

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -269,6 +269,7 @@ export const Fee = ({
                 {feeLevel && !hideFeeOptions ? <H5>{viewFee}</H5> : null}
                 <H6>{cryptoAmount}</H6>
                 <ConfirmSubText>
+                  ~
                   {t(' ( of total amount)', {
                     fiatAmount,
                     percentageOfTotalAmountStr,

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -466,7 +466,28 @@ export const buildTxDetails =
     const effectiveRateForFee = isERC20 ? undefined : effectiveRate; // always use chain rates for fee values
 
     const {type, name, address, email} = recipient || {};
-    const percentageOfTotalAmount = (fee / (amount + fee)) * 100;
+    const feeToFiat = dispatch(
+      toFiat(
+        fee,
+        defaultAltCurrencyIsoCode,
+        chain,
+        chain,
+        rates,
+        effectiveRateForFee,
+      ),
+    );
+    const amountToFiat = dispatch(
+      toFiat(
+        amount,
+        defaultAltCurrencyIsoCode,
+        coin,
+        chain,
+        rates,
+        effectiveRate,
+      ),
+    );
+    const percentageOfTotalAmount =
+      (feeToFiat / (amountToFiat + feeToFiat)) * 100;
     return {
       context,
       currency: coin,
@@ -483,19 +504,7 @@ export const buildTxDetails =
         fee: {
           feeLevel,
           cryptoAmount: dispatch(FormatAmountStr(chain, chain, fee)),
-          fiatAmount: formatFiatAmount(
-            dispatch(
-              toFiat(
-                fee,
-                defaultAltCurrencyIsoCode,
-                chain,
-                chain,
-                rates,
-                effectiveRateForFee,
-              ),
-            ),
-            defaultAltCurrencyIsoCode,
-          ),
+          fiatAmount: formatFiatAmount(feeToFiat, defaultAltCurrencyIsoCode),
           percentageOfTotalAmountStr: `${percentageOfTotalAmount.toFixed(2)} %`,
           percentageOfTotalAmount,
         },
@@ -525,19 +534,7 @@ export const buildTxDetails =
       },
       subTotal: {
         cryptoAmount: dispatch(FormatAmountStr(coin, chain, amount)),
-        fiatAmount: formatFiatAmount(
-          dispatch(
-            toFiat(
-              amount,
-              defaultAltCurrencyIsoCode,
-              coin,
-              chain,
-              rates,
-              effectiveRate,
-            ),
-          ),
-          defaultAltCurrencyIsoCode,
-        ),
+        fiatAmount: formatFiatAmount(amountToFiat, defaultAltCurrencyIsoCode),
       },
       total: {
         cryptoAmount: isERC20
@@ -546,26 +543,7 @@ export const buildTxDetails =
             )}`
           : dispatch(FormatAmountStr(coin, chain, amount + fee)),
         fiatAmount: formatFiatAmount(
-          dispatch(
-            toFiat(
-              amount,
-              defaultAltCurrencyIsoCode,
-              coin,
-              chain,
-              rates,
-              effectiveRate,
-            ),
-          ) +
-            dispatch(
-              toFiat(
-                fee,
-                defaultAltCurrencyIsoCode,
-                chain,
-                chain,
-                rates,
-                effectiveRateForFee,
-              ),
-            ),
+          amountToFiat + feeToFiat,
           defaultAltCurrencyIsoCode,
         ),
       },

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -505,7 +505,7 @@ export const buildTxDetails =
           feeLevel,
           cryptoAmount: dispatch(FormatAmountStr(chain, chain, fee)),
           fiatAmount: formatFiatAmount(feeToFiat, defaultAltCurrencyIsoCode),
-          percentageOfTotalAmountStr: `${percentageOfTotalAmount.toFixed(2)} %`,
+          percentageOfTotalAmountStr: `${percentageOfTotalAmount.toFixed(2)}%`,
           percentageOfTotalAmount,
         },
       }),


### PR DESCRIPTION
* Fixed percent of total amount for ETH or MATIC 
* Added thousands separator for "Gas Limit" field.

![Screenshot 2023-09-20 at 11 22 17](https://github.com/bitpay/bitpay-app/assets/237435/17306f70-67e9-4812-9b30-14182103f2c3)

![Screenshot 2023-09-20 at 11 26 19](https://github.com/bitpay/bitpay-app/assets/237435/d74fd932-6b8c-484d-bb45-da2051bceb89)
