### PR TITLE
Fix: TX history for Thorswap transactions (OP_RETURN)

### DIFF
--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -178,6 +178,10 @@ const ProcessTx =
     // New transaction output format. Fill tx.amount and tx.toAmount for
     // backward compatibility.
     if (tx.outputs?.length) {
+      // ThorSwap has OP_RETURN output in the first position with addressTo = 'false'.
+      tx.outputs = tx.outputs.filter(o => o.address !== 'false');
+      tx.addressTo = tx.outputs[0].address!;
+
       const outputsNr = tx.outputs.length;
 
       if (tx.action !== 'received') {


### PR DESCRIPTION
When first address from `outputs` is `false`, it's a transaction with OP_RETURN (amount: 0). 

```
addressTo: 'false',
outputs: [
    {
      address: 'false',
      amount: 0,
      message: null,
      encryptedMessage: null
    },
    {
      address: 'bxxx',
      amount: 1000000,
      message: '<ECANNOTDECRYPT>',
      encryptedMessage: '{xxx}'
    }
  ]
```



![Simulator Screenshot - iPhone 15 - 2024-08-22 at 18 36 32](https://github.com/user-attachments/assets/559e2dc3-8397-4292-8a64-951e6173693f)
