### PR TITLE
Fix email verification flow

### DIFF
--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -165,11 +165,14 @@ export const startCreateAccount =
   };
 
 export const startSendVerificationEmail =
-  (): Effect => async (dispatch, getState) => {
+  (): Effect<Promise<void>> => async (dispatch, getState) => {
     try {
       const {APP, BITPAY_ID} = getState();
 
-      AuthApi.sendVerificationEmail(APP.network, BITPAY_ID.session.csrfToken);
+      return AuthApi.sendVerificationEmail(
+        APP.network,
+        BITPAY_ID.session.csrfToken,
+      );
     } catch (err) {
       dispatch(
         LogActions.error('An error occurred sending verification email.'),


### PR DESCRIPTION
This PR ensures the email verification flow continues to work after the app is closed and reopened after initial account creation. Closing and reopening the app causes a new unauthenticated session to be created which currently causes the email verification link request to fail with a 401. This PR fixes the issue by requesting that the user log in again if they no longer have an authenticated session.