### PR TITLE
Fix: sell/swap unsupported coins in selector

### DIFF
--- a/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
+++ b/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
@@ -128,7 +128,10 @@ import SellCryptoLoadingQuoteSkeleton from './SellCryptoQuoteSkeleton';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import {GetProtocolPrefixAddress} from '../../../../store/wallet/utils/wallet';
 import {SatToUnit} from '../../../../store/wallet/effects/amount/amount';
-import {getSendMaxData} from '../../utils/external-services-utils';
+import {
+  getExternalServiceSymbol,
+  getSendMaxData,
+} from '../../utils/external-services-utils';
 
 export type SellCryptoRootScreenParams =
   | {
@@ -323,7 +326,7 @@ const SellCryptoRoot = ({
           fromCurrencyAbbreviation &&
           sellCryptoSupportedCoins.some(coin => {
             const symbol = fromChain
-              ? getCurrencyAbbreviation(fromCurrencyAbbreviation, fromChain)
+              ? getExternalServiceSymbol(fromCurrencyAbbreviation, fromChain)
               : fromCurrencyAbbreviation;
             return coin.symbol === symbol;
           })
@@ -364,14 +367,14 @@ const SellCryptoRoot = ({
       (wallet.network === 'livenet' ||
         (__DEV__ &&
           wallet.network === 'testnet' &&
-          getCurrencyAbbreviation(
+          getExternalServiceSymbol(
             wallet.currencyAbbreviation.toLowerCase(),
             wallet.chain,
           ) === 'eth')) &&
       wallet.balance?.satSpendable > 0 &&
       sellCryptoSupportedCoins &&
       sellCryptoSupportedCoins.some(coin => {
-        const symbol = getCurrencyAbbreviation(
+        const symbol = getExternalServiceSymbol(
           wallet.currencyAbbreviation.toLowerCase(),
           wallet.chain,
         );
@@ -391,13 +394,13 @@ const SellCryptoRoot = ({
       (wallet.network === 'livenet' ||
         (__DEV__ &&
           wallet.network === 'testnet' &&
-          getCurrencyAbbreviation(
+          getExternalServiceSymbol(
             wallet.currencyAbbreviation.toLowerCase(),
             wallet.chain,
           ) === 'eth')) &&
       sellCryptoSupportedCoins &&
       sellCryptoSupportedCoins.some(coin => {
-        const symbol = getCurrencyAbbreviation(
+        const symbol = getExternalServiceSymbol(
           wallet.currencyAbbreviation.toLowerCase(),
           wallet.chain,
         );
@@ -823,7 +826,7 @@ const SellCryptoRoot = ({
             );
             return {
               currencyAbbreviation: code.toLowerCase(),
-              symbol: getCurrencyAbbreviation(code, chain),
+              symbol: getExternalServiceSymbol(code, chain),
               name,
               chain,
               protocol: metadata?.networkCode,
@@ -871,7 +874,7 @@ const SellCryptoRoot = ({
       }
 
       if (fromWallet?.chain && fromWallet?.currencyAbbreviation) {
-        const fromWalletSymbol = getCurrencyAbbreviation(
+        const fromWalletSymbol = getExternalServiceSymbol(
           fromWallet!.currencyAbbreviation,
           fromWallet!.chain,
         );
@@ -1022,7 +1025,7 @@ const SellCryptoRoot = ({
       const selectedCoin = sellCryptoSupportedCoins.find(
         coin =>
           coin.symbol ===
-          getCurrencyAbbreviation(
+          getExternalServiceSymbol(
             selectedWallet.currencyAbbreviation,
             selectedWallet.chain,
           ),

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -213,7 +213,7 @@ const SwapCryptoRoot: React.FC = () => {
   const tokenOptions = Object.entries(tokenOptionsByAddress).map(
     ([k, {symbol}]) => {
       const chain = getChainFromTokenByAddressKey(k);
-      return getCurrencyAbbreviation(symbol.toLowerCase(), chain);
+      return getExternalServiceSymbol(symbol.toLowerCase(), chain);
     },
   );
   const {rates} = useAppSelector(({RATE}) => RATE);
@@ -355,7 +355,7 @@ const SwapCryptoRoot: React.FC = () => {
         const isCoinPresentedInExchange = exchange.supportedCoins.find(
           coin =>
             coin.symbol ===
-            getCurrencyAbbreviation(
+            getExternalServiceSymbol(
               fromWallet.currencyAbbreviation,
               fromWallet.chain,
             ),
@@ -406,12 +406,12 @@ const SwapCryptoRoot: React.FC = () => {
     }
 
     const pair =
-      getCurrencyAbbreviation(
+      getExternalServiceSymbol(
         fromWalletSelected.currencyAbbreviation,
         fromWalletSelected.chain,
       ) +
       '_' +
-      getCurrencyAbbreviation(
+      getExternalServiceSymbol(
         toWalletSelected.currencyAbbreviation,
         toWalletSelected.chain,
       );
@@ -799,9 +799,8 @@ const SwapCryptoRoot: React.FC = () => {
       // If currency is not EVM => return true
       // If currency is EVM => check tokens
       (!changellySupportedEvmChains.includes(currencyBlockchain) ||
-        currency.name === 'eth' ||
         allSupportedTokens.includes(
-          getCurrencyAbbreviation(
+          getExternalServiceSymbol(
             currency.name,
             getChainFromChangellyBlockchain(currency.name, currency.blockchain),
           ),
@@ -863,7 +862,7 @@ const SwapCryptoRoot: React.FC = () => {
               const chain = getChainFromChangellyBlockchain(name, blockchain);
               return {
                 currencyAbbreviation: name.toLowerCase(),
-                symbol: getCurrencyAbbreviation(name, chain),
+                symbol: getExternalServiceSymbol(name, chain),
                 name: fullName,
                 chain,
                 protocol,
@@ -937,7 +936,7 @@ const SwapCryptoRoot: React.FC = () => {
           currency.protocol.toLowerCase(),
         )
           ? allSupportedTokens.includes(
-              getCurrencyAbbreviation(
+              getExternalServiceSymbol(
                 currency.ticker.toLowerCase(),
                 currency.protocol.toLowerCase(),
               ),
@@ -999,7 +998,7 @@ const SwapCryptoRoot: React.FC = () => {
               };
               return {
                 currencyAbbreviation: ticker.toLowerCase(),
-                symbol: getCurrencyAbbreviation(
+                symbol: getExternalServiceSymbol(
                   ticker.toLowerCase(),
                   protocol.toLowerCase(),
                 ),
@@ -1580,7 +1579,7 @@ const SwapCryptoRoot: React.FC = () => {
             customToSelectCurrencies={swapCryptoSupportedCoinsTo}
             disabledChain={
               fromWalletSelected
-                ? getCurrencyAbbreviation(
+                ? getExternalServiceSymbol(
                     fromWalletSelected.currencyAbbreviation,
                     fromWalletSelected.chain,
                   )

--- a/src/navigation/services/swap-crypto/utils/changelly-utils.ts
+++ b/src/navigation/services/swap-crypto/utils/changelly-utils.ts
@@ -335,14 +335,14 @@ export const getChangellyFixedCurrencyAbbreviation = (
     usdt: {eth: 'usdt20'},
     matic: {matic: 'maticpolygon'},
     eth: {
-      arbitrum: 'etharb',
-      optimism: 'ethop',
+      arb: 'etharb',
+      op: 'ethop',
     },
     usdc: {
       matic: 'usdcmatic',
-      arbitrum: 'usdcarb',
+      arb: 'usdcarb',
       base: 'usdcbase',
-      optimism: 'usdcop',
+      op: 'usdcop',
     },
   };
 


### PR DESCRIPTION
Due to this error, ETH Optimism/Arbitrum/Base wallets were displayed when they were not necessarily supported by external services. This caused for example that the "Sell" withdrawal method selector to be empty when ETH (Optimism) was selected.