### PR TITLE
Fix initial tab selection in CustomizeHome.tsx

### DIFF
--- a/src/navigation/tabs/settings/general/screens/customize-home/CustomizeHome.tsx
+++ b/src/navigation/tabs/settings/general/screens/customize-home/CustomizeHome.tsx
@@ -57,6 +57,7 @@ const CustomizeHomeSettings = () => {
   const hasCoinbase = useAppSelector(
     ({COINBASE}) => !!COINBASE.token[COINBASE_ENV],
   );
+  const [initialLayoutType] = useState(defaultLayoutType);
   const [layoutType, setLayoutType] = useState(defaultLayoutType);
   const navigation = useNavigation();
   const theme = useTheme();
@@ -187,26 +188,53 @@ const CustomizeHomeSettings = () => {
               }
             },
           }}>
-          <Tab.Screen
-            name={'carousel'}
-            component={Noop}
-            options={{
-              tabBarLabel: t('Carousel'),
-              tabBarIcon: ({focused}) => (
-                <CarouselSvg focused={focused} theme={theme} />
-              ),
-            }}
-          />
-          <Tab.Screen
-            name={'listView'}
-            component={Noop}
-            options={{
-              tabBarLabel: t('List View'),
-              tabBarIcon: ({focused}) => (
-                <ListViewSvg focused={focused} theme={theme} />
-              ),
-            }}
-          />
+          {initialLayoutType === 'carousel' ? (
+            <>
+              <Tab.Screen
+                name={'carousel'}
+                component={Noop}
+                options={{
+                  tabBarLabel: t('Carousel'),
+                  tabBarIcon: ({focused}) => (
+                    <CarouselSvg focused={focused} theme={theme} />
+                  ),
+                }}
+              />
+              <Tab.Screen
+                name={'listView'}
+                component={Noop}
+                options={{
+                  tabBarLabel: t('List View'),
+                  tabBarIcon: ({focused}) => (
+                    <ListViewSvg focused={focused} theme={theme} />
+                  ),
+                }}
+              />
+            </>
+          ) : (
+            <>
+              <Tab.Screen
+                name={'listView'}
+                component={Noop}
+                options={{
+                  tabBarLabel: t('List View'),
+                  tabBarIcon: ({focused}) => (
+                    <ListViewSvg focused={focused} theme={theme} />
+                  ),
+                }}
+              />
+              <Tab.Screen
+                name={'carousel'}
+                component={Noop}
+                options={{
+                  tabBarLabel: t('Carousel'),
+                  tabBarIcon: ({focused}) => (
+                    <CarouselSvg focused={focused} theme={theme} />
+                  ),
+                }}
+              />
+            </>
+          )}
         </Tab.Navigator>
       </LayoutToggleContainer>
 


### PR DESCRIPTION
The Tab Navigator can be a bit unreliable when it comes to programmatically selecting an initial nested tab that isn't the first tab. This PR includes a workaround for this issue by ensuring that the initially selected tab is always listed first in `CustomizeHome.tsx`.