### PR TITLE
[REF] move formatAmount function from bwc to helper methods

### DIFF
--- a/src/store/wallet/effects/amount/amount.ts
+++ b/src/store/wallet/effects/amount/amount.ts
@@ -1,6 +1,6 @@
 import {Effect} from '../../..';
-import {BwcProvider} from '../../../../lib/bwc';
-import {GetPrecision, IsCustomERCToken} from '../../utils/currency';
+import {GetPrecision} from '../../utils/currency';
+import {transformAmount} from '../../../../utils/helper-methods';
 import {SendMaxInfo, Wallet} from '../../wallet.models';
 import {GetMinFee} from '../fee/fee';
 const LOW_AMOUNT_RATIO = 0.15;
@@ -128,12 +128,12 @@ export const FormatAmount =
     fullPrecision?: boolean,
   ): Effect<string> =>
   dispatch => {
-    // TODO : now only works for english, specify opts to change thousand separator and decimal separator
-    let opts: any = {
-      fullPrecision: !!fullPrecision,
-    };
+    try {
+      // TODO : now only works for english, specify opts to change thousand separator and decimal separator
+      let opts: any = {
+        fullPrecision: !!fullPrecision,
+      };
 
-    if (tokenAddress && IsCustomERCToken(tokenAddress, chain)) {
       const {unitToSatoshi, unitDecimals} =
         dispatch(GetPrecision(currencyAbbreviation, chain, tokenAddress)) || {};
       if (unitToSatoshi) {
@@ -149,11 +149,11 @@ export const FormatAmount =
           minDecimals: 2,
         },
       };
-    }
 
-    return BwcProvider.getInstance()
-      .getUtils()
-      .formatAmount(satoshis, currencyAbbreviation.toLowerCase(), opts); // This util returns a string
+      return transformAmount(satoshis, opts);
+    } catch (e) {
+      throw e;
+    }
   };
 
 export const SatToUnit =

--- a/src/utils/helper-methods.ts
+++ b/src/utils/helper-methods.ts
@@ -7,6 +7,7 @@ import {ReactElement} from 'react';
 import {IsERCToken} from '../store/wallet/utils/currency';
 import {Rate, Rates} from '../store/rate/rate.models';
 import {PROTOCOL_NAME} from '../constants/config';
+import _ from 'lodash';
 
 export const sleep = (duration: number) =>
   new Promise<void>(resolve => setTimeout(resolve, duration));
@@ -375,4 +376,75 @@ export const getChainUsingSuffix = (symbol: string) => {
     default:
       return 'eth';
   }
+};
+
+export const transformAmount = (
+  satoshis: number,
+  opts: {
+    fullPrecision: string;
+    decimals: {
+      full: {
+        maxDecimals: number;
+        minDecimals: number;
+      };
+      short: {
+        maxDecimals: number;
+        minDecimals: number;
+      };
+    };
+    toSatoshis: number;
+    thousandsSeparator?: string;
+    decimalSeparator?: string;
+  },
+) => {
+  const MAX_DECIMAL_ANY_CHAIN = 18; // more that 14 gives rounding errors
+
+  const clipDecimals = (number: number, decimals: number) => {
+    let str = number.toString();
+    if (str.indexOf('e') >= 0) {
+      // fixes eth small balances
+      str = number.toFixed(MAX_DECIMAL_ANY_CHAIN);
+    }
+    var x = str.split('.');
+
+    var d = (x[1] || '0').substring(0, decimals);
+    const ret = parseFloat(x[0] + '.' + d);
+    return ret;
+  };
+
+  const addSeparators = (
+    nStr: string,
+    thousands: string,
+    decimal: string,
+    minDecimals: number,
+  ) => {
+    nStr = nStr.replace('.', decimal);
+    var x = nStr.split(decimal);
+    var x0 = x[0];
+    var x1 = x[1];
+
+    x1 = _.dropRightWhile(x1, (n, i) => {
+      return n == '0' && i >= minDecimals;
+    }).join('');
+    var x2 = x.length > 1 ? decimal + x1 : '';
+
+    x0 = x0.replace(/\B(?=(\d{3})+(?!\d))/g, thousands);
+    return x0 + x2;
+  };
+
+  const precision: keyof typeof opts.decimals = opts.fullPrecision
+    ? 'full'
+    : 'short';
+  const decimals = opts.decimals[precision];
+  const toSatoshis = opts.toSatoshis;
+  const amount = clipDecimals(
+    satoshis / toSatoshis,
+    decimals.maxDecimals,
+  ).toFixed(decimals.maxDecimals);
+  return addSeparators(
+    amount,
+    opts.thousandsSeparator || ',',
+    opts.decimalSeparator || '.',
+    decimals.minDecimals,
+  );
 };


### PR DESCRIPTION
In this way, we are no longer dependent on the CWC listing, as we have the accuracy values anyway.