### PR TITLE
Confirm, Coinbase and Gift Card Screen Fixes

### DIFF
--- a/src/navigation/coinbase/CoinbaseGroup.tsx
+++ b/src/navigation/coinbase/CoinbaseGroup.tsx
@@ -48,7 +48,6 @@ const CoinbaseGroup: React.FC<CoinbaseProps> = ({Coinbase}) => {
     <Coinbase.Group
       screenOptions={({navigation}) => ({
         ...baseNavigatorOptions,
-        headerShown: false,
         headerLeft: () => (
           <HeaderBackButton
             onPress={() => {
@@ -58,13 +57,7 @@ const CoinbaseGroup: React.FC<CoinbaseProps> = ({Coinbase}) => {
           />
         ),
       })}>
-      <Coinbase.Screen
-        name={CoinbaseScreens.ROOT}
-        component={CoinbaseRoot}
-        options={{
-          headerShown: true,
-        }}
-      />
+      <Coinbase.Screen name={CoinbaseScreens.ROOT} component={CoinbaseRoot} />
       <Coinbase.Screen
         name={CoinbaseScreens.SETTINGS}
         component={CoinbaseSettings}

--- a/src/navigation/coinbase/components/CoinbaseDashboard.tsx
+++ b/src/navigation/coinbase/components/CoinbaseDashboard.tsx
@@ -43,7 +43,7 @@ import {RootStacks} from '../../../Root';
 import {TabsScreens} from '../../../navigation/tabs/TabsStack';
 import {WalletScreens} from '../../../navigation/wallet/WalletGroup';
 
-const OverviewContainer = styled.View`
+const OverviewContainer = styled.SafeAreaView`
   flex: 1;
 `;
 

--- a/src/navigation/coinbase/screens/CoinbaseAccount.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseAccount.tsx
@@ -90,7 +90,7 @@ import {GroupCoinbaseTransactions} from '../../../store/wallet/effects/transacti
 import {Analytics} from '../../../store/analytics/analytics.effects';
 import {BitpaySupportedTokens} from '../../../constants/currencies';
 
-const AccountContainer = styled.View`
+const AccountContainer = styled.SafeAreaView`
   flex: 1;
 `;
 

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -429,8 +429,8 @@ const GiftCardDetails = ({
                 <Paragraph>{t('Claim Code')}</Paragraph>
                 {giftCard.barcodeImage && defaultClaimCodeType === 'barcode' ? (
                   <ScannableCodeContainer
-                    height={scannableCodeDimensions.height + 20}
-                    width={scannableCodeDimensions.width + 20}>
+                    height={scannableCodeDimensions.height + 40}
+                    width={scannableCodeDimensions.width + 40}>
                     <ScannableCode
                       height={scannableCodeDimensions.height}
                       width={scannableCodeDimensions.width}

--- a/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
@@ -360,7 +360,9 @@ const BillConfirm: React.VFC<
   };
 
   const handlePaymentFailure = async (error: any) => {
-    const handled = dispatch(handleSendError(error));
+    const handled = dispatch(
+      handleSendError({error, onDismiss: () => openWalletSelector(400)}),
+    );
     if (!handled) {
       if (wallet && txp) {
         await removeTxp(wallet, txp).catch(removeErr =>
@@ -372,13 +374,7 @@ const BillConfirm: React.VFC<
       setWallet(undefined);
       setInvoice(undefined);
       setCoinbaseAccount(undefined);
-      showError({
-        error,
-        defaultErrorMessage: t('Could not send transaction'),
-        onDismiss: () => openWalletSelector(400),
-      });
     }
-    await sleep(400);
     toggleThenUntoggle(setResetSwipeButton);
     dispatch(Analytics.track('Bill Pay — Failed Bill Paid', baseEventParams));
   };

--- a/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
@@ -9,10 +9,15 @@ import {
   buildTxDetails,
   createPayProTxProposal,
   handleCreateTxProposalError,
+  handleSendError,
   removeTxp,
   startSendPayment,
 } from '../../../../../store/wallet/effects/send/send';
-import {sleep, formatFiatAmount} from '../../../../../utils/helper-methods';
+import {
+  sleep,
+  formatFiatAmount,
+  toggleThenUntoggle,
+} from '../../../../../utils/helper-methods';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
 import {ShopEffects} from '../../../../../store/shop';
@@ -234,6 +239,7 @@ const BillConfirm: React.VFC<
       updateTxDetails(newTxDetails);
       setInvoice(newInvoice);
       setCoinbaseAccount(selectedCoinbaseAccount);
+      setWallet(undefined);
       setConvenienceFee(serviceFee);
       setSubtotal(totalBillAmount);
       dispatch(dismissOnGoingProcessModal());
@@ -292,6 +298,7 @@ const BillConfirm: React.VFC<
         }),
       );
       setWallet(selectedWallet);
+      setCoinbaseAccount(undefined);
       setKey(keys[selectedWallet.keyId]);
       updateTxDetails(newTxDetails);
       updateTxp(newTxp);
@@ -353,28 +360,31 @@ const BillConfirm: React.VFC<
   };
 
   const handlePaymentFailure = async (error: any) => {
-    if (wallet && txp) {
-      await removeTxp(wallet, txp).catch(removeErr =>
-        console.error('error deleting txp', removeErr),
-      );
+    const handled = dispatch(handleSendError(error));
+    if (!handled) {
+      if (wallet && txp) {
+        await removeTxp(wallet, txp).catch(removeErr =>
+          console.error('error deleting txp', removeErr),
+        );
+      }
+      updateTxDetails(undefined);
+      updateTxp(undefined);
+      setWallet(undefined);
+      setInvoice(undefined);
+      setCoinbaseAccount(undefined);
+      showError({
+        error,
+        defaultErrorMessage: t('Could not send transaction'),
+        onDismiss: () => openWalletSelector(400),
+      });
     }
-    updateTxDetails(undefined);
-    updateTxp(undefined);
-    setWallet(undefined);
-    setInvoice(undefined);
-    setCoinbaseAccount(undefined);
-    showError({
-      error,
-      defaultErrorMessage: t('Could not send transaction'),
-      onDismiss: () => openWalletSelector(400),
-    });
     await sleep(400);
-    setResetSwipeButton(true);
+    toggleThenUntoggle(setResetSwipeButton);
     dispatch(Analytics.track('Bill Pay — Failed Bill Paid', baseEventParams));
   };
 
   const request2FA = async () => {
-    navigation.navigate(WalletScreens.PAY_PRO_CONFIRM_TWO_FACTOR, {
+    navigator.navigate(WalletScreens.PAY_PRO_CONFIRM_TWO_FACTOR, {
       onSubmit: async twoFactorCode => {
         try {
           await sendPayment(twoFactorCode);
@@ -390,12 +400,12 @@ const BillConfirm: React.VFC<
         }
       },
     });
-    await sleep(400);
-    setResetSwipeButton(true);
+    toggleThenUntoggle(setResetSwipeButton);
   };
 
   useEffect(() => {
     openWalletSelector(100);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -353,7 +353,9 @@ const Confirm = () => {
   };
 
   const handlePaymentFailure = async (error: any) => {
-    const handled = dispatch(handleSendError(error));
+    const handled = dispatch(
+      handleSendError({error, onDismiss: () => openWalletSelector(400)}),
+    );
     if (!handled) {
       if (wallet && txp) {
         await removeTxp(wallet, txp).catch(removeErr =>
@@ -365,11 +367,6 @@ const Confirm = () => {
       setWallet(undefined);
       setInvoice(undefined);
       setCoinbaseAccount(undefined);
-      showError({
-        error,
-        defaultErrorMessage: t('Could not send transaction'),
-        onDismiss: () => openWalletSelector(400),
-      });
     }
     toggleThenUntoggle(setResetSwipeButton);
   };

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -17,12 +17,13 @@ import {
   buildTxDetails,
   createPayProTxProposal,
   handleCreateTxProposalError,
+  handleSendError,
   removeTxp,
   showConfirmAmountInfoSheet,
   startSendPayment,
 } from '../../../../../store/wallet/effects/send/send';
 import PaymentSent from '../../../components/PaymentSent';
-import {sleep} from '../../../../../utils/helper-methods';
+import {sleep, toggleThenUntoggle} from '../../../../../utils/helper-methods';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
 import {BuildPayProWalletSelectorList} from '../../../../../store/wallet/utils/wallet';
@@ -184,7 +185,7 @@ const PayProConfirm = () => {
   };
 
   useEffect(() => {
-    wallet ? createTxp(wallet) : setTimeout(() => openKeyWalletSelector(), 300);
+    wallet ? createTxp(wallet) : setTimeout(() => openKeyWalletSelector(), 500);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -192,7 +193,7 @@ const PayProConfirm = () => {
     setWalletSelectorVisible(true);
   };
 
-  const handleCreateGiftCardInvoiceOrTxpError = async (err: any) => {
+  const handleTxpError = async (err: any) => {
     await sleep(400);
     dispatch(dismissOnGoingProcessModal());
     const [errorConfig] = await Promise.all([
@@ -234,7 +235,7 @@ const PayProConfirm = () => {
         }),
       );
     } catch (err) {
-      handleCreateGiftCardInvoiceOrTxpError(err);
+      handleTxpError(err);
     }
   };
 
@@ -296,28 +297,28 @@ const PayProConfirm = () => {
         }
       },
     });
-    await sleep(400);
-    setResetSwipeButton(true);
+    toggleThenUntoggle(setResetSwipeButton);
   };
 
   const handlePaymentFailure = async (error: any) => {
-    dispatch(dismissOnGoingProcessModal());
-    if (wallet && txp) {
-      await removeTxp(wallet, txp).catch(removeErr =>
-        console.error('error deleting txp', removeErr),
-      );
+    const handled = dispatch(handleSendError(error));
+    if (!handled) {
+      if (wallet && txp) {
+        await removeTxp(wallet, txp).catch(removeErr =>
+          console.error('error deleting txp', removeErr),
+        );
+      }
+      updateTxDetails(undefined);
+      updateTxp(undefined);
+      setWallet(undefined);
+      setCoinbaseAccount(undefined);
+      showError({
+        error,
+        defaultErrorMessage: t('Could not send transaction'),
+        onDismiss: () => reshowWalletSelector(),
+      });
     }
-    updateTxDetails(undefined);
-    updateTxp(undefined);
-    setWallet(undefined);
-    setCoinbaseAccount(undefined);
-    showError({
-      error,
-      defaultErrorMessage: t('Could not send transaction'),
-      onDismiss: () => reshowWalletSelector(),
-    });
-    await sleep(400);
-    setResetSwipeButton(true);
+    toggleThenUntoggle(setResetSwipeButton);
     dispatch(
       Analytics.track('BitPay App - Failed Merchant Purchase', {
         merchantBrand: invoice?.merchantName,
@@ -475,7 +476,6 @@ const PayProConfirm = () => {
                   walletId: wallet!.id,
                   key,
                 });
-
           }}
         />
       </ConfirmScrollView>

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirm.tsx
@@ -301,7 +301,9 @@ const PayProConfirm = () => {
   };
 
   const handlePaymentFailure = async (error: any) => {
-    const handled = dispatch(handleSendError(error));
+    const handled = dispatch(
+      handleSendError({error, onDismiss: () => reshowWalletSelector()}),
+    );
     if (!handled) {
       if (wallet && txp) {
         await removeTxp(wallet, txp).catch(removeErr =>
@@ -312,11 +314,6 @@ const PayProConfirm = () => {
       updateTxp(undefined);
       setWallet(undefined);
       setCoinbaseAccount(undefined);
-      showError({
-        error,
-        defaultErrorMessage: t('Could not send transaction'),
-        onDismiss: () => reshowWalletSelector(),
-      });
     }
     toggleThenUntoggle(setResetSwipeButton);
     dispatch(

--- a/src/navigation/wallet/screens/send/confirm/PayProConfirmTwoFactor.tsx
+++ b/src/navigation/wallet/screens/send/confirm/PayProConfirmTwoFactor.tsx
@@ -3,7 +3,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useRef, useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
-import {Keyboard, TextInput} from 'react-native';
+import {Keyboard, SafeAreaView, TextInput} from 'react-native';
 import styled from 'styled-components/native';
 import Button from '../../../../../components/button/Button';
 import BoxInput from '../../../../../components/form/BoxInput';
@@ -66,52 +66,54 @@ const PayProConfirmTwoFactor = ({
   const onFormSubmit = handleSubmit(async ({code}) => submitForm(code));
 
   return (
-    <AuthFormContainer>
-      <AuthFormParagraph>
-        {t('Please enter your two-step verification code.')}
-      </AuthFormParagraph>
-      <AuthRowContainer>
-        <Controller
-          control={control}
-          render={({field: {onChange, onBlur, value}}) => (
-            <BoxInput
-              placeholder={twoFactorCodeLength === 6 ? '123123' : '1231234'}
-              label={t('TWO-STEP VERIFICATION CODE')}
-              onBlur={onBlur}
-              onChangeText={(text: string) => {
-                onChange(text);
-                const codeLength =
-                  twoFactorCodeLength || COINBASE_SMS_2FA_CODE_LENGTH;
-                if (text.length === codeLength) {
-                  submitForm(text);
+    <SafeAreaView>
+      <AuthFormContainer>
+        <AuthFormParagraph>
+          {t('Please enter your two-step verification code.')}
+        </AuthFormParagraph>
+        <AuthRowContainer>
+          <Controller
+            control={control}
+            render={({field: {onChange, onBlur, value}}) => (
+              <BoxInput
+                placeholder={twoFactorCodeLength === 6 ? '123123' : '1231234'}
+                label={t('TWO-STEP VERIFICATION CODE')}
+                onBlur={onBlur}
+                onChangeText={(text: string) => {
+                  onChange(text);
+                  const codeLength =
+                    twoFactorCodeLength || COINBASE_SMS_2FA_CODE_LENGTH;
+                  if (text.length === codeLength) {
+                    submitForm(text);
+                  }
+                }}
+                error={
+                  errors.code?.message
+                    ? t('Please enter a valid verification code.')
+                    : undefined
                 }
-              }}
-              error={
-                errors.code?.message
-                  ? t('Please enter a valid verification code.')
-                  : undefined
-              }
-              keyboardType={'numeric'}
-              textContentType="oneTimeCode"
-              autoFocus
-              value={value}
-              returnKeyType="next"
-              onSubmitEditing={() => codeRef.current?.focus()}
-              blurOnSubmit={false}
-            />
-          )}
-          name="code"
-        />
-      </AuthRowContainer>
+                keyboardType={'numeric'}
+                textContentType="oneTimeCode"
+                autoFocus
+                value={value}
+                returnKeyType="next"
+                onSubmitEditing={() => codeRef.current?.focus()}
+                blurOnSubmit={false}
+              />
+            )}
+            name="code"
+          />
+        </AuthRowContainer>
 
-      <AuthActionsContainer>
-        <PrimaryActionContainer>
-          <Button onPress={onFormSubmit} disabled={submitDisabled}>
-            {t('Continue')}
-          </Button>
-        </PrimaryActionContainer>
-      </AuthActionsContainer>
-    </AuthFormContainer>
+        <AuthActionsContainer>
+          <PrimaryActionContainer>
+            <Button onPress={onFormSubmit} disabled={submitDisabled}>
+              {t('Continue')}
+            </Button>
+          </PrimaryActionContainer>
+        </AuthActionsContainer>
+      </AuthFormContainer>
+    </SafeAreaView>
   );
 };
 

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -1783,9 +1783,9 @@ export const showConfirmAmountInfoSheet =
   };
 
 export const handleSendError =
-  (err: any): Effect<boolean> =>
+  ({error, onDismiss}: {error: any; onDismiss?: () => {}}): Effect<boolean> =>
   dispatch => {
-    switch (err) {
+    switch (error) {
       case 'invalid password':
         dispatch(showBottomNotificationModal(WrongPasswordError()));
         return true;
@@ -1793,6 +1793,19 @@ export const handleSendError =
       case 'biometric check failed':
         return true;
       default:
+        const errorMessage = error?.message || error;
+        dispatch(
+          AppActions.showBottomNotificationModal(
+            CustomErrorMessage({
+              title: t('Error'),
+              errMsg:
+                typeof errorMessage === 'string'
+                  ? errorMessage
+                  : t('Could not send transaction'),
+              action: () => onDismiss && onDismiss(),
+            }),
+          ),
+        );
         return false;
     }
   };

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -83,6 +83,7 @@ import {URL} from '../../../../constants';
 import {WCV2RequestType} from '../../../wallet-connect-v2/wallet-connect-v2.models';
 import {WALLET_CONNECT_SUPPORTED_CHAINS} from '../../../../constants/WalletConnectV2';
 import {TabsScreens} from '../../../../navigation/tabs/TabsStack';
+import {SupportedTokenOptions} from '../../../../constants/SupportedCurrencyOptions';
 
 export const createProposalAndBuildTxDetails =
   (
@@ -423,7 +424,8 @@ export const buildTxDetails =
     return new Promise(async resolve => {
       let gasPrice, gasLimit, nonce, destinationTag, coin, chain, amount, fee;
 
-      const tokenAddress = wallet.tokenAddress;
+      const tokenAddress =
+        wallet.tokenAddress || getTokenAddressForOffchainWallet(wallet);
 
       if (context === 'walletConnect' && request) {
         const {params} = request.params.request;
@@ -1809,3 +1811,10 @@ export const handleSendError =
         return false;
     }
   };
+
+function getTokenAddressForOffchainWallet(wallet: Wallet | WalletRowProps) {
+  return SupportedTokenOptions.find(
+    ({currencyAbbreviation}) =>
+      currencyAbbreviation === wallet.currencyAbbreviation.toLowerCase(),
+  )?.tokenAddress;
+}

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -37,6 +37,7 @@ import {
   CustomErrorMessage,
   ExcludedUtxosWarning,
   GeneralError,
+  WrongPasswordError,
 } from '../../../../navigation/wallet/components/ErrorMessages';
 import {BWCErrorMessage, getErrorName} from '../../../../constants/BWCError';
 import {Invoice} from '../../../shop/shop.models';
@@ -1779,4 +1780,19 @@ export const showConfirmAmountInfoSheet =
         ],
       }),
     );
+  };
+
+export const handleSendError =
+  (err: any): Effect<boolean> =>
+  dispatch => {
+    switch (err) {
+      case 'invalid password':
+        dispatch(showBottomNotificationModal(WrongPasswordError()));
+        return true;
+      case 'password canceled':
+      case 'biometric check failed':
+        return true;
+      default:
+        return false;
+    }
   };

--- a/src/utils/helper-methods.ts
+++ b/src/utils/helper-methods.ts
@@ -462,3 +462,11 @@ export const transformAmount = (
     decimals.minDecimals,
   );
 };
+
+export const toggleThenUntoggle = async (
+  booleanSetter: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  booleanSetter(true);
+  await sleep(500);
+  booleanSetter(false);
+};

--- a/src/utils/helper-methods.ts
+++ b/src/utils/helper-methods.ts
@@ -331,7 +331,7 @@ export const getRateByCurrencyName = (
   chain: string,
 ): Rate[] => {
   const currencyName = getCurrencyAbbreviation(currencyAbbreviation, chain);
-  return rates[currencyName];
+  return rates[currencyName] || rates[currencyAbbreviation];
 };
 
 export const addTokenChainSuffix = (name: string, chain: string) => {


### PR DESCRIPTION
1. Better handles common send errors in bill pay, gift card, and paypro confirm screens
2. Fixes Coinbase 2fa screen (ensures all content is displayed inside a SafeAreaView)
3. Falls back to displaying a claim link for a gift card that comes with a barcode when the barcode fails to generate
4. Fixes offchain Coinbase payments with ERC20 tokens
5. Improves reliability of gift card barcode scanning when using dark mode