### PR TITLE
Fix: prevent showing txp duplicated

### DIFF
--- a/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
@@ -205,7 +205,7 @@ const TransactionProposalNotifications = () => {
   ): number => {
     let i = 0;
     txpsPerWallet.forEach(txp => {
-      if (txp.statusForUs === 'pending' && canBeSigned) {
+      if (txp.statusForUs === 'pending' && canBeSigned && txp.amountStr) {
         i = i + 1;
       }
     });
@@ -423,7 +423,7 @@ const TransactionProposalNotifications = () => {
                       icon={TransactionIcons[txp.uiIcon]}
                       creator={txp.uiCreator}
                       time={txp.uiTime}
-                      value={txp.uiValue}
+                      value={txp.uiValue || txp.feeStr}
                       message={txp.message}
                       onPressTransaction={() => onPressTxp(txp, fullWalletObj)}
                       hideIcon={true}

--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -85,10 +85,6 @@ export const ProcessPendingTxps =
     const {currencyAbbreviation, chain, tokenAddress} = wallet;
 
     txps.forEach((tx: TransactionProposal) => {
-      // Filter received txs with no effects for ERC20 tokens only
-      if (IsERCToken(currencyAbbreviation, chain) && !tx.effects?.[0]) {
-        return;
-      }
       tx = dispatch(ProcessTx(tx, wallet));
 
       // no future transactions...
@@ -216,9 +212,11 @@ const ProcessTx =
       tokenAddress = tx.effects[0].contractAddress?.toLowerCase();
     }
 
-    tx.amountStr = dispatch(
-      FormatAmountStr(tokenSymbol || coin, chain, tokenAddress, tx.amount),
-    );
+    if (tx.coin === wallet.currencyAbbreviation) {
+      tx.amountStr = dispatch(
+        FormatAmountStr(tokenSymbol || coin, chain, tokenAddress, tx.amount),
+      );
+    }
 
     tx.feeStr = tx.fee
       ? // @ts-ignore


### PR DESCRIPTION
* Temporal solution: shouldn't get 2 transactions for sending Token that pay fees with ETH.

BEFORE

![Simulator Screenshot - iPhone 15 - 2024-08-12 at 17 13 00](https://github.com/user-attachments/assets/b81577c2-9714-4f91-9be1-c0478b822254)

AFTER 

![Simulator Screenshot - iPhone 15 - 2024-08-12 at 17 22 07](https://github.com/user-attachments/assets/bf0bfea5-8032-438f-b5a1-77da142629a7)
