### PR TITLE
Fix: deeplinks handling when lock method is enabled

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -16,7 +16,6 @@ import {
   Linking,
   NativeEventEmitter,
   NativeModules,
-  Platform,
   StatusBar,
 } from 'react-native';
 import 'react-native-gesture-handler';
@@ -488,10 +487,7 @@ export default () => {
               }
             };
 
-            if (
-              (pinLockActive || biometricLockActive) &&
-              Platform.OS === 'ios'
-            ) {
+            if (pinLockActive || biometricLockActive) {
               const subscriptionToPinModalDismissed =
                 DeviceEventEmitter.addListener(
                   DeviceEmitterEvents.APP_LOCK_MODAL_DISMISSED,

--- a/src/components/modal/biometric/BiometricModal.tsx
+++ b/src/components/modal/biometric/BiometricModal.tsx
@@ -15,7 +15,12 @@ import TouchID from 'react-native-touch-id-ng';
 import styled from 'styled-components/native';
 import {BaseText} from '../../styled/Text';
 import BitpaySvg from '../../../../assets/img/wallet/transactions/bitpay.svg';
-import {Animated, TouchableOpacity, NativeModules} from 'react-native';
+import {
+  Animated,
+  TouchableOpacity,
+  NativeModules,
+  DeviceEventEmitter,
+} from 'react-native';
 import {
   TO_HANDLE_ERRORS,
   BiometricError,
@@ -25,6 +30,7 @@ import {
 import {LOCK_AUTHORIZED_TIME} from '../../../constants/Lock';
 import {showBottomNotificationModal} from '../../../store/app/app.actions';
 import {useTranslation} from 'react-i18next';
+import {DeviceEmitterEvents} from '../../../constants/device-emitter-events';
 
 const BiometricContainer = styled.View`
   flex: 1;
@@ -125,6 +131,7 @@ const BiometricModal: React.FC = () => {
         dispatch(AppActions.dismissBiometricModal());
         dispatch(AppActions.showBlur(false));
         onClose?.(true);
+        DeviceEventEmitter.emit(DeviceEmitterEvents.APP_LOCK_MODAL_DISMISSED);
       })
       .catch((error: BiometricError) => {
         if (error.code && TO_HANDLE_ERRORS[error.code]) {

--- a/src/components/modal/pin/PinModal.tsx
+++ b/src/components/modal/pin/PinModal.tsx
@@ -2,12 +2,19 @@ import {useNavigation} from '@react-navigation/native';
 import isEqual from 'lodash.isequal';
 import React, {useState, useEffect, useCallback, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Animated, TouchableOpacity, View, NativeModules} from 'react-native';
+import {
+  Animated,
+  DeviceEventEmitter,
+  TouchableOpacity,
+  View,
+  NativeModules,
+} from 'react-native';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import styled, {useTheme} from 'styled-components/native';
 import BitPayLogo from '../../../../assets/img/logos/bitpay-white.svg';
 import VirtualKeyboard from '../../../components/virtual-keyboard/VirtualKeyboard';
+import {DeviceEmitterEvents} from '../../../constants/device-emitter-events';
 import {LOCK_AUTHORIZED_TIME} from '../../../constants/Lock';
 import {BwcProvider} from '../../../lib/bwc';
 import {AppActions} from '../../../store/app';
@@ -126,6 +133,7 @@ const Pin = gestureHandlerRootHOC(() => {
         dispatch(AppActions.dismissPinModal()); // Correct PIN dismiss modal
         reset();
         onClose?.(true);
+        DeviceEventEmitter.emit(DeviceEmitterEvents.APP_LOCK_MODAL_DISMISSED);
       } else {
         setShakeDots(true);
         setMessage(t('Incorrect PIN, try again'));

--- a/src/constants/device-emitter-events.ts
+++ b/src/constants/device-emitter-events.ts
@@ -15,6 +15,11 @@ export enum DeviceEmitterEvents {
   APP_INIT_COMPLETED = 'APP_INIT_COMPLETED',
 
   /**
+   * Triggered when the PIN/Biometric modal is dismissed and app is ready to continue with pending tasks.
+   */
+  APP_LOCK_MODAL_DISMISSED = 'APP_LOCK_MODAL_DISMISSED',
+
+  /**
    * Triggered when the user has completed app onboarding.
    */
   APP_ONBOARDING_COMPLETED = 'APP_ONBOARDING_COMPLETED',

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -5,7 +5,12 @@ import {
   PathConfig,
 } from '@react-navigation/native';
 import {useMemo, useRef} from 'react';
-import {Linking} from 'react-native';
+import {
+  DeviceEventEmitter,
+  Linking,
+  NativeModules,
+  Platform,
+} from 'react-native';
 import AppsFlyer from 'react-native-appsflyer';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {
@@ -27,6 +32,8 @@ import useAppDispatch from './useAppDispatch';
 import {useLogger} from './useLogger';
 import {DebugScreens} from '../../navigation/Debug';
 import {GiftCardScreens} from '../../navigation/tabs/shop/gift-card/GiftCardGroup';
+import useAppSelector from './useAppSelector';
+import {DeviceEmitterEvents} from '../../constants/device-emitter-events';
 
 const getLinkingConfig = (): LinkingOptions<RootStackParamList>['config'] => ({
   initialRouteName: RootStacks.TABS,
@@ -142,6 +149,8 @@ export const useUrlEventHandler = () => {
 export const useDeeplinks = () => {
   const urlEventHandler = useUrlEventHandler();
   const logger = useLogger();
+  const {biometricLockActive, pinLockActive, lockAuthorizedUntil} =
+    useAppSelector(({APP}) => APP);
 
   const memoizedSubscribe = useMemo<
     LinkingOptions<RootStackParamList>['subscribe']
@@ -149,23 +158,54 @@ export const useDeeplinks = () => {
     () => listener => {
       const subscription = Linking.addEventListener('url', async ({url}) => {
         let handled = false;
-        const urlObj = new URL(url);
-        const urlParams = urlObj.searchParams;
+        const handleUrl = async () => {
+          const urlObj = new URL(url);
+          const urlParams = urlObj.searchParams;
 
-        if (!handled) {
-          const isAppsFlyerDeeplink = urlParams.get('af_deeplink') === 'true';
-          const hasEmbeddedDeepLink = !!urlParams.get('deep_link_value');
+          if (!handled) {
+            const isAppsFlyerDeeplink = urlParams.get('af_deeplink') === 'true';
+            const hasEmbeddedDeepLink = !!urlParams.get('deep_link_value');
 
-          // true if should be handled by AppsFlyer SDK
-          handled = !!(isAppsFlyerDeeplink && hasEmbeddedDeepLink);
-        }
+            // true if should be handled by AppsFlyer SDK
+            handled = !!(isAppsFlyerDeeplink && hasEmbeddedDeepLink);
+          }
 
-        if (!handled) {
-          handled = !!(await urlEventHandler({url}));
-        }
+          if (!handled) {
+            handled = !!(await urlEventHandler({url}));
+          }
 
-        if (!handled) {
-          listener(url);
+          if (!handled) {
+            listener(url);
+          }
+        };
+
+        if ((pinLockActive || biometricLockActive) && Platform.OS === 'ios') {
+          if (lockAuthorizedUntil) {
+            const timeSinceBoot = await NativeModules.Timer.getRelativeTime();
+            const totalSecs =
+              Number(lockAuthorizedUntil) - Number(timeSinceBoot);
+            if (totalSecs < 0) {
+              const subscription = DeviceEventEmitter.addListener(
+                DeviceEmitterEvents.APP_LOCK_MODAL_DISMISSED,
+                () => {
+                  subscription.remove();
+                  handleUrl();
+                },
+              );
+            } else {
+              handleUrl();
+            }
+          } else {
+            const subscription = DeviceEventEmitter.addListener(
+              DeviceEmitterEvents.APP_LOCK_MODAL_DISMISSED,
+              () => {
+                subscription.remove();
+                handleUrl();
+              },
+            );
+          }
+        } else {
+          handleUrl();
         }
       });
 
@@ -217,7 +257,13 @@ export const useDeeplinks = () => {
         appsFlyerUnsubscribe();
       };
     },
-    [logger, urlEventHandler],
+    [
+      logger,
+      urlEventHandler,
+      pinLockActive,
+      biometricLockActive,
+      lockAuthorizedUntil,
+    ],
   );
 
   const linkingOptions: LinkingOptions<RootStackParamList> = {

--- a/src/utils/hooks/useDeeplinks.ts
+++ b/src/utils/hooks/useDeeplinks.ts
@@ -5,12 +5,7 @@ import {
   PathConfig,
 } from '@react-navigation/native';
 import {useMemo, useRef} from 'react';
-import {
-  DeviceEventEmitter,
-  Linking,
-  NativeModules,
-  Platform,
-} from 'react-native';
+import {DeviceEventEmitter, Linking, NativeModules} from 'react-native';
 import AppsFlyer from 'react-native-appsflyer';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {
@@ -179,7 +174,7 @@ export const useDeeplinks = () => {
           }
         };
 
-        if ((pinLockActive || biometricLockActive) && Platform.OS === 'ios') {
+        if (pinLockActive || biometricLockActive) {
           if (lockAuthorizedUntil) {
             const timeSinceBoot = await NativeModules.Timer.getRelativeTime();
             const totalSecs =


### PR DESCRIPTION
How to reproduce the error:

iOS:
Enable the PIN/Biometric lock method:
- If the app is closed (Not in the background) and you click on a deeplink: There is a race between the lock modal and the navigation to the destination page. If the modal is showed before the navigation, then the app crashes and needs to restart.

Proposed solution: Wait for the lock modal to be successfully dismissed before performing the navigation.



- If the app is in the background there are 3 possible cases to take into account:
1) It has been minimized more than 20 seconds ago since the last unlock (`lockAuthorizedUntil`). So when you click on a deeplink, you return to the app, it shows the lock modal and a case similar to the previous one happens, in which a race occurs between the lock modal and the link navigation.

2) It has been minimized after the selected lock method has been successfully dismissed, and the deeplink has been clicked within 20 seconds (lockAuthorizedUntil), so the lock modal should not be displayed and only navigation should be performed.

3) The app has been minimized with the lock modal already open. In this case the lock modal should continue to be shown and wait for it to be correctly dismissed to continue with the link

Proposed solution: Control the `lockAuthorizedUntil` variable, to verify whether the time has been met or not. If the time is not met, the deeplink navigation is carried out normally. If the time has already passed or the modal was previously open, wait for the lock modal to be successfully dismissed before performing the navigation.



Android:
After some testing, it seems to work correctly, so no changes are necessary here.