### PR TITLE
Fix Shop tab "Pay Bills" behavior and fix token icons

### DIFF
--- a/src/components/currency-image/CurrencyImage.tsx
+++ b/src/components/currency-image/CurrencyImage.tsx
@@ -24,7 +24,7 @@ const BadgeContainer = styled.View<{size?: number}>`
   height: ${({size = 54}) => size}%;
   width: ${({size = 54}) => size}%;
   position: absolute;
-  right: 0;
+  right: -2px;
   bottom: 0;
 `;
 

--- a/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
@@ -88,7 +88,7 @@ const AddressItem = styled.View`
 
 const AddressItemText = styled(Paragraph)`
   flex-grow: 1;
-  margin-left: 0px;
+  margin-left: 1px;
 `;
 
 const AddressPillContainer = styled.View`

--- a/src/navigation/tabs/shop/ShopHome.tsx
+++ b/src/navigation/tabs/shop/ShopHome.tsx
@@ -341,6 +341,18 @@ const ShopHome: React.FC<
               screenListeners={{
                 tabPress: tab => {
                   if (tab.target) {
+                    if (tab.target.includes(ShopTabs.BILLS)) {
+                      tab.preventDefault();
+                      navigation.navigate('Tabs', {
+                        screen: 'Bills',
+                      });
+                      dispatch(
+                        Analytics.track('Bill Pay - Clicked Bill Pay', {
+                          context: 'Shop Tab',
+                        }),
+                      );
+                      return;
+                    }
                     setActiveTab(
                       tab.target.includes(ShopTabs.GIFT_CARDS)
                         ? ShopTabs.GIFT_CARDS
@@ -348,13 +360,6 @@ const ShopHome: React.FC<
                         ? ShopTabs.BILLS
                         : ShopTabs.SHOP_ONLINE,
                     );
-                    if (tab.target.includes(ShopTabs.BILLS)) {
-                      dispatch(
-                        Analytics.track('Bill Pay - Clicked Bill Pay', {
-                          context: 'Shop Tab',
-                        }),
-                      );
-                    }
                   }
                 },
               }}>

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -635,6 +635,8 @@ export const WalletSelector = ({
 
 const CurrencyImageAndBadgeContainer = styled.View<{height: number}>`
   height: ${({height}) => height}px;
+  margin-left: 13px;
+  margin-right: 12px;
 `;
 
 export const CurrencyIconAndBadge = ({
@@ -656,7 +658,7 @@ export const CurrencyIconAndBadge = ({
   return (
     <CurrencyImageAndBadgeContainer height={size}>
       <CurrencyImage
-        img={() => <CurrencyIcon height={size} />}
+        img={() => <CurrencyIcon height={size} width={size} />}
         badgeUri={badgeImg}
         size={size}
       />


### PR DESCRIPTION
This PR ensures users are taken to the new top-level bill pay tab when tapping the old "Pay Bills" subtab in the Shop tab.