### PR TITLE
properly render redeemInstructions that contain html

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-native-rate": "1.2.12",
     "react-native-reanimated": "3.0.2",
     "react-native-reanimated-carousel": "3.5.1",
+    "react-native-render-html": "6.3.4",
     "react-native-restart": "0.0.27",
     "react-native-rounded-checkbox": "0.3.3",
     "react-native-safe-area-context": "4.5.0",

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import RNPrint from 'react-native-print';
+import RenderHtml from 'react-native-render-html';
 import TimeAgo from 'react-native-timeago';
 import {StackScreenProps} from '@react-navigation/stack';
 import styled from 'styled-components/native';
@@ -18,6 +19,7 @@ import {
   ActiveOpacity,
   CtaContainer,
   HeaderRightContainer,
+  WIDTH,
 } from '../../../../../components/styled/Containers';
 import {
   BaseText,
@@ -234,30 +236,47 @@ const GiftCardDetails = ({
     copiedValue: string,
     cardConfig: CardConfig,
     customMessage?: string,
-  ) =>
-    AppActions.showBottomNotificationModal({
+  ) => {
+    const redeemInstructions =
+      customMessage ||
+      cardConfig.redeemInstructions ||
+      t(
+        'Paste this code on . This gift card cannot be recovered if your claim code is lost.',
+        {website: cardConfig.website},
+      );
+    const containsHtml = redeemInstructions.includes('</');
+    const redeemHtml = redeemInstructions
+      .replaceAll(': \n', ': <br>')
+      .replaceAll('\n\n', '<br><br>');
+    const redeemTextStyle = {
+      color: theme.colors.text,
+      fontFamily,
+      fontSize: 16,
+      lineHeight: 24,
+    };
+    return AppActions.showBottomNotificationModal({
       type: 'success',
       title: t('Copied: ', {copiedValue}),
       message: '',
       message2: (
         <ScrollableBottomNotificationMessageContainer
           contentContainerStyle={{paddingBottom: 10}}>
-          <Markdown
-            style={{
-              body: {
-                color: theme.colors.text,
-                fontFamily,
-                fontSize: 16,
-                lineHeight: 24,
-              },
-            }}>
-            {customMessage ||
-              cardConfig.redeemInstructions ||
-              t(
-                'Paste this code on . This gift card cannot be recovered if your claim code is lost.',
-                {website: cardConfig.website},
-              )}
-          </Markdown>
+          {containsHtml ? (
+            <RenderHtml
+              baseStyle={redeemTextStyle}
+              contentWidth={WIDTH - 2 * horizontalPadding}
+              source={{
+                html: redeemHtml,
+              }}
+            />
+          ) : (
+            <Markdown
+              style={{
+                body: redeemTextStyle,
+              }}>
+              {redeemInstructions}
+            </Markdown>
+          )}
         </ScrollableBottomNotificationMessageContainer>
       ),
       enableBackdropDismiss: true,
@@ -269,6 +288,7 @@ const GiftCardDetails = ({
         },
       ],
     });
+  };
 
   const assetOptions: Array<Option> = [
     {


### PR DESCRIPTION
Currently, if redeem instructions contain HTML, the HTML tags are rendered as plain text which looks messy and hard to read. This PR ensures that redeem instructions containing HTML render properly.