### PR TITLE
Fix: match theme fallback color for BlurView

### DIFF
--- a/src/components/blur/Blur.tsx
+++ b/src/components/blur/Blur.tsx
@@ -17,7 +17,7 @@ export const Blur = () => {
       }}
       blurType={theme.dark ? 'dark' : 'light'}
       blurAmount={10}
-      reducedTransparencyFallbackColor="white"
+      reducedTransparencyFallbackColor={theme.colors.background}
     />
   );
 };


### PR DESCRIPTION
* It's needed when "Reduce Transparency" on iPhone is ON.