### PR TITLE
Redeem 3 newly synced gift cards after login

### DIFF
--- a/src/lib/gift-cards/gift-card.ts
+++ b/src/lib/gift-cards/gift-card.ts
@@ -165,7 +165,8 @@ export function redemptionFailuresLessThanADayOld(
 ) {
   const dayAgo = moment().subtract(1, 'day').toDate();
   return (
-    ['PENDING'].includes(giftCard.status) && new Date(giftCard.date) > dayAgo
+    ['FAILURE', 'PENDING'].includes(giftCard.status) &&
+    new Date(giftCard.date) > dayAgo
   );
 }
 

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -444,7 +444,9 @@ const startPairAndLoadUser =
       dispatch(startBitPayIdStoreInit(data.user));
       dispatch(CardEffects.startCardStoreInit(data.user));
       dispatch(ShopEffects.startFetchCatalog());
-      dispatch(ShopEffects.startSyncGiftCards());
+      dispatch(ShopEffects.startSyncGiftCards()).then(() =>
+        dispatch(ShopEffects.redeemSyncedGiftCards()),
+      );
       dispatch(ShopEffects.startGetBillPayAccounts()).catch(_ => {});
     } catch (err) {
       let errMsg;

--- a/src/store/shop/shop.effects.ts
+++ b/src/store/shop/shop.effects.ts
@@ -120,6 +120,19 @@ export const startSyncGiftCards =
     }
   };
 
+export const redeemSyncedGiftCards =
+  (): Effect<Promise<void>> => async (dispatch, getState) => {
+    const {APP, SHOP} = getState();
+    const savedGiftCards = SHOP.giftCards[APP.network];
+    const syncedGiftCards = savedGiftCards.filter(
+      giftCard => giftCard.status === 'SYNCED',
+    );
+    const redeemPromises = syncedGiftCards
+      .slice(0, 3)
+      .map(giftCard => dispatch(startRedeemGiftCard(giftCard.invoiceId)));
+    await Promise.all(redeemPromises);
+  };
+
 export const startCreateBillPayInvoice =
   (params: BillPayInvoiceParams): Effect<Promise<BillPayOrder>> =>
   async (dispatch, getState) => {


### PR DESCRIPTION
This will improve the gift card experience by proactively fetching gift card redemption information for the 3 most recent gift card purchases immediately after initial gift card sync completes after a user logs in to their account.