### PR TITLE
Allow any BTC tx to be RBF'd (full RBF)

### DIFF
--- a/src/navigation/wallet/screens/TransactionDetails.tsx
+++ b/src/navigation/wallet/screens/TransactionDetails.tsx
@@ -458,7 +458,6 @@ const TransactionDetails = () => {
           ) : null}
 
           {currencyAbbreviation === 'btc' &&
-          txs.isRBF &&
           (IsSent(txs.action) || IsMoved(txs.action)) ? (
             <Banner
               type={'info'}

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -168,7 +168,7 @@ export const createProposalAndBuildTxDetails =
           currencyAbbreviation === 'btc' &&
           !(context && ['paypro', 'selectInputs'].includes(context))
         ) {
-          tx.enableRBF = tx.enableRBF || enableReplaceByFee;
+          tx.enableRBF = tx.enableRBF ?? enableReplaceByFee;
         }
 
         const tokenFeeLevel = token ? cachedFeeLevel.eth : undefined;


### PR DESCRIPTION
I've tested this locally. Just add `mempoolfullrbf=1` to your Bitcoin Core config.

Note: This also fixes a bug where deselecting RBF won't set `txp.enableRBF` to false. Not really necessary with full rbf, but nice to have code working correctly anyway :)