### PR TITLE
Fix: prevent unlock modal from being displayed twice in a row when the app is open

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -467,15 +467,15 @@ export default () => {
             await RNBootSplash.hide({fade: true});
             // avoid splash conflicting with modal in iOS
             // https://stackoverflow.com/questions/65359539/showing-a-react-native-modal-right-after-app-startup-freezes-the-screen-in-ios
-            dispatch(LogActions.debug(`Pin Lock Active: ${pinLockActive}`));
             dispatch(
-              LogActions.debug(`Biometric Lock Active: ${biometricLockActive}`),
+              LogActions.debug(
+                `Biometric Lock Active: ${biometricLockActive} | Pin Lock Active: ${pinLockActive}`,
+              ),
             );
             if (pinLockActive) {
               await sleep(500);
               dispatch(AppActions.showPinModal({type: 'check'}));
-            }
-            if (biometricLockActive) {
+            } else if (biometricLockActive) {
               await sleep(500);
               dispatch(AppActions.showBiometricModal({}));
             }

--- a/src/store/app/app.reducer.ts
+++ b/src/store/app/app.reducer.ts
@@ -26,24 +26,25 @@ import moment from 'moment';
 import {Web3WalletTypes} from '@walletconnect/web3wallet';
 
 export const appReduxPersistBlackList: Array<keyof AppState> = [
+  'activeModalId',
   'appIsLoading',
   'appWasInit',
-  'showOnGoingProcessModal',
-  'onGoingProcessModalMessage',
-  'showInAppMessage',
-  'inAppMessageData',
-  'showInAppNotification',
-  'inAppNotificationData',
-  'showDecryptPasswordModal',
-  'showPinModal',
-  'pinModalConfig',
-  'showBottomNotificationModal',
-  'showBiometricModal',
   'biometricModalConfig',
-  'activeModalId',
-  'failedAppInit',
   'brazeContentCardSubscription',
+  'failedAppInit',
   'inAppBrowserOpen',
+  'inAppMessageData',
+  'inAppNotificationData',
+  'lockAuthorizedUntil',
+  'onGoingProcessModalMessage',
+  'pinModalConfig',
+  'showBiometricModal',
+  'showBottomNotificationModal',
+  'showDecryptPasswordModal',
+  'showInAppMessage',
+  'showInAppNotification',
+  'showOnGoingProcessModal',
+  'showPinModal',
 ];
 
 export type ModalId =


### PR DESCRIPTION
Way to reproduce the issue: Leave the app open for more than 20 seconds, in which case the `lockAuthorizedUntil` will have expired. When closing and reopening the app, the value of `lockAuthorizedUntil` was not removed, so after successfully passing the unlock to open the app, it interprets that `lockAuthorizedUntil` has expired and asks for it again.

The solution I propose is to add `lockAuthorizedUntil` to the `appReduxPersistBlackList`