### PR TITLE
[FIX] rate calculation when creating using crypto amount instead of usd

### DIFF
--- a/src/store/shop/shop.models.ts
+++ b/src/store/shop/shop.models.ts
@@ -178,6 +178,7 @@ export interface Invoice {
       threshold: number;
     };
   };
+  usdAmount: number;
 }
 
 export interface PhoneCountryInfo {


### PR DESCRIPTION
Choosing any other currency than usd here https://bitpay.com/demos/ results in incorrect rate calculations