### PR TITLE
Ref: prevent cached responses for token allowance requests

### DIFF
--- a/src/navigation/services/components/ApproveErc20Modal.tsx
+++ b/src/navigation/services/components/ApproveErc20Modal.tsx
@@ -529,8 +529,8 @@ const ApproveErc20Modal: React.FC<ApproveErc20ModalProps> = ({
                       <LinkIcon />
                       <ContractLink
                         onPress={() =>
-                          console.log(
-                            'TODO: spenderData.address: ' + spenderData.address,
+                          dispatch(
+                            viewOnBlockchain(wallet, spenderData.address),
                           )
                         }>
                         {t('View Contract')}

--- a/src/navigation/wallet/components/SendingToERC20Warning.tsx
+++ b/src/navigation/wallet/components/SendingToERC20Warning.tsx
@@ -123,10 +123,10 @@ interface Props {
 }
 
 export const viewOnBlockchain =
-  (wallet: Wallet): Effect =>
+  (wallet: Wallet, address?: string): Effect =>
   async dispatch => {
     const chain = wallet.chain.toLowerCase();
-    const tokenAddress = wallet.credentials.token?.address;
+    const tokenAddress = address ?? wallet.credentials.token?.address;
     const url =
       wallet.network === 'livenet'
         ? `https://${BitpaySupportedEvmCoins[chain]?.paymentInfo.blockExplorerUrls}address/${tokenAddress}`


### PR DESCRIPTION
In this PR I also fixed the "View contract" link of the spender address