### PR TITLE
Gift Card and Bill Pay fixes

### DIFF
--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -26,11 +26,11 @@ const fetchInitialUserData = async (token: string) => {
 
 const fetchBasicInfo = async (
   token: string,
-  params?: {includeExternalData: boolean},
+  params?: {includeExternalData?: boolean; includeMethodData?: boolean},
 ) => {
   const query = UserQueries.FETCH_BASIC_INFO(
     token,
-    params || {includeExternalData: false},
+    params || {includeExternalData: false, includeMethodData: false},
   );
   const {data} = await GraphQlApi.getInstance().request<FetchBasicInfoResponse>(
     query,

--- a/src/api/user/user.queries.ts
+++ b/src/api/user/user.queries.ts
@@ -30,6 +30,10 @@ export const basicInfoExternalFields = `
   legalGivenName
 `;
 
+export const basicInfoMethodFields = `
+  methodVerified
+`;
+
 /**
  * Fetches all user data, for example for initializing data after pairing
  * or refreshing user data on init.
@@ -41,8 +45,9 @@ export const FETCH_ALL_USER_DATA = (token: string): GqlQueryParams => {
     query: `
       query FETCH_ALL_USER_DATA ($token:String!) {
         user:bitpayUser(token:$token) {
-          basicInfo: user {
+          basicInfo: user(includeMethodData:true) {
             ${basicInfoFields}
+            ${basicInfoMethodFields}
           }
           cards:debitCards {
             ${cardFields}
@@ -63,15 +68,18 @@ export const FETCH_ALL_USER_DATA = (token: string): GqlQueryParams => {
 
 export const FETCH_BASIC_INFO = (
   token: string,
-  params: {includeExternalData: boolean},
+  params: {includeExternalData?: boolean; includeMethodData?: boolean},
 ): GqlQueryParams => {
   return {
     query: `
       query FETCH_BASIC_INFO ($token:String!) {
         user:bitpayUser(token:$token) {
-          basicInfo:user(includeExternalData:${params.includeExternalData}) {
+          basicInfo:user(includeExternalData:${
+            params.includeExternalData
+          }, includeMethodData:${params.includeMethodData}) {
             ${basicInfoFields}
             ${params.includeExternalData ? basicInfoExternalFields : ''}
+            ${params.includeMethodData ? basicInfoMethodFields : ''}
           }
         }
       }

--- a/src/api/user/user.types.ts
+++ b/src/api/user/user.types.ts
@@ -10,6 +10,7 @@ export interface BasicUserInfo {
   incentiveLevel?: string;
   incentiveLevelId?: string;
   methodEntityId?: string;
+  methodVerified?: boolean;
   name: string;
   phone?: string;
   referralCode: string;

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -4,7 +4,6 @@ import {Network} from '.';
 
 export const STATIC_CONTENT_CARDS_ENABLED = true;
 export const APP_ANALYTICS_ENABLED = !__DEV__;
-export const METHOD_ENV = __DEV__ ? 'dev' : 'production';
 
 // GENERAL
 export const APP_NAME = 'bitpay';
@@ -63,6 +62,11 @@ export const EVM_BLOCKCHAIN_EXPLORERS: {[key in string]: any} = {
     [Network.mainnet]: 'polygonscan.com/',
     [Network.testnet]: 'mumbai.polygonscan.com/',
   },
+};
+
+export const METHOD_ENVS = {
+  [Network.mainnet]: 'production',
+  [Network.testnet]: 'dev',
 };
 
 export const PROTOCOL_NAME: {[key in string]: any} = {

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -77,7 +77,6 @@ import {Wallet} from '../../../../store/wallet/wallet.models';
 import {
   APP_DEEPLINK_PREFIX,
   APP_NAME_UPPERCASE,
-  APP_NETWORK,
 } from '../../../../constants/config';
 import {
   BuyCryptoExchangeKey,
@@ -443,7 +442,9 @@ const BuyCryptoOffers: React.FC = () => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
   const createdOn = useAppSelector(({WALLET}: RootState) => WALLET.createdOn);
-  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[APP_NETWORK]);
+  const user = useAppSelector(
+    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
+  );
 
   BuyCryptoSupportedExchanges.forEach((exchange: BuyCryptoExchangeKey) => {
     if (offersDefault[exchange]) {

--- a/src/navigation/tabs/settings/about/screens/StorageUsage.tsx
+++ b/src/navigation/tabs/settings/about/screens/StorageUsage.tsx
@@ -15,7 +15,6 @@ import {useTranslation} from 'react-i18next';
 import {LogActions} from '../../../../../store/log';
 import {Black, Feather, LightBlack, White} from '../../../../../styles/colors';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../../constants/config';
 
 const ScrollContainer = styled.ScrollView``;
 
@@ -47,7 +46,9 @@ const StorageUsage: React.VFC = () => {
   const [customTokenStorage, setCustomTokenStorage] = useState<string>('');
   const [contactStorage, setContactStorage] = useState<string>('');
 
-  const giftCards = useAppSelector(({SHOP}) => SHOP.giftCards[APP_NETWORK]);
+  const giftCards = useAppSelector(
+    ({APP, SHOP}) => SHOP.giftCards[APP.network],
+  );
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const customTokens = useAppSelector(({WALLET}) => WALLET.customTokenData);
   const contacts = useAppSelector(({CONTACT}) => CONTACT.list);

--- a/src/navigation/tabs/shop/ShopHome.tsx
+++ b/src/navigation/tabs/shop/ShopHome.tsx
@@ -31,7 +31,6 @@ import {
   selectCategoriesWithIntegrations,
   selectIntegrations,
 } from '../../../store/shop/shop.selectors';
-import {APP_NETWORK} from '../../../constants/config';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ShopScreens, ShopStackParamList} from './ShopStack';
@@ -130,12 +129,14 @@ const ShopHome: React.FC<
   const theme = useTheme();
   const availableCardMap = useAppSelector(({SHOP}) => SHOP.availableCardMap);
   const supportedCardMap = useAppSelector(({SHOP}) => SHOP.supportedCardMap);
-  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[APP_NETWORK]);
+  const user = useAppSelector(
+    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
+  );
   const giftCards = useAppSelector(
-    ({SHOP}) => SHOP.giftCards[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.giftCards[APP.network],
   ) as GiftCard[];
   const billPayAccounts = useAppSelector(
-    ({SHOP}) => SHOP.billPayAccounts[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.billPayAccounts[APP.network],
   ) as BillPayAccount[];
   const purchasedGiftCards = useMemo(
     () =>

--- a/src/navigation/tabs/shop/ShopStack.tsx
+++ b/src/navigation/tabs/shop/ShopStack.tsx
@@ -5,20 +5,12 @@ import {
   baseNavigatorOptions,
 } from '../../../constants/NavigationOptions';
 import ShopHome, {ShopHomeParamList} from './ShopHome';
-import {HeaderTitle} from '../../../components/styled/Text';
 import {NavigatorScreenParams} from '@react-navigation/native';
-import {CardConfigMap, GiftCard} from '../../../store/shop/shop.models';
-import ArchivedGiftCards from './gift-card/screens/ArchivedGiftCards';
 import {HeaderBackButton} from '@react-navigation/elements';
-import {useTranslation} from 'react-i18next';
 import {useTheme} from 'styled-components/native';
 
 export type ShopStackParamList = {
   Home: NavigatorScreenParams<ShopHomeParamList>;
-  ArchivedGiftCards: {
-    giftCards: GiftCard[];
-    supportedGiftCardMap: CardConfigMap;
-  };
 };
 
 export enum ShopScreens {
@@ -30,7 +22,6 @@ const Shop = createNativeStackNavigator<ShopStackParamList>();
 
 const ShopStack = () => {
   const theme = useTheme();
-  const {t} = useTranslation();
   return (
     <Shop.Navigator
       initialRouteName={ShopScreens.HOME}
@@ -49,15 +40,6 @@ const ShopStack = () => {
         ),
       })}>
       <Shop.Screen name={ShopScreens.HOME} component={ShopHome} />
-      <Shop.Screen
-        name={ShopScreens.ARCHIVED_GIFT_CARDS}
-        component={ArchivedGiftCards}
-        options={{
-          headerTitle: () => (
-            <HeaderTitle>{t('Archived Gift Cards')}</HeaderTitle>
-          ),
-        }}
-      />
     </Shop.Navigator>
   );
 };

--- a/src/navigation/tabs/shop/bill/components/BillList.tsx
+++ b/src/navigation/tabs/shop/bill/components/BillList.tsx
@@ -9,7 +9,6 @@ import {
   BillPayPayment,
   BillPayment,
 } from '../../../../../store/shop/shop.models';
-import {APP_NETWORK} from '../../../../../constants/config';
 import {AppActions} from '../../../../../store/app';
 import {Analytics} from '../../../../../store/analytics/analytics.effects';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
@@ -54,7 +53,7 @@ export const BillList = ({
   const dispatch = useAppDispatch();
   const {t} = useTranslation();
   const persistedBillPayPayments = useAppSelector(
-    ({SHOP}) => SHOP.billPayPayments[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.billPayPayments[APP.network],
   ) as BillPayPayment[];
   const allProcessingPayments = persistedBillPayPayments
     .filter(

--- a/src/navigation/tabs/shop/bill/components/PaymentList.tsx
+++ b/src/navigation/tabs/shop/bill/components/PaymentList.tsx
@@ -24,7 +24,6 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../../constants/config';
 import {ShopEffects} from '../../../../../store/shop';
 import {AppActions} from '../../../../../store/app';
 import {CustomErrorMessage} from '../../../../wallet/components/ErrorMessages';
@@ -61,7 +60,7 @@ export const PaymentList = ({
   const theme = useTheme();
   const {t} = useTranslation();
   const persistedBillPayPayments = useAppSelector(
-    ({SHOP}) => SHOP.billPayPayments[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.billPayPayments[APP.network],
   ) as BillPayPayment[];
   const billPayPayments = persistedBillPayPayments.sort(sortByDescendingDate);
   const [payments, setPayments] = useState(billPayPayments);

--- a/src/navigation/tabs/shop/bill/screens/BillSettings.tsx
+++ b/src/navigation/tabs/shop/bill/screens/BillSettings.tsx
@@ -101,7 +101,7 @@ const BillSettings = ({
                         await dispatch(BitPayIdEffects.startResetMethodUser());
                         await dispatch(
                           BitPayIdEffects.startFetchBasicInfo(apiToken),
-                        );
+                        ).catch(() => {});
                         await dispatch(ShopEffects.startGetBillPayAccounts());
                       },
                       primary: true,

--- a/src/navigation/tabs/shop/bill/screens/BillsHome.tsx
+++ b/src/navigation/tabs/shop/bill/screens/BillsHome.tsx
@@ -9,7 +9,6 @@ import {SlateDark, White} from '../../../../../styles/colors';
 import {ShopEffects} from '../../../../../store/shop';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {sleep} from '../../../../../utils/helper-methods';
-import {APP_NETWORK} from '../../../../../constants/config';
 
 const BillsHome = ({}: NativeStackScreenProps<
   BillGroupParamList,
@@ -17,7 +16,9 @@ const BillsHome = ({}: NativeStackScreenProps<
 >) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
-  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[APP_NETWORK]);
+  const user = useAppSelector(
+    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
+  );
   const [refreshing, setRefreshing] = useState(false);
   return (
     <ScreenContainer>

--- a/src/navigation/tabs/shop/bill/screens/ConnectBills.tsx
+++ b/src/navigation/tabs/shop/bill/screens/ConnectBills.tsx
@@ -7,7 +7,7 @@ import {ShopEffects} from '../../../../../store/shop';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
-import {APP_NETWORK, METHOD_ENV} from '../../../../../constants/config';
+import {METHOD_ENVS} from '../../../../../constants/config';
 import {AppActions} from '../../../../../store/app';
 import {CustomErrorMessage} from '../../../../wallet/components/ErrorMessages';
 import {useTranslation} from 'react-i18next';
@@ -25,11 +25,10 @@ const ConnectBills = ({
   const insets = useSafeAreaInsets();
   const [isWebViewShown, setIsWebViewShown] = useState(true);
   const [token, setToken] = useState('');
-  const user = useAppSelector(
-    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
-  );
+  const appNetwork = useAppSelector(({APP}) => APP.network);
+  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[appNetwork]);
   const billPayAccounts = useAppSelector(
-    ({SHOP}) => SHOP.billPayAccounts[APP_NETWORK],
+    ({SHOP}) => SHOP.billPayAccounts[appNetwork],
   ) as BillPayAccount[];
   const [currentBillPayAccountIds] = useState(
     billPayAccounts.map(({id}) => id),
@@ -37,7 +36,7 @@ const ConnectBills = ({
   const [publicAccountToken, setPublicAccountToken] = useState('');
   const [exiting, setExiting] = useState(false);
   const apiToken = useAppSelector(
-    ({BITPAY_ID}) => BITPAY_ID.apiToken[APP_NETWORK],
+    ({BITPAY_ID}) => BITPAY_ID.apiToken[appNetwork],
   );
   const [isInitialApplication] = useState(!user?.methodEntityId);
 
@@ -153,7 +152,7 @@ const ConnectBills = ({
         <WebView
           style={{marginTop: insets.top}}
           source={{
-            uri: `https://elements.${METHOD_ENV}.methodfi.com/?token=${token}`,
+            uri: `https://elements.${METHOD_ENVS[appNetwork]}.methodfi.com/?token=${token}`,
           }}
           originWhitelist={['https://*', 'methodelements://*']}
           onShouldStartLoadWithRequest={handleNavigationStateChange}

--- a/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
+++ b/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
@@ -142,7 +142,7 @@ const ConnectBillsOptions = ({
       BitPayIdEffects.startFetchBasicInfo(apiToken, {
         includeExternalData: true,
       }),
-    );
+    ).catch(() => {});
     setContinueButtonState(undefined);
     dispatch(
       AppActions.showBottomNotificationModal({

--- a/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
+++ b/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
@@ -32,7 +32,6 @@ import {
 import UserInfo from '../../components/UserInfo';
 import {BitPayIdEffects} from '../../../../../store/bitpay-id';
 import {AppActions} from '../../../../../store/app';
-import {APP_NETWORK} from '../../../../../constants/config';
 
 const TitleText = styled(H5)`
   margin-bottom: 14px;
@@ -124,7 +123,7 @@ const ConnectBillsOptions = ({
   const {t} = useTranslation();
   const theme = useTheme();
   const apiToken = useAppSelector(
-    ({BITPAY_ID}) => BITPAY_ID.apiToken[APP_NETWORK],
+    ({APP, BITPAY_ID}) => BITPAY_ID.apiToken[APP.network],
   );
 
   const [selectedOption, setSelectedOption] = useState(

--- a/src/navigation/tabs/shop/bill/screens/Payments.tsx
+++ b/src/navigation/tabs/shop/bill/screens/Payments.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components/native';
 import {useAppSelector} from '../../../../../utils/hooks';
 import {BillPayAccount} from '../../../../../store/shop/shop.models';
 import {PaymentList} from '../components/PaymentList';
-import {APP_NETWORK} from '../../../../../constants/config';
 import {SendToPillContainer} from '../../../../wallet/screens/send/confirm/Shared';
 import {BillAccountPill} from '../components/BillAccountPill';
 import {ScreenContainer} from '../../components/styled/ShopTabComponents';
@@ -23,7 +22,7 @@ const Payments = ({
   const {t} = useTranslation();
   const {account} = route.params;
   const accounts = useAppSelector(
-    ({SHOP}) => SHOP.billPayAccounts[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.billPayAccounts[APP.network],
   ) as BillPayAccount[];
 
   useLayoutEffect(() => {

--- a/src/navigation/tabs/shop/components/Bills.tsx
+++ b/src/navigation/tabs/shop/components/Bills.tsx
@@ -27,7 +27,7 @@ import {
   useLogger,
 } from '../../../../utils/hooks';
 import {BillPayAccount} from '../../../../store/shop/shop.models';
-import {APP_NETWORK, BASE_BITPAY_URLS} from '../../../../constants/config';
+import {BASE_BITPAY_URLS} from '../../../../constants/config';
 import {ShopEffects} from '../../../../store/shop';
 import {AppActions, AppEffects} from '../../../../store/app';
 import BillPitch from '../bill/components/BillPitch';
@@ -73,23 +73,25 @@ const BillsHeaderButton = styled(SectionHeaderButton)`
   margin-top: 0;
 `;
 
-const verificationBaseUrl = `${BASE_BITPAY_URLS[APP_NETWORK]}/wallet-verify?product=billpay`;
-
 export const Bills = () => {
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
   const {t} = useTranslation();
   const logger = useLogger();
 
+  const appNetwork = useAppSelector(({APP}) => APP.network);
+
   const accounts = useAppSelector(
-    ({SHOP}) => SHOP.billPayAccounts[APP_NETWORK],
+    ({SHOP}) => SHOP.billPayAccounts[appNetwork],
   ) as BillPayAccount[];
 
   const apiToken = useAppSelector(
-    ({BITPAY_ID}) => BITPAY_ID.apiToken[APP_NETWORK],
+    ({BITPAY_ID}) => BITPAY_ID.apiToken[appNetwork],
   );
 
   const isJoinedWaitlist = useAppSelector(({SHOP}) => SHOP.isJoinedWaitlist);
+
+  const verificationBaseUrl = `${BASE_BITPAY_URLS[appNetwork]}/wallet-verify?product=billpay`;
 
   const [connected, setConnected] = useState(!!accounts.length);
 

--- a/src/navigation/tabs/shop/components/Bills.tsx
+++ b/src/navigation/tabs/shop/components/Bills.tsx
@@ -275,52 +275,62 @@ export const Bills = () => {
                       );
                     }}
                   />
-                  <Button
-                    style={{marginTop: 20, marginBottom: 10}}
-                    height={50}
-                    buttonStyle="secondary"
-                    onPress={() => {
-                      navigation.navigate(BillScreens.PAY_ALL_BILLS, {
-                        accounts,
-                      });
-                      dispatch(
-                        Analytics.track('Bill Pay — Clicked Pay All Bills'),
-                      );
-                    }}>
-                    {t('Pay All Bills')}
-                  </Button>
-                  {/* <Button
-                    style={{marginTop: 20, marginBottom: 10}}
-                    state={connectButtonState}
-                    height={50}
-                    buttonStyle="secondary"
-                    onPress={() => {
-                      verifyUserInfo();
-                      dispatch(
-                        Analytics.track(
-                          'Bill Pay - Clicked Connect More Bills',
-                        ),
-                      );
-                    }}>
-                    {t('Connect More Bills')}
-                  </Button> */}
-                  <Button
-                    buttonType={'link'}
-                    onPress={() => {
-                      navigation.navigate(
-                        BillScreens.CONNECT_BILLS_OPTIONS,
-                        {},
-                      );
-                      dispatch(
-                        Analytics.track(
-                          'Bill Pay - Clicked Connect More Bills',
-                        ),
-                      );
-                    }}>
-                    {connectButtonState
-                      ? t('Loading...')
-                      : t('Connect More Bills')}
-                  </Button>
+                  {accounts.some(account => account.isPayable) ? (
+                    <>
+                      <Button
+                        style={{marginTop: 20, marginBottom: 10}}
+                        height={50}
+                        buttonStyle="secondary"
+                        onPress={() => {
+                          navigation.navigate(BillScreens.PAY_ALL_BILLS, {
+                            accounts,
+                          });
+                          dispatch(
+                            Analytics.track('Bill Pay — Clicked Pay All Bills'),
+                          );
+                        }}>
+                        {t('Pay All Bills')}
+                      </Button>
+                      <Button
+                        buttonType={'link'}
+                        onPress={() => {
+                          navigation.navigate(
+                            BillScreens.CONNECT_BILLS_OPTIONS,
+                            {},
+                          );
+                          dispatch(
+                            Analytics.track(
+                              'Bill Pay - Clicked Connect More Bills',
+                            ),
+                          );
+                        }}>
+                        {connectButtonState
+                          ? t('Loading...')
+                          : t('Connect More Bills')}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        style={{marginTop: 20, marginBottom: 10}}
+                        state={connectButtonState}
+                        height={50}
+                        buttonStyle="secondary"
+                        onPress={() => {
+                          navigation.navigate(
+                            BillScreens.CONNECT_BILLS_OPTIONS,
+                            {},
+                          );
+                          dispatch(
+                            Analytics.track(
+                              'Bill Pay - Clicked Connect More Bills',
+                            ),
+                          );
+                        }}>
+                        {t('Connect More Bills')}
+                      </Button>
+                    </>
+                  )}
                   <SectionSpacer />
                 </>
               )}

--- a/src/navigation/tabs/shop/components/Bills.tsx
+++ b/src/navigation/tabs/shop/components/Bills.tsx
@@ -148,14 +148,30 @@ export const Bills = () => {
     }
   };
 
-  const verifyUserInfo = async () => {
+  const connectBills = async () => {
+    if (user?.methodVerified) {
+      navigation.navigate(BillScreens.CONNECT_BILLS_OPTIONS, {});
+      return;
+    }
     setConnectButtonState('loading');
-    await dispatch(
-      BitPayIdEffects.startFetchBasicInfo(apiToken, {
-        includeExternalData: true,
-      }),
-    );
-    setConnectButtonState(undefined);
+    try {
+      const userInfo = await dispatch(
+        BitPayIdEffects.startFetchBasicInfo(apiToken, {
+          includeExternalData: true,
+        }),
+      );
+      setConnectButtonState(undefined);
+      if (userInfo.methodVerified) {
+        navigation.navigate(BillScreens.CONNECT_BILLS_OPTIONS, {});
+        return;
+      }
+    } catch (err) {
+      setConnectButtonState(undefined);
+    }
+    verifyUserInfo();
+  };
+
+  const verifyUserInfo = async () => {
     dispatch(
       AppActions.showBottomNotificationModal({
         type: 'info',
@@ -172,7 +188,7 @@ export const Bills = () => {
                 tokenType: 'auth',
               });
               dispatch(Analytics.track('Bill Pay - Confirmed User Info'));
-              if (!user?.methodEntityId) {
+              if (!user?.methodVerified) {
                 dispatch(Analytics.track('Bill Pay - Started Application'));
               }
             },
@@ -235,7 +251,7 @@ export const Bills = () => {
                     state={connectButtonState}
                     height={50}
                     onPress={async () => {
-                      verifyUserInfo();
+                      connectBills();
                       dispatch(
                         Analytics.track('Bill Pay - Clicked Connect My Bills'),
                       );
@@ -294,10 +310,7 @@ export const Bills = () => {
                       <Button
                         buttonType={'link'}
                         onPress={() => {
-                          navigation.navigate(
-                            BillScreens.CONNECT_BILLS_OPTIONS,
-                            {},
-                          );
+                          connectBills();
                           dispatch(
                             Analytics.track(
                               'Bill Pay - Clicked Connect More Bills',
@@ -317,10 +330,7 @@ export const Bills = () => {
                         height={50}
                         buttonStyle="secondary"
                         onPress={() => {
-                          navigation.navigate(
-                            BillScreens.CONNECT_BILLS_OPTIONS,
-                            {},
-                          );
+                          connectBills();
                           dispatch(
                             Analytics.track(
                               'Bill Pay - Clicked Connect More Bills',

--- a/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
@@ -35,7 +35,6 @@ import {GiftCardScreens} from '../gift-card/GiftCardGroup';
 import MyGiftCards from './MyGiftCards';
 import FilterSheet, {initializeCategoryMap} from './FilterSheet';
 import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../constants/config';
 import GhostSvg from '../../../../../assets/img/ghost-cheeky.svg';
 import {useTranslation} from 'react-i18next';
 import {Analytics} from '../../../../store/analytics/analytics.effects';
@@ -131,7 +130,7 @@ export default ({
   const navigation = useNavigation();
   const theme = useTheme();
   const giftCards = useAppSelector(
-    ({SHOP}) => SHOP.giftCards[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.giftCards[APP.network],
   ) as GiftCard[];
   const [searchVal, setSearchVal] = useState('');
   const [searchResults, setSearchResults] = useState([] as CardConfig[]);

--- a/src/navigation/tabs/shop/components/MyGiftCards.tsx
+++ b/src/navigation/tabs/shop/components/MyGiftCards.tsx
@@ -16,13 +16,10 @@ import {ActiveOpacity, WIDTH} from '../../../../components/styled/Containers';
 import {BaseText} from '../../../../components/styled/Text';
 import {SlateDark, White} from '../../../../styles/colors';
 import {useAppSelector} from '../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../constants/config';
 import {
   isGiftCardDisplayable,
-  redemptionFailuresLessThanADayOld,
   sortByDescendingDate,
 } from '../../../../lib/gift-cards/gift-card';
-import {ShopScreens} from '../ShopStack';
 import {useTranslation} from 'react-i18next';
 import {TouchableOpacity} from 'react-native';
 
@@ -56,7 +53,7 @@ const MyGiftCards = ({
   const navigation = useNavigation();
   const [slideIndex, setSlideIndex] = useState(0);
   const allGiftCards = useAppSelector(
-    ({SHOP}) => SHOP.giftCards[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.giftCards[APP.network],
   ) as GiftCard[];
   const supportedGiftCardMap = supportedGiftCards.reduce(
     (map, cardConfig) => ({...map, ...{[cardConfig.name]: cardConfig}}),
@@ -77,7 +74,7 @@ const MyGiftCards = ({
   const seeArchivedGiftCards = () => {
     shouldShowArchivedSlide
       ? setSlideIndex(1)
-      : navigation.navigate(ShopScreens.ARCHIVED_GIFT_CARDS, {
+      : navigation.navigate(GiftCardScreens.ARCHIVED_GIFT_CARDS, {
           giftCards: archivedGiftCards,
           supportedGiftCardMap,
         });

--- a/src/navigation/tabs/shop/components/UserInfo.tsx
+++ b/src/navigation/tabs/shop/components/UserInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import {useAppSelector} from '../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../constants/config';
 import {formatUSPhone} from '../bill/utils';
 import {
   Field,
@@ -12,7 +11,9 @@ import {
 import {ScrollableBottomNotificationMessageContainer} from '../../../../components/modal/bottom-notification/BottomNotification';
 
 const UserInfo = () => {
-  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[APP_NETWORK]);
+  const user = useAppSelector(
+    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
+  );
   return (
     <ScrollableBottomNotificationMessageContainer
       contentContainerStyle={{paddingBottom: 10}}>

--- a/src/navigation/tabs/shop/gift-card/GiftCardGroup.tsx
+++ b/src/navigation/tabs/shop/gift-card/GiftCardGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   CardConfig,
+  CardConfigMap,
   GiftCard,
   PhoneCountryInfo,
 } from '../../../../store/shop/shop.models';
@@ -22,12 +23,17 @@ import {HeaderBackButton} from '@react-navigation/elements';
 import GiftCardDeeplinkScreen, {
   GiftCardDeeplinkScreenParamList,
 } from './GiftCardDeeplink';
+import ArchivedGiftCards from './screens/ArchivedGiftCards';
 
 interface GiftCardProps {
   GiftCard: typeof Root;
 }
 
 export type GiftCardGroupParamList = {
+  ArchivedGiftCards: {
+    giftCards: GiftCard[];
+    supportedGiftCardMap: CardConfigMap;
+  };
   BuyGiftCard: {cardConfig: CardConfig};
   EnterEmail: {
     cardConfig: CardConfig;
@@ -52,6 +58,7 @@ export type GiftCardGroupParamList = {
 };
 
 export enum GiftCardScreens {
+  ARCHIVED_GIFT_CARDS = 'ArchivedGiftCards',
   BUY_GIFT_CARD = 'BuyGiftCard',
   ENTER_EMAIL = 'EnterEmail',
   ENTER_PHONE = 'EnterPhone',
@@ -111,6 +118,15 @@ const GiftCardGroup: React.FC<GiftCardProps> = ({GiftCard}) => {
       <GiftCard.Screen
         name={GiftCardScreens.GIFT_CARD_DEEPLINK}
         component={GiftCardDeeplinkScreen}
+      />
+      <GiftCard.Screen
+        name={GiftCardScreens.ARCHIVED_GIFT_CARDS}
+        component={ArchivedGiftCards}
+        options={{
+          headerTitle: () => (
+            <HeaderTitle>{t('Archived Gift Cards')}</HeaderTitle>
+          ),
+        }}
       />
     </GiftCard.Group>
   );

--- a/src/navigation/tabs/shop/gift-card/screens/ArchivedGiftCards.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/ArchivedGiftCards.tsx
@@ -5,23 +5,21 @@ import {
   ScreenContainer,
   SectionContainer,
 } from '../../components/styled/ShopTabComponents';
-import {GiftCardScreens} from '../GiftCardGroup';
+import {GiftCardGroupParamList, GiftCardScreens} from '../GiftCardGroup';
 import {GiftCard} from '../../../../../store/shop/shop.models';
 import GiftCardCreditsItem from '../../components/GiftCardCreditsItem';
 import {FlatList, TouchableOpacity} from 'react-native';
 import {useAppSelector} from '../../../../../utils/hooks';
-import {APP_NETWORK} from '../../../../../constants/config';
 import {sortByDescendingDate} from '../../../../../lib/gift-cards/gift-card';
-import {ShopStackParamList} from '../../ShopStack';
 
 const ArchivedGiftCards = ({
   route,
   navigation,
-}: NativeStackScreenProps<ShopStackParamList, 'ArchivedGiftCards'>) => {
+}: NativeStackScreenProps<GiftCardGroupParamList, 'ArchivedGiftCards'>) => {
   const navigator = useNavigation();
   const {supportedGiftCardMap} = route.params;
   const allGiftCards = useAppSelector(
-    ({SHOP}) => SHOP.giftCards[APP_NETWORK],
+    ({APP, SHOP}) => SHOP.giftCards[APP.network],
   ) as GiftCard[];
   const giftCards = allGiftCards
     .filter(

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -8,7 +8,6 @@ import TagsSvg from '../../../../../../assets/img/tags-stack.svg';
 import {
   BaseText,
   fontFamily,
-  HeaderTitle,
   TextAlign,
 } from '../../../../../components/styled/Text';
 import styled from 'styled-components/native';
@@ -35,14 +34,12 @@ import {
   isSupportedDiscountType,
 } from '../../../../../lib/gift-cards/gift-card';
 import {useNavigation, useTheme} from '@react-navigation/native';
-import {useDispatch} from 'react-redux';
 import {AppActions} from '../../../../../store/app';
 import GiftCardDiscountText from '../../components/GiftCardDiscountText';
 import {formatFiatAmount, sleep} from '../../../../../utils/helper-methods';
 import {CustomErrorMessage} from '../../../../wallet/components/ErrorMessages';
 import {ShopActions} from '../../../../../store/shop';
-import {APP_NETWORK} from '../../../../../constants/config';
-import {useAppSelector} from '../../../../../utils/hooks';
+import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {useTranslation} from 'react-i18next';
 import {Analytics} from '../../../../../store/analytics/analytics.effects';
 import GiftCardImage from '../../components/GiftCardImage';
@@ -120,11 +117,13 @@ const BuyGiftCard = ({
   navigation,
 }: NativeStackScreenProps<GiftCardGroupParamList, 'BuyGiftCard'>) => {
   const {t} = useTranslation();
+  const dispatch = useAppDispatch();
   const navigator = useNavigation();
-  const dispatch = useDispatch();
   const theme = useTheme();
   const {cardConfig} = route.params;
-  const user = useAppSelector(({BITPAY_ID}) => BITPAY_ID.user[APP_NETWORK]);
+  const user = useAppSelector(
+    ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
+  );
   const syncGiftCardPurchasesWithBitPayId = useAppSelector(
     ({SHOP}) => SHOP.syncGiftCardPurchasesWithBitPayId,
   );
@@ -148,13 +147,7 @@ const BuyGiftCard = ({
   );
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: () => {
-        return (
-          <HeaderTitle>
-            {t('BuyGiftCard', {displayName: cardConfig.displayName})}
-          </HeaderTitle>
-        );
-      },
+      headerTitle: t('BuyGiftCard', {displayName: cardConfig.displayName}),
     });
   });
   useEffect(() => {
@@ -205,9 +198,8 @@ const BuyGiftCard = ({
   };
 
   const goToAmountScreen = (phone?: string) => {
-    navigation.navigate(WalletScreens.AMOUNT, {
+    navigator.navigate(WalletScreens.AMOUNT, {
       fiatCurrencyAbbreviation: cardConfig.currency,
-      opts: {hideSendMax: true},
       onAmountSelected: selectedAmount =>
         onAmountScreenSubmit(+selectedAmount, phone),
     });

--- a/src/navigation/tabs/shop/gift-card/screens/EnterEmail.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/EnterEmail.tsx
@@ -14,6 +14,7 @@ import AuthFormContainer, {
   AuthRowContainer,
 } from '../../../../auth/components/AuthFormContainer';
 import {GiftCardGroupParamList} from '../GiftCardGroup';
+import {ScreenContainer} from '../../components/styled/ShopTabComponents';
 
 const PrimaryActionContainer = styled.View`
   margin-bottom: 20px;
@@ -47,39 +48,41 @@ const EnterEmail = ({
   });
 
   return (
-    <AuthFormContainer>
-      <AuthFormParagraph>
-        {t(
-          'Your email address will be used for payment notifications and receipts.',
-        )}
-      </AuthFormParagraph>
-      <AuthRowContainer>
-        <Controller
-          control={control}
-          defaultValue={initialEmail}
-          render={({field: {onChange, onBlur, value}}) => (
-            <BoxInput
-              placeholder={'satoshi@bitpay.com'}
-              label={t('EMAIL ADDRESS')}
-              onBlur={onBlur}
-              onChangeText={(text: string) => onChange(text)}
-              error={errors.email?.message}
-              keyboardType={'email-address'}
-              value={value}
-              returnKeyType="next"
-              blurOnSubmit={false}
-            />
+    <ScreenContainer>
+      <AuthFormContainer>
+        <AuthFormParagraph>
+          {t(
+            'Your email address will be used for payment notifications and receipts.',
           )}
-          name="email"
-        />
-      </AuthRowContainer>
+        </AuthFormParagraph>
+        <AuthRowContainer>
+          <Controller
+            control={control}
+            defaultValue={initialEmail}
+            render={({field: {onChange, onBlur, value}}) => (
+              <BoxInput
+                placeholder={'satoshi@bitpay.com'}
+                label={t('EMAIL ADDRESS')}
+                onBlur={onBlur}
+                onChangeText={(text: string) => onChange(text)}
+                error={errors.email?.message}
+                keyboardType={'email-address'}
+                value={value}
+                returnKeyType="next"
+                blurOnSubmit={false}
+              />
+            )}
+            name="email"
+          />
+        </AuthRowContainer>
 
-      <AuthActionsContainer>
-        <PrimaryActionContainer>
-          <Button onPress={onFormSubmit}>{t('Continue')}</Button>
-        </PrimaryActionContainer>
-      </AuthActionsContainer>
-    </AuthFormContainer>
+        <AuthActionsContainer>
+          <PrimaryActionContainer>
+            <Button onPress={onFormSubmit}>{t('Continue')}</Button>
+          </PrimaryActionContainer>
+        </AuthActionsContainer>
+      </AuthFormContainer>
+    </ScreenContainer>
   );
 };
 

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -49,7 +49,7 @@ import {
   PrintSvg,
 } from '../../components/svg/ShopTabSvgs';
 import OptionsSheet, {Option} from '../../../../wallet/components/OptionsSheet';
-import {APP_NETWORK, BASE_BITPAY_URLS} from '../../../../../constants/config';
+import {BASE_BITPAY_URLS} from '../../../../../constants/config';
 import {formatFiatAmount, sleep} from '../../../../../utils/helper-methods';
 import {AppActions} from '../../../../../store/app';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -168,8 +168,9 @@ const GiftCardDetails = ({
     width: 0,
   });
   const {cardConfig, giftCard: initialGiftCard} = route.params;
+  const appNetwork = useAppSelector(({APP}) => APP.network);
   const giftCards = useAppSelector(
-    ({SHOP}) => SHOP.giftCards[APP_NETWORK],
+    ({SHOP}) => SHOP.giftCards[appNetwork],
   ) as GiftCard[];
   const [giftCard, setGiftCard] = useState(
     giftCards.find(card => card.invoiceId === initialGiftCard.invoiceId) ||
@@ -334,7 +335,7 @@ const GiftCardDetails = ({
       description: t('View Invoice'),
       onPress: () =>
         Linking.openURL(
-          `${BASE_BITPAY_URLS[APP_NETWORK]}/invoice?id=${giftCard.invoiceId}`,
+          `${BASE_BITPAY_URLS[appNetwork]}/invoice?id=${giftCard.invoiceId}`,
         ),
     },
     {
@@ -375,7 +376,12 @@ const GiftCardDetails = ({
   };
 
   const toggleArchiveStatus = () => {
-    dispatch(ShopActions.toggledGiftCardArchivedStatus({giftCard}));
+    dispatch(
+      ShopActions.toggledGiftCardArchivedStatus({
+        giftCard,
+        network: appNetwork,
+      }),
+    );
     giftCard.archived = !giftCard.archived;
     if (giftCard.archived) {
       navigation.pop();

--- a/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/BillConfirm.tsx
@@ -11,7 +11,12 @@ import {useNavigation, useRoute} from '@react-navigation/native';
 import {HeaderRightContainer} from '../../../../../components/styled/Containers';
 import {RouteProp, StackActions} from '@react-navigation/core';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
-import {Wallet, Key} from '../../../../../store/wallet/wallet.models';
+import {
+  TransactionProposal,
+  TxDetails,
+  Wallet,
+  Key,
+} from '../../../../../store/wallet/wallet.models';
 import SwipeButton from '../../../../../components/swipe-button/SwipeButton';
 import {
   buildTxDetails,
@@ -41,7 +46,7 @@ import {
 } from './Shared';
 import {AppActions} from '../../../../../store/app';
 import {CustomErrorMessage} from '../../../components/ErrorMessages';
-import {APP_NETWORK, BASE_BITPAY_URLS} from '../../../../../constants/config';
+import {BASE_BITPAY_URLS} from '../../../../../constants/config';
 import {BillPayAccount, Invoice} from '../../../../../store/shop/shop.models';
 import {WalletRowProps} from '../../../../../components/list/WalletRow';
 import {
@@ -88,6 +93,10 @@ export interface BillPaymentRequest {
 
 export interface BillConfirmParamList {
   billPayments: BillPaymentRequest[];
+  wallet?: Wallet;
+  recipient: {address: string};
+  txDetails?: TxDetails;
+  txp?: TransactionProposal;
 }
 
 const BillConfirm: React.VFC<
@@ -108,6 +117,7 @@ const BillConfirm: React.VFC<
 
   const billPayAccount = billPayments[0].billPayAccount;
 
+  const appNetwork = useAppSelector(({APP}) => APP.network);
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
 
   const [walletSelectorVisible, setWalletSelectorVisible] = useState(false);
@@ -154,12 +164,12 @@ const BillConfirm: React.VFC<
       dispatch(
         BuildPayProWalletSelectorList({
           keys,
-          network: APP_NETWORK,
+          network: appNetwork,
           invoice,
           skipThreshold: true,
         }),
       ),
-    [dispatch, invoice, keys],
+    [appNetwork, dispatch, invoice, keys],
   );
 
   useLayoutEffect(() => {
@@ -343,7 +353,7 @@ const BillConfirm: React.VFC<
         },
         {totalBillAmount: 0, serviceFee: 0},
       );
-      const baseUrl = BASE_BITPAY_URLS[APP_NETWORK];
+      const baseUrl = BASE_BITPAY_URLS[appNetwork];
       const paymentUrl = `${baseUrl}/i/${invoiceId}`;
       const {txDetails: newTxDetails, txp: newTxp} = await dispatch(
         await createPayProTxProposal({
@@ -408,7 +418,7 @@ const BillConfirm: React.VFC<
     dispatch(
       Analytics.track('Bill Pay - Successful Bill Paid', {
         ...baseEventParams,
-        network: APP_NETWORK,
+        network: appNetwork,
       }),
     );
   };

--- a/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/GiftCardConfirm.tsx
@@ -34,10 +34,7 @@ import {
   openUrlWithInAppBrowser,
   startOnGoingProcessModal,
 } from '../../../../../store/app/app.effects';
-import {
-  dismissOnGoingProcessModal,
-  showBottomNotificationModal,
-} from '../../../../../store/app/app.actions';
+import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
 import RemoteImage from '../../../../tabs/shop/components/RemoteImage';
 import {ShopActions, ShopEffects} from '../../../../../store/shop';
 import {BuildPayProWalletSelectorList} from '../../../../../store/wallet/utils/wallet';
@@ -53,11 +50,8 @@ import {
   WalletSelector,
 } from './Shared';
 import {AppActions} from '../../../../../store/app';
-import {
-  CustomErrorMessage,
-  WrongPasswordError,
-} from '../../../components/ErrorMessages';
-import {APP_NETWORK, BASE_BITPAY_URLS} from '../../../../../constants/config';
+import {CustomErrorMessage} from '../../../components/ErrorMessages';
+import {BASE_BITPAY_URLS} from '../../../../../constants/config';
 import {URL} from '../../../../../constants';
 import {
   CardConfig,
@@ -141,8 +135,9 @@ const Confirm = () => {
     txDetails: _txDetails,
     txp: _txp,
   } = route.params!;
+  const appNetwork = useAppSelector(({APP}) => APP.network);
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
-  const giftCards = useAppSelector(({SHOP}) => SHOP.giftCards[APP_NETWORK]);
+  const giftCards = useAppSelector(({SHOP}) => SHOP.giftCards[appNetwork]);
 
   const [walletSelectorVisible, setWalletSelectorVisible] = useState(false);
   const [key, setKey] = useState(keys[_wallet ? _wallet.keyId : '']);
@@ -172,12 +167,12 @@ const Confirm = () => {
       dispatch(
         BuildPayProWalletSelectorList({
           keys,
-          network: APP_NETWORK,
+          network: appNetwork,
           invoice,
           skipThreshold: true,
         }),
       ),
-    [dispatch, keys, invoice],
+    [dispatch, keys, appNetwork, invoice],
   );
 
   const getTransactionCurrency = () => {
@@ -188,7 +183,7 @@ const Confirm = () => {
 
   useEffect(() => {
     return () => {
-      dispatch(ShopActions.deletedUnsoldGiftCards());
+      dispatch(ShopActions.deletedUnsoldGiftCards({network: appNetwork}));
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -252,7 +247,7 @@ const Confirm = () => {
     transactionCurrency: string;
   }) => {
     dispatch(startOnGoingProcessModal('FETCHING_PAYMENT_INFO'));
-    dispatch(ShopActions.deletedUnsoldGiftCards());
+    dispatch(ShopActions.deletedUnsoldGiftCards({network: appNetwork}));
     const invoiceCreationParams = {
       amount,
       brand: cardConfig.name,
@@ -329,7 +324,7 @@ const Confirm = () => {
           selectedWallet.chain,
         ),
       });
-      const baseUrl = BASE_BITPAY_URLS[APP_NETWORK];
+      const baseUrl = BASE_BITPAY_URLS[appNetwork];
       const paymentUrl = `${baseUrl}/i/${invoiceId}`;
       const {txDetails: newTxDetails, txp: newTxp} = await dispatch(
         await createPayProTxProposal({
@@ -399,6 +394,7 @@ const Confirm = () => {
           ShopActions.updatedGiftCardStatus({
             invoiceId: invoice!.id,
             status: 'PENDING',
+            network: appNetwork,
           }),
         );
         txp && wallet && recipient
@@ -422,6 +418,7 @@ const Confirm = () => {
         ShopActions.updatedGiftCardStatus({
           invoiceId: invoice!.id,
           status: 'UNREDEEMED',
+          network: appNetwork,
         }),
       );
       dispatch(dismissOnGoingProcessModal());

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -25,7 +25,7 @@ import BitPayIdApi from '../../api/bitpay';
 import {ReceivingAddress, SecuritySettings} from './bitpay-id.models';
 import {getCoinAndChainFromCurrencyCode} from '../../navigation/bitpay-id/utils/bitpay-id-utils';
 import axios from 'axios';
-import {APP_NETWORK, BASE_BITPAY_URLS} from '../../constants/config';
+import {BASE_BITPAY_URLS} from '../../constants/config';
 import Braze from 'react-native-appboy-sdk';
 import {dismissOnGoingProcessModal, setBrazeEid} from '../app/app.actions';
 import uuid from 'react-native-uuid';
@@ -517,8 +517,8 @@ export const startDisconnectBitPayId =
     dispatch(BitPayIdActions.bitPayIdDisconnected(APP.network));
     dispatch(Analytics.track('Log Out User success', {}));
     dispatch(CardActions.isJoinedWaitlist(false));
-    dispatch(ShopActions.clearedBillPayAccounts());
-    dispatch(ShopActions.clearedBillPayPayments());
+    dispatch(ShopActions.clearedBillPayAccounts({network: APP.network}));
+    dispatch(ShopActions.clearedBillPayPayments({network: APP.network}));
     dispatch(dismissOnGoingProcessModal());
   };
 
@@ -724,14 +724,14 @@ export const startSubmitForgotPasswordEmail =
 
 export const startResetMethodUser =
   (): Effect<Promise<any>> => async (dispatch, getState) => {
-    const {BITPAY_ID} = getState();
+    const {APP, BITPAY_ID} = getState();
     await BitPayIdApi.getInstance()
-      .request('resetMethodUser', BITPAY_ID.apiToken[APP_NETWORK])
+      .request('resetMethodUser', BITPAY_ID.apiToken[APP.network])
       .then(res => {
         if (res?.data?.error) {
           throw new Error(res.data.error);
         }
-        dispatch(BitPayIdActions.successResetMethodUser(APP_NETWORK));
+        dispatch(BitPayIdActions.successResetMethodUser(APP.network));
         return res.data.data as any;
       })
       .catch(err => {

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -5,7 +5,7 @@ import {
   RegisterErrorResponse,
 } from '../../api/auth/auth.types';
 import UserApi from '../../api/user';
-import {InitialUserData} from '../../api/user/user.types';
+import {BasicUserInfo, InitialUserData} from '../../api/user/user.types';
 import {Network} from '../../constants';
 import Dosh from '../../lib/dosh';
 import {MixpanelWrapper} from '../../lib/Mixpanel';
@@ -525,17 +525,24 @@ export const startDisconnectBitPayId =
 export const startFetchBasicInfo =
   (
     token: string,
-    params?: {includeExternalData: boolean},
-  ): Effect<Promise<void>> =>
+    params: {includeExternalData?: boolean} = {
+      includeExternalData: false,
+    },
+  ): Effect<Promise<BasicUserInfo>> =>
   async (dispatch, getState) => {
     try {
       const {APP} = getState();
-      const user = await UserApi.fetchBasicInfo(token, params);
+      const user = await UserApi.fetchBasicInfo(token, {
+        ...params,
+        includeMethodData: true,
+      });
       dispatch(BitPayIdActions.successFetchBasicInfo(APP.network, user));
+      return user;
     } catch (err) {
       dispatch(LogActions.error('Failed to fetch basic user info'));
       dispatch(LogActions.error(JSON.stringify(err)));
       dispatch(BitPayIdActions.failedFetchBasicInfo());
+      throw err;
     }
   };
 

--- a/src/store/bitpay-id/bitpay-id.models.ts
+++ b/src/store/bitpay-id/bitpay-id.models.ts
@@ -52,6 +52,7 @@ export interface User {
   legalFamilyName?: string;
   legalGivenName?: string;
   methodEntityId?: string;
+  methodVerified?: boolean;
   phone?: string;
   address?: string;
   dateOfBirth?: string;

--- a/src/store/bitpay-id/bitpay-id.reducer.ts
+++ b/src/store/bitpay-id/bitpay-id.reducer.ts
@@ -387,6 +387,7 @@ export const bitPayIdReducer = (
           [action.payload.network]: {
             ...state.user[action.payload.network],
             methodEntityId: undefined,
+            methodVerified: undefined,
           },
         },
       };

--- a/src/store/shop/shop.actions.ts
+++ b/src/store/shop/shop.actions.ts
@@ -10,6 +10,7 @@ import {
   PhoneCountryInfo,
   UnsoldGiftCard,
 } from './shop.models';
+import {Network} from '../../constants';
 
 export const successFetchCatalog = (payload: {
   availableCardMap: CardConfigMap;
@@ -37,6 +38,7 @@ export const failedCreateGiftCardInvoice = (): ShopActionType => ({
 
 export const initializedUnsoldGiftCard = (payload: {
   giftCard: UnsoldGiftCard;
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.INITIALIZED_UNSOLD_GIFT_CARD,
   payload,
@@ -44,6 +46,7 @@ export const initializedUnsoldGiftCard = (payload: {
 
 export const setPurchasedGiftCards = (payload: {
   giftCards: GiftCard[];
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.SET_PURCHASED_GIFT_CARDS,
   payload,
@@ -51,40 +54,53 @@ export const setPurchasedGiftCards = (payload: {
 
 export const setBillPayAccounts = (payload: {
   accounts: BillPayAccount[];
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.SET_BILL_PAY_ACCOUNTS,
   payload,
 });
 
-export const clearedBillPayAccounts = (): ShopActionType => ({
+export const clearedBillPayAccounts = (payload: {
+  network: Network;
+}): ShopActionType => ({
   type: ShopActionTypes.CLEARED_BILL_PAY_ACCOUNTS,
+  payload,
 });
 
 export const setBillPayPayments = (payload: {
   billPayPayments: BillPayPayment[];
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.SET_BILL_PAY_PAYMENTS,
   payload,
 });
 
-export const clearedBillPayPayments = (): ShopActionType => ({
+export const clearedBillPayPayments = (payload: {
+  network: Network;
+}): ShopActionType => ({
   type: ShopActionTypes.CLEARED_BILL_PAY_PAYMENTS,
+  payload,
 });
 
 export const updatedGiftCardStatus = (payload: {
   invoiceId: string;
   status: 'PENDING' | 'UNREDEEMED';
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.UPDATED_GIFT_CARD_STATUS,
   payload,
 });
 
-export const deletedUnsoldGiftCards = (): ShopActionType => ({
+export const deletedUnsoldGiftCards = (payload: {
+  network: Network;
+}): ShopActionType => ({
   type: ShopActionTypes.DELETED_UNSOLD_GIFT_CARDS,
+  payload,
 });
 
 export const redeemedGiftCard = (payload: {
   giftCard: GiftCard;
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.REDEEMED_GIFT_CARD,
   payload,
@@ -92,6 +108,7 @@ export const redeemedGiftCard = (payload: {
 
 export const toggledGiftCardArchivedStatus = (payload: {
   giftCard: GiftCard;
+  network: Network;
 }): ShopActionType => ({
   type: ShopActionTypes.TOGGLED_GIFT_CARD_ARCHIVED_STATUS,
   payload,

--- a/src/store/shop/shop.reducer.ts
+++ b/src/store/shop/shop.reducer.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import {Network} from '../../constants';
-import {APP_NETWORK} from '../../constants/config';
 import {
   BillPayAccount,
   BillPayPayment,
@@ -89,7 +88,8 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: state.giftCards[APP_NETWORK].concat(giftCard),
+          [action.payload.network]:
+            state.giftCards[action.payload.network].concat(giftCard),
         },
       };
     case ShopActionTypes.SET_PURCHASED_GIFT_CARDS:
@@ -98,7 +98,7 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: giftCards,
+          [action.payload.network]: giftCards,
         },
       };
     case ShopActionTypes.SET_BILL_PAY_ACCOUNTS:
@@ -107,7 +107,7 @@ export const shopReducer = (
         ...state,
         billPayAccounts: {
           ...state.billPayAccounts,
-          [APP_NETWORK]: accounts,
+          [action.payload.network]: accounts,
         },
       };
     case ShopActionTypes.CLEARED_BILL_PAY_ACCOUNTS:
@@ -115,7 +115,7 @@ export const shopReducer = (
         ...state,
         billPayAccounts: {
           ...state.billPayAccounts,
-          [APP_NETWORK]: [],
+          [action.payload.network]: [],
         },
       };
     case ShopActionTypes.SET_BILL_PAY_PAYMENTS:
@@ -124,8 +124,11 @@ export const shopReducer = (
         ...state,
         billPayPayments: {
           ...state.billPayPayments,
-          [APP_NETWORK]: _.uniqBy(
-            [...billPayPayments, ...state.billPayPayments[APP_NETWORK]],
+          [action.payload.network]: _.uniqBy(
+            [
+              ...billPayPayments,
+              ...state.billPayPayments[action.payload.network],
+            ],
             billPayPayment => billPayPayment.id,
           ),
         },
@@ -135,7 +138,7 @@ export const shopReducer = (
         ...state,
         billPayPayments: {
           ...state.billPayPayments,
-          [APP_NETWORK]: [],
+          [action.payload.network]: [],
         },
       };
     case ShopActionTypes.DELETED_UNSOLD_GIFT_CARDS:
@@ -143,9 +146,9 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: state.giftCards[APP_NETWORK].filter(
-            card => card.status !== 'UNREDEEMED',
-          ),
+          [action.payload.network]: state.giftCards[
+            action.payload.network
+          ].filter(card => card.status !== 'UNREDEEMED'),
         },
       };
     case ShopActionTypes.REDEEMED_GIFT_CARD:
@@ -154,10 +157,11 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: state.giftCards[APP_NETWORK].map(card =>
-            card.invoiceId === redeemedGiftCard.invoiceId
-              ? {...card, ...redeemedGiftCard}
-              : card,
+          [action.payload.network]: state.giftCards[action.payload.network].map(
+            card =>
+              card.invoiceId === redeemedGiftCard.invoiceId
+                ? {...card, ...redeemedGiftCard}
+                : card,
           ),
         },
       };
@@ -167,10 +171,11 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: state.giftCards[APP_NETWORK].map(card =>
-            card.invoiceId === archivableGiftCard.invoiceId
-              ? {...card, archived: !archivableGiftCard.archived}
-              : card,
+          [action.payload.network]: state.giftCards[action.payload.network].map(
+            card =>
+              card.invoiceId === archivableGiftCard.invoiceId
+                ? {...card, archived: !archivableGiftCard.archived}
+                : card,
           ),
         },
       };
@@ -192,8 +197,9 @@ export const shopReducer = (
         ...state,
         giftCards: {
           ...state.giftCards,
-          [APP_NETWORK]: state.giftCards[APP_NETWORK].map(card =>
-            card.invoiceId === invoiceIdToUpdate ? {...card, status} : card,
+          [action.payload.network]: state.giftCards[action.payload.network].map(
+            card =>
+              card.invoiceId === invoiceIdToUpdate ? {...card, status} : card,
           ),
         },
       };

--- a/src/store/shop/shop.types.ts
+++ b/src/store/shop/shop.types.ts
@@ -1,3 +1,4 @@
+import {Network} from '../../constants';
 import {
   BillPayAccount,
   BillPayPayment,
@@ -54,45 +55,60 @@ interface initializedUnsoldGiftCard {
   type: typeof ShopActionTypes.INITIALIZED_UNSOLD_GIFT_CARD;
   payload: {
     giftCard: UnsoldGiftCard;
+    network: Network;
   };
 }
 interface setPurchasedGiftCards {
   type: typeof ShopActionTypes.SET_PURCHASED_GIFT_CARDS;
   payload: {
     giftCards: GiftCard[];
+    network: Network;
   };
 }
 interface setBillPayAccounts {
   type: typeof ShopActionTypes.SET_BILL_PAY_ACCOUNTS;
   payload: {
     accounts: BillPayAccount[];
+    network: Network;
   };
 }
 interface clearedBillPayAccounts {
   type: typeof ShopActionTypes.CLEARED_BILL_PAY_ACCOUNTS;
+  payload: {
+    network: Network;
+  };
 }
 interface setBillPayPayments {
   type: typeof ShopActionTypes.SET_BILL_PAY_PAYMENTS;
   payload: {
     billPayPayments: BillPayPayment[];
+    network: Network;
   };
 }
 interface clearedBillPayPayments {
   type: typeof ShopActionTypes.CLEARED_BILL_PAY_PAYMENTS;
+  payload: {
+    network: Network;
+  };
 }
 interface deletedUnsoldGiftCard {
   type: typeof ShopActionTypes.DELETED_UNSOLD_GIFT_CARDS;
+  payload: {
+    network: Network;
+  };
 }
 interface redeemedGiftCard {
   type: typeof ShopActionTypes.REDEEMED_GIFT_CARD;
   payload: {
     giftCard: GiftCard;
+    network: Network;
   };
 }
 interface toggledGiftCardArchivedStatus {
   type: typeof ShopActionTypes.TOGGLED_GIFT_CARD_ARCHIVED_STATUS;
   payload: {
     giftCard: GiftCard;
+    network: Network;
   };
 }
 interface toggledSyncGiftCardPurchasesWithBitPayId {
@@ -109,6 +125,7 @@ interface updatedGiftCardStatus {
   payload: {
     invoiceId: string;
     status: 'PENDING' | 'UNREDEEMED';
+    network: Network;
   };
 }
 interface updatedPhone {

--- a/src/store/wallet/effects/import/import.ts
+++ b/src/store/wallet/effects/import/import.ts
@@ -163,7 +163,7 @@ export const startMigrationMMKVStorage =
 
 export const startMigration =
   (): Effect<Promise<void>> =>
-  async (dispatch): Promise<void> => {
+  async (dispatch, getState): Promise<void> => {
     return new Promise(async resolve => {
       dispatch(LogActions.info('[startMigration] - starting...'));
       const goToNewUserOnboarding = () => {
@@ -548,7 +548,10 @@ export const startMigration =
           ...giftCard,
           archived: numActiveGiftCards > 3 ? true : giftCard.archived,
         }));
-        dispatch(ShopActions.setPurchasedGiftCards({giftCards}));
+        const {APP} = getState();
+        dispatch(
+          ShopActions.setPurchasedGiftCards({giftCards, network: APP.network}),
+        );
 
         const giftCardEmail = await RNFS.readFile(
           cordovaStoragePath + 'amazonUserInfo',


### PR DESCRIPTION
1. Makes it easy to point gift cards and bill pay to test.bitpay.com simply by enabling test mode
2. Ensures "Enter Email" gift card screen falls within the safe area view on iOS
3. Hides the "Pay all Bills" button if the only bills that have been connected are not yet payable
4. Ensures custom bill flow only becomes available after user becomes verified in method