### PR TITLE
[FIX] Flashing transaction proposals on scroll

### DIFF
--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -15,6 +15,7 @@ import React, {
 import {useTranslation} from 'react-i18next';
 import {
   DeviceEventEmitter,
+  FlatList,
   Linking,
   RefreshControl,
   Share,
@@ -1245,23 +1246,21 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
                     </ProposalBadgeContainer>
                   </TransactionSectionHeaderContainer>
                   {fullWalletObj.credentials.n > 1 ? (
-                    <FlashList
+                    <FlatList
                       contentContainerStyle={{
                         paddingTop: 20,
                         paddingBottom: 20,
                       }}
-                      estimatedItemSize={TRANSACTION_ROW_HEIGHT}
                       data={needActionPendingTxps}
                       keyExtractor={pendingTxpsKeyExtractor}
                       renderItem={renderTxp}
                     />
                   ) : (
-                    <FlashList
+                    <FlatList
                       contentContainerStyle={{
                         paddingTop: 20,
                         paddingBottom: 20,
                       }}
-                      estimatedItemSize={TRANSACTION_ROW_HEIGHT}
                       data={needActionUnsentTxps}
                       keyExtractor={pendingTxpsKeyExtractor}
                       renderItem={renderTxp}


### PR DESCRIPTION
It appears that using a `FlashList` within the `ListHeaderComponent` of another `FlashList` causes the `FlashList` inside of the `ListHeaderComponent` to...well...flash during scrolling. This PR gets the `ListHeaderComponent` containing transaction proposals to use a `FlatList` again (instead of a `FlashList`) to eliminate flashing during scrolling.