### PR TITLE
[FIX] use `useNativeSegwit` wallet creation option properly

### DIFF
--- a/src/navigation/services/components/ToWalletSelectorModal.tsx
+++ b/src/navigation/services/components/ToWalletSelectorModal.tsx
@@ -68,7 +68,7 @@ import {
   DescriptionRow,
   TokensHeading,
 } from '../../../components/list/CurrencySelectionRow';
-import {IsUtxoCoin} from '../../../store/wallet/utils/currency';
+import {IsSegwitCoin} from '../../../store/wallet/utils/currency';
 import {SUPPORTED_EVM_COINS} from '../../../constants/currencies';
 
 const ModalHeader = styled.View`
@@ -329,7 +329,7 @@ const ToWalletSelectorModal: React.FC<ToWalletSelectorModalProps> = ({
       },
       options: {
         network: Network.mainnet,
-        useNativeSegwit: IsUtxoCoin(selectedCurrency.currencyAbbreviation),
+        useNativeSegwit: IsSegwitCoin(selectedCurrency.currencyAbbreviation),
         singleAddress: false,
         walletName: undefined,
       },

--- a/src/navigation/wallet/screens/AddWallet.tsx
+++ b/src/navigation/wallet/screens/AddWallet.tsx
@@ -92,7 +92,7 @@ import InfoSvg from '../../../../assets/img/info.svg';
 import {URL} from '../../../constants';
 import {useTranslation} from 'react-i18next';
 import {BitpayIdScreens} from '../../bitpay-id/BitpayIdGroup';
-import {IsERCToken} from '../../../store/wallet/utils/currency';
+import {IsERCToken, IsSegwitCoin} from '../../../store/wallet/utils/currency';
 import {updatePortfolioBalance} from '../../../store/wallet/wallet.actions';
 import {LogActions} from '../../../store/log';
 import CurrencySelectionRow from '../../../components/list/CurrencySelectionRow';
@@ -232,10 +232,7 @@ const AddWallet = ({
   const singleAddressCurrency =
     BitpaySupportedCoins[currencyAbbreviation?.toLowerCase() as string]
       ?.properties?.singleAddress;
-  const nativeSegwitCurrency = _currencyAbbreviation
-    ? ['btc', 'ltc'].includes(_currencyAbbreviation.toLowerCase())
-    : false;
-
+  const nativeSegwitCurrency = IsSegwitCoin(_currencyAbbreviation);
   const [useNativeSegwit, setUseNativeSegwit] = useState(nativeSegwitCurrency);
   const [evmWallets, setEvmWallets] = useState<Wallet[] | undefined>();
   const [UIFormattedEvmWallets, setUIFormattedEvmWallets] = useState<

--- a/src/navigation/wallet/screens/CreateMultisig.tsx
+++ b/src/navigation/wallet/screens/CreateMultisig.tsx
@@ -61,6 +61,7 @@ import {Analytics} from '../../../store/analytics/analytics.effects';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {RootStacks} from '../../../Root';
 import {TabsScreens} from '../../../navigation/tabs/TabsStack';
+import {IsSegwitCoin} from '../../../store/wallet/utils/currency';
 
 export interface CreateMultisigParamsList {
   currency: string;
@@ -184,7 +185,7 @@ const CreateMultisig: React.FC<CreateMultisigProps> = ({navigation, route}) => {
   const {t} = useTranslation();
   const logger = useLogger();
   const {currency, key} = route.params;
-  const segwitSupported = ['btc', 'ltc'].includes(currency.toLowerCase());
+  const segwitSupported = IsSegwitCoin(currency);
   const [showOptions, setShowOptions] = useState(false);
   const [testnetEnabled, setTestnetEnabled] = useState(false);
   const [options, setOptions] = useState({

--- a/src/store/wallet/effects/create/create.ts
+++ b/src/store/wallet/effects/create/create.ts
@@ -32,6 +32,7 @@ import {
 import {addTokenChainSuffix, sleep} from '../../../../utils/helper-methods';
 import {t} from 'i18next';
 import {LogActions} from '../../../log';
+import {IsSegwitCoin} from '../../utils/currency';
 export interface CreateOptions {
   network?: Network;
   account?: number;
@@ -283,7 +284,7 @@ const createMultipleWallets =
           coin: coin.currencyAbbreviation as SupportedCoins,
           options: {
             ...options,
-            useNativeSegwit: ['btc', 'ltc'].includes(coin.currencyAbbreviation),
+            useNativeSegwit: IsSegwitCoin(coin.currencyAbbreviation),
           },
         }),
       )) as Wallet;

--- a/src/store/wallet/utils/currency.ts
+++ b/src/store/wallet/utils/currency.ts
@@ -49,6 +49,10 @@ export const GetPrecision =
     );
   };
 
+export const IsSegwitCoin = (currencyAbbreviation: string = ''): boolean => {
+  return ['btc', 'ltc'].includes(currencyAbbreviation.toLowerCase());
+};
+
 export const IsUtxoCoin = (currencyAbbreviation: string): boolean => {
   return Object.keys(BitpaySupportedUtxoCoins).includes(
     currencyAbbreviation.toLowerCase(),


### PR DESCRIPTION
Only set the `useNativeSegwit` option for coins that support segwit when creating a new wallet.