### PR TITLE
Display HandlePayPro errors

### DIFF
--- a/src/store/wallet/effects/paypro/paypro.ts
+++ b/src/store/wallet/effects/paypro/paypro.ts
@@ -173,6 +173,7 @@ export const HandlePayPro =
         errorStr = JSON.stringify(err);
       }
       dispatch(LogActions.error(`HandlePayPro ERR: ${errorStr}`));
+      throw err;
     }
   };
 


### PR DESCRIPTION
Currently errors that happen inside of the `HandlePayPro` method are swallowed. This PR ensures they bubble up to the user and are displayed using the standard error info sheet. Also includes the `FAILURE` status in the gift card redemption failure status list.