### PR TITLE
Support regtest paypro payments

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,4 +1,5 @@
 // @ts-ignore
+import {REGTEST_BASE_BITPAY_URL} from '@env';
 import {version} from '../../package.json'; // TODO: better way to get version
 import {Network} from '.';
 
@@ -13,6 +14,7 @@ export const APP_VERSION = version;
 export const BASE_BITPAY_URLS = {
   [Network.mainnet]: 'https://bitpay.com',
   [Network.testnet]: 'https://test.bitpay.com',
+  [Network.regtest]: REGTEST_BASE_BITPAY_URL || '',
 };
 // BITCORE
 export const BASE_BITCORE_URL = {
@@ -78,6 +80,7 @@ export const EVM_BLOCKCHAIN_EXPLORERS: {[key in string]: any} = {
 export const METHOD_ENVS = {
   [Network.mainnet]: 'production',
   [Network.testnet]: 'dev',
+  [Network.regtest]: 'dev',
 };
 
 export const PROTOCOL_NAME: {[key in string]: any} = {

--- a/src/lib/bwc.ts
+++ b/src/lib/bwc.ts
@@ -1,5 +1,6 @@
 import BWC from 'bitcore-wallet-client';
 import {Constants} from 'bitcore-wallet-client/ts_build/lib/common';
+import {PAYPRO_TRUSTED_KEYS} from '@env';
 import {
   APP_NAME,
   APP_VERSION,
@@ -102,7 +103,12 @@ export class BwcProvider {
   }
 
   public getPayProV2() {
-    return BWC.PayProV2;
+    const PayProV2 = BWC.PayProV2;
+    PayProV2.trustedKeys = {
+      ...PayProV2.trustedKeys,
+      ...JSON.parse(PAYPRO_TRUSTED_KEYS || '{}'),
+    };
+    return PayProV2;
   }
 
   public parseSecret(invitationCode: string) {

--- a/src/navigation/tabs/settings/general/screens/Theme.tsx
+++ b/src/navigation/tabs/settings/general/screens/Theme.tsx
@@ -2,6 +2,7 @@ import React, {useLayoutEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {ColorSchemeName, Pressable, View} from 'react-native';
 import {useTheme} from 'styled-components/native';
+import {TEST_MODE_NETWORK} from '@env';
 import Checkbox from '../../../../../components/checkbox/Checkbox';
 import {
   Hr,
@@ -31,19 +32,20 @@ const ThemeSettings: React.FC = () => {
   const navigation = useNavigation();
   const [clickCount, setClickCount] = useState(0);
   const network = useAppSelector(({APP}) => APP.network);
+  const testModeNetwork = TEST_MODE_NETWORK || Network.testnet;
 
   const onPressTitle = () => {
     const _clickCount = clickCount + 1;
     setClickCount(_clickCount);
     if (_clickCount >= 10) {
       const changeNetwork =
-        network === Network.mainnet ? Network.testnet : Network.mainnet;
+        network === Network.mainnet ? testModeNetwork : Network.mainnet;
 
       dispatch(
         showBottomNotificationModal({
           type: 'info',
           title: `${
-            network === Network.testnet ? 'Disable' : 'Enable'
+            network === testModeNetwork ? 'Disable' : 'Enable'
           } Test Mode`,
           message:
             'Tap continue to switch networks. Your app will restart to enable the new network.',

--- a/src/store/app/app.reducer.ts
+++ b/src/store/app/app.reducer.ts
@@ -170,6 +170,11 @@ const initialState: AppState = {
       pub: '',
       sin: '',
     },
+    [Network.regtest]: {
+      priv: '',
+      pub: '',
+      sin: '',
+    },
   },
   network: APP_NETWORK,
   baseBitPayURL: BASE_BITPAY_URLS[Network.mainnet],

--- a/src/store/bitpay-id/bitpay-id.reducer.ts
+++ b/src/store/bitpay-id/bitpay-id.reducer.ts
@@ -93,22 +93,27 @@ const initialState: BitPayIdState = {
   apiToken: {
     [Network.mainnet]: '',
     [Network.testnet]: '',
+    [Network.regtest]: '',
   },
   doshToken: {
     [Network.mainnet]: '',
     [Network.testnet]: '',
+    [Network.regtest]: '',
   },
   user: {
     [Network.mainnet]: null,
     [Network.testnet]: null,
+    [Network.regtest]: null,
   },
   receivingAddresses: {
     [Network.mainnet]: [],
     [Network.testnet]: [],
+    [Network.regtest]: [],
   },
   securitySettings: {
     [Network.mainnet]: null,
     [Network.testnet]: null,
+    [Network.regtest]: null,
   },
   fetchSessionStatus: null,
   createAccountStatus: null,

--- a/src/store/card/card.reducer.ts
+++ b/src/store/card/card.reducer.ts
@@ -105,6 +105,7 @@ const initialState: CardState = {
   cards: {
     [Network.mainnet]: [],
     [Network.testnet]: [],
+    [Network.regtest]: [],
   },
   balances: {},
   virtualCardImages: {},

--- a/src/store/shop/shop.reducer.ts
+++ b/src/store/shop/shop.reducer.ts
@@ -50,14 +50,17 @@ export const initialShopState: ShopState = {
   billPayAccounts: {
     [Network.mainnet]: [],
     [Network.testnet]: [],
+    [Network.regtest]: [],
   },
   billPayPayments: {
     [Network.mainnet]: [],
     [Network.testnet]: [],
+    [Network.regtest]: [],
   },
   giftCards: {
     [Network.mainnet]: [],
     [Network.testnet]: [],
+    [Network.regtest]: [],
   },
   syncGiftCardPurchasesWithBitPayId: true,
   isJoinedWaitlist: false,
@@ -216,6 +219,7 @@ export const shopReducer = (
         giftCards: {
           [Network.mainnet]: [],
           [Network.testnet]: [],
+          [Network.regtest]: [],
         },
       };
     case ShopActionTypes.IS_JOINED_WAITLIST:


### PR DESCRIPTION
Fixes regtest related typescript errors, and makes it possible to test payment protocol payments on regtest in test mode by specifying the following variables in `.env.development`:

`TEST_MODE_NETWORK=regtest`
`REGTEST_BASE_BITPAY_URL`
`PAYPRO_TRUSTED_KEYS`