### PR TITLE
Ensure iOS build works well with new react-navigation

### DIFF
--- a/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
+++ b/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
@@ -1,6 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
 import {Linking} from 'react-native';
+import {TouchableOpacity} from 'react-native-gesture-handler';
 import Braze, {ContentCard} from 'react-native-appboy-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import styled, {useTheme} from 'styled-components/native';
@@ -34,7 +35,7 @@ interface QuickLinksCardProps {
   ctaOverride?: () => void;
 }
 
-const QuickLinkCardContainer = styled.TouchableOpacity`
+const QuickLinkCardContainer = styled(TouchableOpacity)`
   justify-content: flex-start;
   align-items: center;
   flex-direction: row;

--- a/src/navigation/tabs/shop/components/ShopCarouselList.tsx
+++ b/src/navigation/tabs/shop/components/ShopCarouselList.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import styled, {css} from 'styled-components/native';
+import {TouchableHighlight} from 'react-native-gesture-handler';
 import Carousel from 'react-native-reanimated-carousel';
 import {
   CardConfig,
   DirectIntegrationApiObject,
 } from '../../../../store/shop/shop.models';
+import {ActiveOpacity} from '../../../../components/styled/Containers';
+
 interface SlideContainerParams {
   inLastSlide: boolean;
   isSingleSlide: boolean;
@@ -24,7 +27,9 @@ interface TouchableHighlightParams {
   width: number;
 }
 
-const ItemTouchableHighlight = styled.TouchableHighlight<TouchableHighlightParams>`
+const ItemTouchableHighlight = styled(
+  TouchableHighlight,
+)<TouchableHighlightParams>`
   ${({width}) =>
     css`
       width: ${width}px;
@@ -103,6 +108,7 @@ export default ({
                     ? carouselItemWidthInLastSlide
                     : carouselItemWidth
                 }
+                activeOpacity={ActiveOpacity}
                 key={listItem.displayName}
                 onPress={() => {
                   console.log('press', listItem.displayName);

--- a/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
@@ -15,7 +15,7 @@ import {
 import {sleep, formatFiatAmount} from '../../../../../utils/helper-methods';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
-import {ShopActions, ShopEffects} from '../../../../../store/shop';
+import {ShopEffects} from '../../../../../store/shop';
 import {BuildPayProWalletSelectorList} from '../../../../../store/wallet/utils/wallet';
 import {
   Amount,
@@ -129,13 +129,6 @@ const BillConfirm: React.VFC<
       ),
     [dispatch, invoice, keys],
   );
-
-  useEffect(() => {
-    return () => {
-      dispatch(ShopActions.deletedUnsoldGiftCards());
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -538,11 +531,11 @@ const BillConfirm: React.VFC<
       <PaymentSent
         isVisible={showPaymentSentModal}
         onCloseModal={async () => {
+          setShowPaymentSentModal(false);
+          await sleep(500);
           navigation.dispatch(StackActions.popToTop());
           navigation.dispatch(StackActions.pop());
           navigator.navigate(BillScreens.PAYMENTS, {});
-          await sleep(0);
-          setShowPaymentSentModal(false);
         }}
       />
     </ConfirmContainer>

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -460,6 +460,8 @@ const PayProConfirm = () => {
         <PaymentSent
           isVisible={showPaymentSentModal}
           onCloseModal={async () => {
+            setShowPaymentSentModal(false);
+            await sleep(500);
             navigation.dispatch(StackActions.popToTop());
             if (coinbaseAccount) {
               navigation.dispatch(StackActions.pop(3));
@@ -473,8 +475,7 @@ const PayProConfirm = () => {
                   walletId: wallet!.id,
                   key,
                 });
-            await sleep(0);
-            setShowPaymentSentModal(false);
+
           }}
         />
       </ConfirmScrollView>


### PR DESCRIPTION
Prevent `onPress` handler from firing while scrolling carousels horizontally on iOS.
Prevent crash on iOS when dismissing payment success modals on PayPro and Bill confirm screens.