### PR TITLE
Fix: swap crypto fixes

### DIFF
--- a/src/components/chain-search/ChainSearch.tsx
+++ b/src/components/chain-search/ChainSearch.tsx
@@ -157,7 +157,8 @@ const SearchComponent = <T extends SearchableItem>({
           'keyoverview',
           'send',
           'receive',
-          'swap',
+          'swapFrom',
+          'swapTo',
           'buy',
           'sell',
         ].includes(context)

--- a/src/components/list/GlobalSelectRow.tsx
+++ b/src/components/list/GlobalSelectRow.tsx
@@ -84,7 +84,7 @@ const GlobalSelectRow = ({item, hasSelectedChainFilterOption, emit}: Props) => {
         <CurrencyImage img={img} />
       </CurrencyImageContainer>
       <CurrencyColumn>
-        <H5>{currencyName.includes('Ethereum') ? 'Ethereum' : currencyName}</H5>
+        <H5>{currencyName}</H5>
         <ListItemSubText ellipsizeMode="tail" numberOfLines={1}>
           {currencyAbbreviation.toUpperCase()}
         </ListItemSubText>

--- a/src/components/modal/chain-selector/ChainSelector.tsx
+++ b/src/components/modal/chain-selector/ChainSelector.tsx
@@ -48,7 +48,8 @@ import {SearchIconContainer} from '../../chain-search/ChainSearch';
 
 export const ignoreGlobalListContextList = [
   'sell',
-  'swap',
+  'swapFrom',
+  'swapTo',
   'buy',
   'walletconnect',
   'createNewKey',
@@ -176,7 +177,7 @@ const ChainSelector = ({onModalHide}: {onModalHide?: () => void}) => {
                 | SupportedChains
                 | undefined;
 
-              // Check if the context is one of 'sell', 'swap', 'buy', 'walletconnect'
+              // Check if the context is one of 'sell', 'swapFrom', 'swapTo', 'buy', 'walletconnect'
               if (selectingNetworkForDeposit) {
                 dispatch(setSelectedNetworkForDeposit(option));
               } else if (

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -117,7 +117,7 @@ import {
   ThorswapCurrency,
   ThorswapGetCurrenciesRequestData,
 } from '../../../../store/swap-crypto/models/thorswap.models';
-import {SwapCryptoExchangeKey} from '../utils/swap-crypto-utils';
+import {isPairSupported, SwapCryptoExchangeKey} from '../utils/swap-crypto-utils';
 import {SwapCryptoLimits} from '../../../../store/swap-crypto/swap-crypto.models';
 
 export type SwapCryptoRootScreenParams =
@@ -423,7 +423,15 @@ const SwapCryptoRoot: React.FC = () => {
           exchange.showOffer &&
           !exchange.disabled &&
           exchange.supportedCoins &&
-          exchange.supportedCoins.length > 0,
+          exchange.supportedCoins.length > 0 &&
+          isPairSupported(
+            exchange.key,
+            fromWalletSelected.currencyAbbreviation,
+            fromWalletSelected.chain,
+            toWalletSelected.currencyAbbreviation,
+            toWalletSelected.chain,
+            exchange.supportedCoins,
+          )
       )
       .map(exchange => exchange.key);
 

--- a/src/navigation/services/swap-crypto/utils/changelly-utils.ts
+++ b/src/navigation/services/swap-crypto/utils/changelly-utils.ts
@@ -270,6 +270,12 @@ export const getChangellyCurrenciesFixedProps = (
       contractAddress?: string;
     };
   } = {
+    usdc: {
+      name: 'usdc',
+      fullName: 'USD Coin',
+      blockchain: 'ethereum',
+      contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    },
     usdt20: {
       name: 'usdt',
       fullName: 'Tether USD',

--- a/src/navigation/tabs/settings/external-services/screens/SwapHistorySelector.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SwapHistorySelector.tsx
@@ -79,9 +79,8 @@ const SwapHistorySelector = () => {
             ? Object.values(allSwapExchangesData).map(
                 (exchange: ExchangeData) => {
                   return exchange?.showExchange ? (
-                    <View>
+                    <View key={exchange.key}>
                       <Setting
-                        key={exchange.key}
                         onPress={() => {
                           haptic('impactLight');
                           navigation.navigate(exchange.screenHistory);


### PR DESCRIPTION
This PR fixes:

- The minimum is now handled in Amount View, if the pair selected by the user is only supported by Changelly

Thorswap no longer maintains an endpoint to consult the limits of the selected pair, so if Thorswap is enabled, in the amount selector I do not show minAmount (maxAmount is the available funds of the wallet). I only show minAmount and maxAmount if Changelly is the only exchange enabled for swap.

- "USD Coin" was being renamed as "Ethereum" in the swap selectors, this error had two origins: The first is that Changelly decided to change the name of "USD Coin" to "USD Coin Ehtereum Chain", and in turn we had a line in the GlobalSelector that stepped on every string that contains the word Ethereum for "Ethereum"

- Filters were not working for swap crypto. It was due to "context"

- Other small issues