### PR TITLE
Fix transaction history infinite scroll

### DIFF
--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -463,6 +463,7 @@ export const GroupTransactionHistory = (history: any[]) => {
           {
             title: t('Pending Transactions'),
             data: _pendingTransactions,
+            time: Date.now(),
           },
         ]
       : [];
@@ -479,7 +480,7 @@ export const GroupTransactionHistory = (history: any[]) => {
         .locale(i18n.language || 'en')
         .format('MMMM');
       const title = IsDateInCurrentMonth(time) ? t('Recent') : month;
-      return {title, data: group};
+      return {title, data: group, time};
     });
   return pendingTransactionsGroup.concat(confirmedTransactionsGroup);
 };


### PR DESCRIPTION
Currently the list of transactions in Wallet Details only displays the most recent 25 transactions. Scrolling to the bottom of the list fetches the next 25 transactions but never actually renders them. This PR gets infinite scroll working properly for Wallet Details transaction history by actually rendering the next 25 transactions fetched at the bottom of the list and also wraps all transaction item components with `useCallback`.