### PR TITLE
Ref: migrate tracking data from anonymous users

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -6,6 +6,7 @@ declare module '*.svg' {
 
 declare module '@env' {
   export const BRAZE_EXPORT_API_KEY: string;
+  export const BRAZE_MERGE_AND_DELETE_API_KEY: string;
   export const BRAZE_REST_API_ENDPOINT: string;
   export const COINBASE_CLIENT_ID: string;
   export const COINBASE_CLIENT_SECRET: string;

--- a/src/lib/Braze/index.ts
+++ b/src/lib/Braze/index.ts
@@ -1,4 +1,6 @@
 import Braze from 'react-native-appboy-sdk';
+import axios from 'axios';
+import {BRAZE_MERGE_AND_DELETE_API_KEY, BRAZE_REST_API_ENDPOINT} from '@env';
 
 const nonCustomAttributes = [
   'country',
@@ -81,6 +83,52 @@ const setUserAttributes = (attributes: BrazeUserAttributes) => {
   });
 };
 
+const mergeUsers = async (
+  user_to_merge: string,
+  user_to_keep: string,
+): Promise<any> => {
+  const url = 'https://' + BRAZE_REST_API_ENDPOINT + '/users/merge';
+  const body = {
+    merge_updates: [
+      {
+        identifier_to_merge: {
+          external_id: user_to_merge,
+        },
+        identifier_to_keep: {
+          external_id: user_to_keep,
+        },
+      },
+    ],
+  };
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer ' + BRAZE_MERGE_AND_DELETE_API_KEY,
+  };
+  try {
+    const {data} = await axios.post(url, body, {headers});
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
+const deleteUser = async (eid: string): Promise<any> => {
+  const url = 'https://' + BRAZE_REST_API_ENDPOINT + '/users/delete';
+  const body = {
+    external_ids: [eid],
+  };
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer ' + BRAZE_MERGE_AND_DELETE_API_KEY,
+  };
+  try {
+    const {data} = await axios.post(url, body, {headers});
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
 export type BrazeUserAttributes = {
   [K in (typeof nonCustomAttributes)[number]]?: string;
 } & Record<string, any>;
@@ -125,6 +173,14 @@ export const BrazeWrapper = (() => {
         userId,
         attributes,
       };
+    },
+
+    merge(userToMerge: string, userToKeep: string) {
+      return mergeUsers(userToMerge, userToKeep);
+    },
+
+    delete(eid: string) {
+      return deleteUser(eid);
     },
 
     screen(name: string, properties: Record<string, any> = {}) {

--- a/src/navigation/onboarding/screens/OnboardingStart.tsx
+++ b/src/navigation/onboarding/screens/OnboardingStart.tsx
@@ -1,4 +1,3 @@
-import {useNavigation} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useLayoutEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -17,7 +16,6 @@ import {
 } from '../../../components/styled/Containers';
 import {Link} from '../../../components/styled/Text';
 import {BitPayIdEffects} from '../../../store/bitpay-id';
-import {Action, LuckySevens} from '../../../styles/colors';
 import {
   useAppDispatch,
   useAppSelector,
@@ -33,7 +31,7 @@ import {useSharedValue} from 'react-native-reanimated';
 
 type OnboardingStartScreenProps = NativeStackScreenProps<
   OnboardingGroupParamList,
-  OnboardingScreens.START
+  OnboardingScreens.ONBOARDING_START
 >;
 
 // IMAGES
@@ -180,7 +178,6 @@ const OnboardingStart = ({navigation}: OnboardingStartScreenProps) => {
   }, [navigation, isPaired, t]);
 
   const carouselRef = useRef<ICarouselInstance>(null);
-  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
   const [scrollHintHeight, setScrollHintHeight] = useState(0);
   const progressValue = useSharedValue<number>(0);
 
@@ -233,9 +230,6 @@ const OnboardingStart = ({navigation}: OnboardingStartScreenProps) => {
           ref={carouselRef}
           scrollAnimationDuration={1000}
           onProgressChange={(_, index) => {
-            if (Number.isInteger(index)) {
-              setActiveSlideIndex(index);
-            }
             progressValue.value = index;
           }}
           renderItem={({item}) => <OnboardingSlide item={item} />}

--- a/src/store/analytics/analytics.effects.ts
+++ b/src/store/analytics/analytics.effects.ts
@@ -187,5 +187,29 @@ export const Analytics = (() => {
           onComplete?.();
         });
       },
+
+    /**
+     * Installed Application Event
+     *
+     * @param properties An object of properties for the screen view event.
+     * @param onComplete A function to run once the screen event has been successfully sent.
+     */
+    installedApp:
+      (
+        properties: Record<string, any> = {},
+        onComplete?: () => void,
+      ): Effect<any> =>
+      () => {
+        guard(async () => {
+          if (_isTrackingAuthorized) {
+            const eventName = 'Application Installed';
+            BrazeWrapper.track(eventName, properties);
+            MixpanelWrapper.track(eventName, properties);
+            AppsFlyerWrapper.track(eventName, properties);
+          }
+
+          onComplete?.();
+        });
+      },
   };
 })();

--- a/src/store/app/app.actions.ts
+++ b/src/store/app/app.actions.ts
@@ -55,6 +55,10 @@ export const setAppFirstOpenEventDate = (date: number): AppActionType => ({
   payload: date,
 });
 
+export const setAppInstalled = (): AppActionType => ({
+  type: AppActionTypes.SET_APP_INSTALLED,
+});
+
 export const setIntroCompleted = (): AppActionType => ({
   type: AppActionTypes.SET_INTRO_COMPLETED,
 });

--- a/src/store/app/app.reducer.ts
+++ b/src/store/app/app.reducer.ts
@@ -91,6 +91,7 @@ export interface AppState {
    */
   appIsReadyForDeeplinking: boolean;
   appFirstOpenData: AppFirstOpenData;
+  appInstalled: boolean;
   introCompleted: boolean;
   userFeedback: FeedbackType;
   onboardingCompleted: boolean;
@@ -186,6 +187,7 @@ const initialState: AppState = {
   appWasInit: false,
   appIsReadyForDeeplinking: false,
   appFirstOpenData: {firstOpenEventComplete: false, firstOpenDate: undefined},
+  appInstalled: false,
   introCompleted: false,
   userFeedback: {
     time: moment().unix(),
@@ -319,6 +321,12 @@ export const appReducer = (
       return {
         ...state,
         introCompleted: true,
+      };
+
+    case AppActionTypes.SET_APP_INSTALLED:
+      return {
+        ...state,
+        appInstalled: true,
       };
 
     case AppActionTypes.SHOW_ONGOING_PROCESS_MODAL:

--- a/src/store/app/app.types.ts
+++ b/src/store/app/app.types.ts
@@ -29,6 +29,7 @@ export enum AppActionTypes {
   SET_APP_FIRST_OPEN_DATE = 'APP/SET_APP_FIRST_OPEN_DATE',
   SET_INTRO_COMPLETED = 'APP/SET_INTRO_COMPLETED',
   SET_ONBOARDING_COMPLETED = 'APP/SET_ONBOARDING_COMPLETED',
+  SET_APP_INSTALLED = 'APP/SET_INSTALLED_COMPLETED',
   SHOW_ONGOING_PROCESS_MODAL = 'APP/SHOW_ONGOING_PROCESS_MODAL',
   DISMISS_ONGOING_PROCESS_MODAL = 'APP/DISMISS_ONGOING_PROCESS_MODAL',
   SHOW_IN_APP_MESSAGE = 'APP/SHOW_IN_APP_MESSAGE',
@@ -134,6 +135,10 @@ interface SetIntroCompleted {
 
 interface SetOnboardingCompleted {
   type: typeof AppActionTypes.SET_ONBOARDING_COMPLETED;
+}
+
+interface setAppInstalled {
+  type: typeof AppActionTypes.SET_APP_INSTALLED;
 }
 
 interface ShowOnGoingProcessModal {
@@ -422,6 +427,7 @@ export type AppActionType =
   | setUserFeedback
   | SetIntroCompleted
   | SetOnboardingCompleted
+  | setAppInstalled
   | ShowOnGoingProcessModal
   | DismissOnGoingProcessModal
   | ShowInAppMessage


### PR DESCRIPTION
* Generate new EID when anonymous user allow Push Notifications
* Migrate current EID when user login BitPay and remove old EID. (Avoid duplicated profiles)
* New event "Application Installed" (similar First App Opened)
* Continue tracking when "Log Out User success" using same EID as logged

Required: API key for merge and delete functions.