### PR TITLE
Fix: box input icons

### DIFF
--- a/src/components/form/BoxInput.tsx
+++ b/src/components/form/BoxInput.tsx
@@ -27,6 +27,7 @@ interface InputProps {
   isError?: boolean;
   type?: InputType;
   disabled?: boolean;
+  paddingRight?: number;
 }
 
 const InputContainer = styled.View<InputProps>`
@@ -36,6 +37,11 @@ const InputContainer = styled.View<InputProps>`
   flex-direction: row;
   justify-content: center;
   position: relative;
+  ${({paddingRight}) =>
+    paddingRight &&
+    css`
+      padding-right: ${paddingRight}px;
+    `}
 
   ${({isFocused}) =>
     isFocused &&
@@ -149,6 +155,7 @@ interface BoxInputProps extends TextInputProps {
   error?: any;
   type?: InputType;
   disabled?: boolean;
+  paddingRight?: number;
 }
 
 const BoxInput = React.forwardRef<
@@ -167,6 +174,7 @@ const BoxInput = React.forwardRef<
       type,
       disabled,
       keyboardType,
+      paddingRight,
       ...props
     },
     ref,
@@ -213,7 +221,8 @@ const BoxInput = React.forwardRef<
         <InputContainer
           isFocused={isFocused}
           isError={error}
-          disabled={disabled}>
+          disabled={disabled}
+          paddingRight={paddingRight}>
           {prefix ? <Prefix>{prefix()}</Prefix> : null}
 
           <Input

--- a/src/navigation/tabs/contacts/screens/ContactsAdd.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsAdd.tsx
@@ -92,14 +92,12 @@ const ScrollContainer = styled.ScrollView`
 `;
 
 const AddressBadge = styled.View`
-  background: ${({theme}) => (theme && theme.dark ? '#000' : '#fff')};
   position: absolute;
   right: 13px;
   top: 50%;
 `;
 
 const ScanButtonContainer = styled.TouchableOpacity`
-  background: ${({theme}) => (theme && theme.dark ? '#000' : '#fff')};
   position: absolute;
   right: 5px;
   top: 32px;
@@ -624,6 +622,7 @@ const ContactsAdd = ({
                   }}
                   error={errors.address?.message}
                   value={value}
+                  paddingRight={38}
                 />
               )}
               name="address"

--- a/src/navigation/wallet/screens/VerifyPhrase.tsx
+++ b/src/navigation/wallet/screens/VerifyPhrase.tsx
@@ -67,7 +67,6 @@ const HeaderText = styled(BaseText)`
 `;
 
 const ValidationBadge = styled.View`
-  background: ${({theme}) => (theme && theme.dark ? '#000' : '#fff')};
   position: absolute;
   right: 13px;
   top: 50%;


### PR DESCRIPTION
Removes the background and prevents the icon from overlapping the text