### PR TITLE
Fix cut off "Buy Gift Cards" button in TransactMenu on short screens

### DIFF
--- a/src/components/modal/transact-menu/TransactMenu.tsx
+++ b/src/components/modal/transact-menu/TransactMenu.tsx
@@ -10,7 +10,7 @@ import {
   Disabled,
   DisabledDark,
 } from '../../../styles/colors';
-import {ActiveOpacity, SheetContainer} from '../../styled/Containers';
+import {ActiveOpacity, HEIGHT, SheetContainer} from '../../styled/Containers';
 import {BaseText, H6} from '../../styled/Text';
 import SheetModal from '../base/sheet/SheetModal';
 import Icons from './TransactMenuIcons';
@@ -253,7 +253,7 @@ const TransactModal = () => {
         <ModalContainer>
           <FlatList
             data={TransactMenuList}
-            scrollEnabled={false}
+            scrollEnabled={HEIGHT < 700}
             renderItem={renderItem}
           />
 


### PR DESCRIPTION
Currently the "Buy Gift Cards" button is cut off in the the `TransactMenu` on shorter devices like the iPhone SE. This PR enables scrolling of the `TransactMenu` on short screens to ensure all list items can be accessed.