### PR TITLE
Fix paypro payments from within BCH wallets

### DIFF
--- a/src/navigation/wallet/screens/send/SendTo.tsx
+++ b/src/navigation/wallet/screens/send/SendTo.tsx
@@ -355,7 +355,7 @@ const SendTo = () => {
         isValid = ValidateCoinAddress(data, chain, network);
       }
 
-      if (currencyAbbreviation === 'bch' && isValid) {
+      if (currencyAbbreviation === 'bch' && isValid && !isPayPro) {
         const isLegacy = CheckIfLegacyBCH(data);
         if (isLegacy) {
           const appName = APP_NAME_UPPERCASE;


### PR DESCRIPTION
This PR fixes the `undefined is not a function` error that currently appears when scanning a paypro invoice from within a BCH wallet.