### PR TITLE
Feat: run detect and create tokens when new block arrives

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -208,6 +208,7 @@ export type SilentPushEvent = {
   notification_type?: string;
   ab?: any;
   tokenAddress?: string | null;
+  chain?: string;
   coin?: string;
   network?: string;
 };

--- a/src/components/modal/import-ledger-wallet/ImportLedgerWalletModal.tsx
+++ b/src/components/modal/import-ledger-wallet/ImportLedgerWalletModal.tsx
@@ -93,7 +93,12 @@ export const ImportLedgerWalletModal = () => {
           }),
         );
       }
-      dispatch(startUpdateAllKeyAndWalletStatus({force: true}));
+      dispatch(
+        startUpdateAllKeyAndWalletStatus({
+          context: 'importLedger',
+          force: true,
+        }),
+      );
     }
     dispatch(AppActions.importLedgerModalToggled(false));
   };

--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -193,10 +193,17 @@ const HomeRoot = () => {
     try {
       await dispatch(startGetRates({}));
       await Promise.all([
-        dispatch(startUpdateAllKeyAndWalletStatus({force: true})),
+        dispatch(
+          startUpdateAllKeyAndWalletStatus({
+            context: 'homeRootOnRefresh',
+            force: true,
+            createTokenWalletWithFunds: true,
+          }),
+        ),
         dispatch(requestBrazeContentRefresh()),
         sleep(1000),
       ]);
+      await sleep(2000);
       dispatch(updatePortfolioBalance());
     } catch (err) {
       dispatch(showBottomNotificationModal(BalanceUpdateError()));

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -977,8 +977,16 @@ export const setEmailNotifications =
   };
 
 const _startUpdateAllKeyAndWalletStatus = debounce(
-  async dispatch => {
-    dispatch(startUpdateAllKeyAndWalletStatus({force: true}));
+  async (dispatch, chain, tokenAddress) => {
+    dispatch(
+      startUpdateAllKeyAndWalletStatus({
+        context: 'newBlockEvent',
+        force: true,
+        createTokenWalletWithFunds: true,
+        chain,
+        tokenAddress,
+      }),
+    );
     DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
   },
   5000,
@@ -1062,7 +1070,12 @@ export const handleBwsEvent =
           break;
         case 'NewBlock':
           if (response.network && response.network === 'livenet') {
-            _startUpdateAllKeyAndWalletStatus(dispatch);
+            // Chain and tokenAddress are passed to check if a new token received funds on that network and create the wallet if necessary
+            _startUpdateAllKeyAndWalletStatus(
+              dispatch,
+              response.chain,
+              response.tokenAddress,
+            );
           }
           break;
         case 'TxProposalAcceptedBy':

--- a/src/store/wallet/effects/import/import.ts
+++ b/src/store/wallet/effects/import/import.ts
@@ -272,7 +272,12 @@ export const startMigration =
 
         // update store with token rates from coin gecko and update balances
         await dispatch(startGetRates({force: true}));
-        await dispatch(startUpdateAllKeyAndWalletStatus({force: true}));
+        await dispatch(
+          startUpdateAllKeyAndWalletStatus({
+            context: 'startMigration',
+            force: true,
+          }),
+        );
         dispatch(
           LogActions.info(
             '[startMigration] - success migration keys and wallets',

--- a/src/store/wallet/effects/init/init.ts
+++ b/src/store/wallet/effects/init/init.ts
@@ -16,7 +16,7 @@ export const startWalletStoreInit =
       await dispatch(startGetRates({init: true})); // populate rates and alternative currency list
 
       if (Object.keys(WALLET.keys).length) {
-        dispatch(startUpdateAllKeyAndWalletStatus({}));
+        dispatch(startUpdateAllKeyAndWalletStatus({context: 'init'}));
       }
 
       dispatch(WalletActions.successWalletStoreInit());


### PR DESCRIPTION
I also include a verified_contract filter to minimize possible spam tokens

Fix: The detectAndCreateTokens function was running only for the first detected EVM wallet. With this fix all EVM wallets for the key will be checked.

I updated the Key overview to update the status every time the user enters the view

I added more logs