### PR TITLE
Get BitPay ID settings working well with new navigation

### DIFF
--- a/src/navigation/bitpay-id/BitpayIdGroup.tsx
+++ b/src/navigation/bitpay-id/BitpayIdGroup.tsx
@@ -1,4 +1,3 @@
-import {useNavigation} from '@react-navigation/native';
 import React from 'react';
 import Button from '../../components/button/Button';
 import haptic from '../../components/haptic-feedback/haptic';
@@ -14,9 +13,6 @@ import Profile from './screens/ProfileSettings';
 import ReceiveSettings from './screens/ReceiveSettings';
 import {useTranslation} from 'react-i18next';
 import ReceivingEnabled from './screens/ReceivingEnabled';
-import PayProConfirmTwoFactor, {
-  PayProConfirmTwoFactorParamList,
-} from '../wallet/screens/send/confirm/PayProConfirmTwoFactor';
 import EnableTwoFactor, {
   EnableTwoFactorScreenParamList,
 } from './screens/EnableTwoFactor';
@@ -39,7 +35,6 @@ export type BitpayIdGroupParamList = {
   BitPayIdProfile: undefined;
   ReceiveSettings: undefined;
   ReceivingEnabled: undefined;
-  TwoFactor: PayProConfirmTwoFactorParamList;
   EnableTwoFactor: EnableTwoFactorScreenParamList;
   TwoFactorEnabled: TwoFactorEnabledScreenParamList;
 };

--- a/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
+++ b/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
@@ -26,6 +26,7 @@ import haptic from '../../../components/haptic-feedback/haptic';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 import {useTranslation} from 'react-i18next';
+import {WalletScreens} from '../../../navigation/wallet/WalletGroup';
 
 const EnableTwoFactorContainer = styled.SafeAreaView`
   flex: 1;
@@ -91,7 +92,7 @@ const QRContainer = styled.View`
     dark
       ? `
   background-color: ${White};
-  padding: 10px;
+  padding: 15px;
   margin-left: 15px;
   border-radius: 6px;
   `
@@ -168,7 +169,7 @@ const EnableTwoFactor = ({route, navigation}: EnableTwoFactorProps) => {
     await requestTwoFactorChange(twoFactorCode);
     await dispatch(dismissOnGoingProcessModal());
     if (otpEnabled) {
-      navigation.popToTop();
+      navigation.pop(2);
       return;
     }
     navigator.navigate(BitpayIdScreens.TWO_FACTOR_ENABLED);
@@ -238,7 +239,7 @@ const EnableTwoFactor = ({route, navigation}: EnableTwoFactorProps) => {
               <Button
                 buttonStyle={'primary'}
                 onPress={() => {
-                  navigator.navigate(BitpayIdScreens.TWO_FACTOR, {
+                  navigator.navigate(WalletScreens.PAY_PRO_CONFIRM_TWO_FACTOR, {
                     onSubmit: async (twoFactorCode: string) => {
                       toggleTwoFactor(twoFactorCode);
                     },

--- a/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
@@ -147,7 +147,7 @@ type ReceiveSettingsProps = NativeStackScreenProps<
   BitpayIdScreens.RECEIVE_SETTINGS
 >;
 
-const ReceiveSettings = ({route}: ReceiveSettingsProps) => {
+const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const navigator = useNavigation();
@@ -299,7 +299,7 @@ const ReceiveSettings = ({route}: ReceiveSettingsProps) => {
     await dispatch(dismissOnGoingProcessModal());
     return !receivingAddresses.length && newReceivingAddresses.length
       ? navigator.navigate(BitpayIdScreens.RECEIVING_ENABLED)
-      : navigation.popToTop();
+      : navigation.pop();
   };
 
   useEffect(() => {
@@ -515,7 +515,7 @@ const ReceiveSettings = ({route}: ReceiveSettingsProps) => {
         }}>
         <Button
           onPress={() =>
-            navigator.navigate(BitpayIdScreens.TWO_FACTOR, {
+            navigator.navigate(WalletScreens.PAY_PRO_CONFIRM_TWO_FACTOR, {
               onSubmit: async (twoFactorCode: string) => {
                 saveAddresses(twoFactorCode).catch(async error => {
                   dispatch(dismissOnGoingProcessModal());
@@ -545,8 +545,9 @@ const ReceiveSettings = ({route}: ReceiveSettingsProps) => {
       />
       <TwoFactorRequiredModal
         isVisible={twoFactorModalRequiredVisible}
-        onClose={enable => {
+        onClose={async enable => {
           setTwoFactorModalRequiredVisible(false);
+          await sleep(500);
           navigation.pop();
           if (enable) {
             navigator.navigate(BitpayIdScreens.ENABLE_TWO_FACTOR);

--- a/src/navigation/bitpay-id/screens/ReceivingEnabled.tsx
+++ b/src/navigation/bitpay-id/screens/ReceivingEnabled.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import {t} from 'i18next';
 import Button from '../../../components/button/Button';
 import {Br, HEIGHT} from '../../../components/styled/Containers';
 import SuccessSvg from '../../../../assets/img/success.svg';
@@ -58,7 +57,7 @@ const EmailText = styled(BaseText)`
   font-weight: 500;
 `;
 
-const ReceivingEnabled = ({route, navigation}: ReceivingEnabledProps) => {
+const ReceivingEnabled = ({navigation}: ReceivingEnabledProps) => {
   const {t} = useTranslation();
   const user = useAppSelector(
     ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
@@ -83,7 +82,7 @@ const ReceivingEnabled = ({route, navigation}: ReceivingEnabledProps) => {
           <SuccessSvg height={20} width={20} />
         </EmailContainer>
       </ViewBody>
-      <Button buttonStyle={'primary'} onPress={() => navigation.popToTop()}>
+      <Button buttonStyle={'primary'} onPress={() => navigation.pop(3)}>
         {t('Go back to settings')}
       </Button>
     </ViewContainer>

--- a/src/navigation/bitpay-id/screens/TwoFactorEnabled.tsx
+++ b/src/navigation/bitpay-id/screens/TwoFactorEnabled.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import {t} from 'i18next';
 import Button from '../../../components/button/Button';
 import {HEIGHT} from '../../../components/styled/Containers';
 import SuccessSvg from '../../../../assets/img/success.svg';
@@ -30,7 +29,7 @@ const ViewBody = styled.View`
   padding-bottom: 100px;
 `;
 
-const TwoFactorEnabled = ({route, navigation}: TwoFactorEnabledProps) => {
+const TwoFactorEnabled = ({navigation}: TwoFactorEnabledProps) => {
   const {t} = useTranslation();
   return (
     <ViewContainer>
@@ -40,7 +39,7 @@ const TwoFactorEnabled = ({route, navigation}: TwoFactorEnabledProps) => {
           <H3>{t('Two-Factor Authentication is now enabled')}</H3>
         </TextAlign>
       </ViewBody>
-      <Button buttonStyle={'primary'} onPress={() => navigation.popToTop()}>
+      <Button buttonStyle={'primary'} onPress={() => navigation.pop(2)}>
         {t('Go back to settings')}
       </Button>
     </ViewContainer>


### PR DESCRIPTION
This PR fixes the following BitPay ID settings features:

1. 2FA enabling/disabling
2. Managing "Receive via Email Address" wallet addresses