### PR TITLE
Fix: unlink Coinbase for invalid accounts

### DIFF
--- a/src/store/coinbase/coinbase.effects.ts
+++ b/src/store/coinbase/coinbase.effects.ts
@@ -204,6 +204,7 @@ export const coinbaseRefreshToken =
           'coinbaseRefreshToken: ' + coinbaseParseErrorToString(error),
         ),
       );
+      dispatch(coinbaseDisconnectAccount());
     }
   };
 


### PR DESCRIPTION
Coinbase stopped support for some regions and removed many user accounts. For this case, the app was trying to reconnect every time with error. This PR disconnect the account directly.