### PR TITLE
Disable hardware back button on verify email screen

### DIFF
--- a/src/navigation/auth/screens/VerifyEmail.tsx
+++ b/src/navigation/auth/screens/VerifyEmail.tsx
@@ -10,7 +10,7 @@ import {AuthGroupParamList, AuthScreens} from '../AuthGroup';
 import AuthFormContainer, {
   AuthFormParagraph,
 } from '../components/AuthFormContainer';
-import {SafeAreaView} from 'react-native';
+import {BackHandler, SafeAreaView} from 'react-native';
 import {RootStacks} from '../../../Root';
 import {TabsScreens} from '../../tabs/TabsStack';
 import {BitpayIdScreens} from '../../bitpay-id/BitpayIdGroup';
@@ -65,6 +65,14 @@ const VerifyEmailScreen: React.FC<VerifyEmailScreenProps> = ({navigation}) => {
       headerLeft: () => null,
     });
   }, [navigation]);
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => true,
+    );
+    return () => backHandler.remove();
+  }, []);
 
   useEffect(() => {
     if (!email || !csrfToken) {


### PR DESCRIPTION
This will prevent users from accidentally navigating back to the create account screen via the android hardware back button after already having successfully created an account.