### PR TITLE
Error Fallback Screen for Top-Level Tabs

### DIFF
--- a/src/navigation/card/screens/CardHome.tsx
+++ b/src/navigation/card/screens/CardHome.tsx
@@ -1,12 +1,12 @@
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React from 'react';
-import {SafeAreaView} from 'react-native';
 import {selectCardGroups} from '../../../store/card/card.selectors';
 import {useAppSelector} from '../../../utils/hooks';
 import {CardScreens, CardStackParamList} from '../CardStack';
 import CardDashboard from '../components/CardDashboard';
 import CardIntro from '../components/CardIntro';
 import styled from 'styled-components/native';
+import {withErrorFallback} from '../../../navigation/tabs/TabScreenErrorFallback';
 
 export type CardHomeScreenParamList =
   | {
@@ -37,4 +37,4 @@ const CardHome: React.FC<CardHomeScreenProps> = ({navigation, route}) => {
   return <CardIntro />;
 };
 
-export default CardHome;
+export default withErrorFallback(CardHome);

--- a/src/navigation/tabs/TabScreenErrorFallback.tsx
+++ b/src/navigation/tabs/TabScreenErrorFallback.tsx
@@ -1,0 +1,127 @@
+import React, {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Linking, ScrollView} from 'react-native';
+import ErrorBoundary from 'react-native-error-boundary';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {
+  ScreenContainer,
+  ScreenGutter,
+  WIDTH,
+} from '../../components/styled/Containers';
+import styled from 'styled-components/native';
+import {H3, Link, Paragraph, TextAlign} from '../../components/styled/Text';
+import {ShopScreens, ShopStackParamList} from './shop/ShopStack';
+import {BillGroupParamList, BillScreens} from './shop/bill/BillGroup';
+import {CardHomeScreenProps} from '../card/screens/CardHome';
+import WarningSvg from '../../../assets/img/warning.svg';
+import {Grey, LightBlack, Slate10} from '../../styles/colors';
+
+interface TabsScreenErrorFallbackProps {
+  error?: Error;
+  stackTrace?: string;
+}
+
+const TabScreenContainer = styled(ScreenContainer)`
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+`;
+
+const TabScreenErrorBody = styled.View`
+  align-items: center;
+  align-self: center;
+  padding: ${ScreenGutter};
+  gap: 15px;
+`;
+
+const ErrorBox = styled.View`
+  background-color: ${({theme}) => (theme.dark ? LightBlack : Slate10)};
+  border-radius: 8px;
+  padding: 25px;
+  max-height: 315px;
+  max-width: ${WIDTH - 40}px;
+  margin-top: 20px;
+  overflow: hidden;
+`;
+
+const StackTrace = styled(Paragraph)`
+  font-size: 12px;
+  line-height: 18px;
+`;
+
+const StackTraceContainer = styled.View`
+  flex-shrink: 1;
+`;
+
+const ErrorMessageContainer = styled.View`
+  padding: 20px;
+  border: 1px solid ${({theme}) => (theme.dark ? '#353535' : Grey)};
+  border-radius: 6px;
+  margin-bottom: 10px;
+`;
+
+const TabScreenErrorFallback: React.FC<TabsScreenErrorFallbackProps> = ({
+  error,
+  stackTrace,
+}) => {
+  const {t} = useTranslation();
+  return (
+    <ScreenContainer>
+      <ScrollView contentContainerStyle={{flex: 1}}>
+        <TabScreenContainer>
+          <TabScreenErrorBody>
+            <WarningSvg height={50} width={50} />
+            <H3>Something Went Wrong</H3>
+            <TextAlign align={'center'}>
+              <Paragraph>
+                We are unable to load this tab. If this error persists, please{' '}
+                <Link
+                  onPress={() =>
+                    Linking.openURL('https://bitpay.com/request-help/wizard')
+                  }>
+                  {t('contact BitPay Support')}
+                </Link>{' '}
+                and provide the error message below.
+              </Paragraph>
+            </TextAlign>
+            <ErrorBox>
+              <ErrorMessageContainer>
+                <Paragraph>{error?.message || ''}</Paragraph>
+              </ErrorMessageContainer>
+              <StackTraceContainer>
+                <StackTrace>{stackTrace || ''}</StackTrace>
+              </StackTraceContainer>
+            </ErrorBox>
+          </TabScreenErrorBody>
+        </TabScreenContainer>
+      </ScrollView>
+    </ScreenContainer>
+  );
+};
+
+type TabScreenProps =
+  | CardHomeScreenProps
+  | NativeStackScreenProps<BillGroupParamList, BillScreens.BILLS_HOME>
+  | NativeStackScreenProps<ShopStackParamList, ShopScreens.HOME>;
+
+export const withErrorFallback = <T extends TabScreenProps>(
+  TabScreen: React.FC<T>,
+) => {
+  return function TabScreenWithFallback(props: T) {
+    const [error, setError] = useState<Error>();
+    const [stackTrace, setStackTrace] = useState<string>();
+    const fallbackComponent = () => (
+      <TabScreenErrorFallback error={error} stackTrace={stackTrace} />
+    );
+    return (
+      <ErrorBoundary
+        FallbackComponent={fallbackComponent}
+        onError={(err, stack) => {
+          setError(err);
+          setStackTrace(stack);
+        }}>
+        <TabScreen {...props} />
+      </ErrorBoundary>
+    );
+  };
+};

--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -70,6 +70,7 @@ import {
 } from '../../../store/wallet/effects/send/send';
 import {Analytics} from '../../../store/analytics/analytics.effects';
 import Icons from '../../wallet/components/WalletIcons';
+import {withErrorFallback} from '../TabScreenErrorFallback';
 
 const HomeRootContainerFactory = (insetsTop: number) => {
   const platformSpecificContainer = Platform.select({
@@ -343,4 +344,4 @@ const HomeRoot = () => {
   );
 };
 
-export default HomeRoot;
+export default withErrorFallback(HomeRoot);

--- a/src/navigation/tabs/shop/ShopHome.tsx
+++ b/src/navigation/tabs/shop/ShopHome.tsx
@@ -40,6 +40,7 @@ import {useTheme} from 'styled-components/native';
 import {SlateDark, White} from '../../../styles/colors';
 import {sleep} from '../../../utils/helper-methods';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
+import {withErrorFallback} from '../TabScreenErrorFallback';
 
 export enum ShopTabs {
   GIFT_CARDS = 'Gift Cards',
@@ -335,4 +336,4 @@ const ShopHome: React.FC<
   );
 };
 
-export default ShopHome;
+export default withErrorFallback(ShopHome);

--- a/src/navigation/tabs/shop/ShopStack.tsx
+++ b/src/navigation/tabs/shop/ShopStack.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {
-  baseNativeHeaderBackButtonProps,
-  baseNavigatorOptions,
-} from '../../../constants/NavigationOptions';
+import {baseNavigatorOptions} from '../../../constants/NavigationOptions';
 import ShopHome, {ShopHomeParamList} from './ShopHome';
 import {NavigatorScreenParams} from '@react-navigation/native';
-import {HeaderBackButton} from '@react-navigation/elements';
 import {useTheme} from 'styled-components/native';
 
 export type ShopStackParamList = {
@@ -25,19 +21,11 @@ const ShopStack = () => {
   return (
     <Shop.Navigator
       initialRouteName={ShopScreens.HOME}
-      screenOptions={({navigation}) => ({
+      screenOptions={() => ({
         ...baseNavigatorOptions,
         headerStyle: {
           backgroundColor: theme.colors.background,
         },
-        headerLeft: () => (
-          <HeaderBackButton
-            onPress={() => {
-              navigation.goBack();
-            }}
-            {...baseNativeHeaderBackButtonProps}
-          />
-        ),
       })}>
       <Shop.Screen name={ShopScreens.HOME} component={ShopHome} />
     </Shop.Navigator>

--- a/src/navigation/tabs/shop/bill/screens/BillsHome.tsx
+++ b/src/navigation/tabs/shop/bill/screens/BillsHome.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {BillGroupParamList} from '../BillGroup';
+import {BillGroupParamList, BillScreens} from '../BillGroup';
 import {RefreshControl, ScrollView} from 'react-native';
 import {ScreenContainer} from '../../components/styled/ShopTabComponents';
 import {Bills} from '../../components/Bills';
@@ -9,10 +9,11 @@ import {SlateDark, White} from '../../../../../styles/colors';
 import {ShopEffects} from '../../../../../store/shop';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {sleep} from '../../../../../utils/helper-methods';
+import {withErrorFallback} from '../../../../../navigation/tabs/TabScreenErrorFallback';
 
 const BillsHome = ({}: NativeStackScreenProps<
   BillGroupParamList,
-  'BillsHome'
+  BillScreens.BILLS_HOME
 >) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
@@ -47,4 +48,4 @@ const BillsHome = ({}: NativeStackScreenProps<
   );
 };
 
-export default BillsHome;
+export default withErrorFallback(BillsHome);


### PR DESCRIPTION
Currently, if one of the top-level tabs crashes, the entire app crashes. This PR ensures that only the affected tab crashes and that an error screen is shown its place. To test this PR, throw an error in any of the top-level tabs.