### PR TITLE
Fix: key updates when there are changes in settings

### DIFF
--- a/src/navigation/wallet/screens/KeySettings.tsx
+++ b/src/navigation/wallet/screens/KeySettings.tsx
@@ -365,7 +365,7 @@ const KeySettings = () => {
         </SearchComponentContainer>
       </>
     );
-  }, []);
+  }, [_key, keyName]);
 
   const renderListFooterComponent = useCallback(() => {
     return (
@@ -559,7 +559,7 @@ const KeySettings = () => {
         </VerticalPadding>
       </>
     );
-  }, []);
+  }, [_key]);
 
   const memoizedRenderItem = useCallback(
     ({item, index}: {item: AccountRowProps; index: number}) => {

--- a/src/navigation/wallet/screens/UpdateKeyOrWalletName.tsx
+++ b/src/navigation/wallet/screens/UpdateKeyOrWalletName.tsx
@@ -69,7 +69,20 @@ const UpdateKeyOrWalletName: React.FC<UpdateKeyOrWalletNameScreenProps> = ({
     formState: {errors},
   } = useForm<{name: string}>({resolver: yupResolver(schema)});
 
-  const placeholder = context === 'key' ? key.keyName : walletName;
+  const setPlaceholderName = (context: string) => {
+    switch (context) {
+      case 'key':
+        return key.keyName;
+      case 'wallet':
+        return walletName;
+      case 'account':
+        return accountItem?.accountName;
+      default:
+        return '';
+    }
+  };
+
+  const placeholder = setPlaceholderName(context);
 
   const updateName = ({name}: {name: string}) => {
     if (context === 'key') {


### PR DESCRIPTION
Fixes: 
- The placeholder is not auto-filling in the Account name change form.
- When a new Key name is saved, it is not updated where names are displayed in settings, for example in the "Export wallet" option