### PR TITLE
Fix: backup encrypt pass request

### DIFF
--- a/src/navigation/wallet/screens/BackupOnboarding.tsx
+++ b/src/navigation/wallet/screens/BackupOnboarding.tsx
@@ -187,7 +187,7 @@ const BackupOnboarding: React.FC = () => {
             buttonStyle={'primary'}
             onPress={() => {
               haptic('impactLight');
-              if (!key.isPrivKeyEncrypted) {
+              if (!key.methods?.isPrivKeyEncrypted()) {
                 navigation.navigate('RecoveryPhrase', {
                   keyId: key.id,
                   words: getMnemonic(key),


### PR DESCRIPTION
Steps to reproduce the error:
1) Go to Settings -> Wallets & Keys -> (Select a Key) -> Enable: "Request Encrypt Password" -> Enter a new password
2) Go to Backup -> Write Down Recovery Phrase -> Enter your password
3) Go back and Disable "Request Encrypt Password"
4) Enter again in Backup -> Write Down Recovery Phrase
At this point the encrypt password will be requested again despite having been previously disabled. (Entering any password will be considered valid and you will enter the backup view).