### PR TITLE
Fix: renew Braze EID for (silent) push notifications

### DIFF
--- a/src/store/analytics/analytics.effects.ts
+++ b/src/store/analytics/analytics.effects.ts
@@ -110,20 +110,15 @@ export const Analytics = (() => {
       (
         userEid: string | undefined,
         traits?: Record<string, any> | undefined,
-        onComplete?: () => void,
       ): Effect<void> =>
       () => {
-        guard(async () => {
-          if (_isTrackingAuthorized) {
-            BrazeWrapper.identify(userEid, traits);
-            MixpanelWrapper.identify(userEid);
-          } else {
-            // require EID for functionality
-            BrazeWrapper.identify(userEid);
-          }
-
-          onComplete?.();
-        });
+        if (_isTrackingAuthorized) {
+          BrazeWrapper.identify(userEid, traits);
+          MixpanelWrapper.identify(userEid);
+        } else {
+          // require EID for functionality
+          BrazeWrapper.identify(userEid);
+        }
       },
 
     /**

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -507,7 +507,7 @@ export const startDisconnectBitPayId =
       dispatch(LogActions.debug('Generating EID for anonymous user...'));
       const eid = uuid.v4().toString();
       dispatch(setBrazeEid(eid));
-      BrazeWrapper.identify(eid);
+      dispatch(Analytics.identify(eid));
       dispatch(renewSubscription());
     } catch (err) {
       dispatch(LogActions.debug('An error occured while clearing Braze user.'));

--- a/src/utils/braze.ts
+++ b/src/utils/braze.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CONTENT_CARD_BASE: ContentCardBase = {
   dismissed: false,
   dismissible: false,
   openURLInWebView: false,
+  isControl: false,
   extras: {},
 };
 


### PR DESCRIPTION
It helps to force subscription to (silent) push notifications after login or logout BitPay ID