### PR TITLE
Ref: do not show wallet address form on moonpay checkout

### DIFF
--- a/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoOffers.tsx
@@ -1816,7 +1816,7 @@ const BuyCryptoOffers: React.FC = () => {
         APP_DEEPLINK_PREFIX + `moonpay?externalId=${externalTransactionId}`,
       env: moonpayEnv,
       lockAmount: true,
-      showWalletAddressForm: true,
+      showWalletAddressForm: false,
     };
 
     let data;

--- a/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
+++ b/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
@@ -553,7 +553,7 @@ const SellCryptoRoot = ({
       colorCode: BitPay,
       theme: theme.dark ? 'dark' : 'light',
       quoteCurrencyCode: cloneDeep(fiatCurrency).toLowerCase(),
-      showWalletAddressForm: true,
+      showWalletAddressForm: false,
     };
 
     let data: MoonpayGetSellSignedPaymentUrlData;


### PR DESCRIPTION
From Moonpay team:
"I noticed upon testing earlier that you are showing the "Enter Wallet Address" screen.
We know through our data that this can often cause CVR issues, as it adds an extra screen to the funnel and can confuse users.
To avoid this, please stop using the showWalletAddressForm param."