### PR TITLE
Fix gift card claim link sharing on android

### DIFF
--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -7,6 +7,7 @@ import {
   Image,
   DeviceEventEmitter,
   TouchableOpacity,
+  Platform,
 } from 'react-native';
 import RNPrint from 'react-native-print';
 import RenderHtml from 'react-native-render-html';
@@ -343,11 +344,11 @@ const GiftCardDetails = ({
       description: t('Share Claim Code'),
       onPress: async () => {
         await sleep(500);
-        Share.share(
-          giftCard.claimLink
+        const dataToShare =
+          Platform.OS === 'ios' && giftCard.claimLink
             ? {url: giftCard.claimLink}
-            : {message: giftCard.claimCode},
-        );
+            : {message: giftCard.claimLink || giftCard.claimCode};
+        Share.share(dataToShare);
       },
     },
     ...(defaultClaimCodeType !== 'link'


### PR DESCRIPTION
The `url` share property is only supported on iOS, which is currently making the "Share claim code" gift card feature useless on android. This PR falls back to sharing gift card claim links via the `message` property on android.