### PR TITLE
Fix: check existing tokens before auto-create

### DIFF
--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -139,6 +139,7 @@ import KeySvg from '../../../../assets/img/key.svg';
 import ReceiveAddress from '../components/ReceiveAddress';
 import {IsEVMChain} from '../../../store/wallet/utils/currency';
 import {LogActions} from '../../../store/log/';
+import uniqBy from 'lodash.uniqby';
 
 export type AccountDetailsScreenParamList = {
   selectedAccountAddress: string;
@@ -341,8 +342,11 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
   );
 
   const key = keys[keyId];
-  const keyFullWalletObjs = key.wallets.filter(
-    w => w.receiveAddress === selectedAccountAddress,
+  const keyFullWalletObjs = uniqBy(
+    key.wallets.filter(w => w.receiveAddress === selectedAccountAddress),
+    wallet => {
+      return wallet.id;
+    },
   );
   let pendingTxps: AccountProposalsProps = {};
   keyFullWalletObjs.forEach(x => {

--- a/src/store/wallet/effects/create/create.ts
+++ b/src/store/wallet/effects/create/create.ts
@@ -17,6 +17,7 @@ import {
   failedAddWallet,
   successAddWallet,
   successCreateKey,
+  successUpdateKey,
 } from '../../wallet.actions';
 import API from 'bitcore-wallet-client/ts_build';
 import {Key, KeyMethods, KeyOptions, Token, Wallet} from '../../wallet.models';
@@ -45,6 +46,7 @@ import {MoralisErc20TokenBalanceByWalletData} from '../../../moralis/moralis.typ
 import {getERC20TokenBalanceByWallet} from '../../../moralis/moralis.effects';
 import {getTokenContractInfo, startUpdateWalletStatus} from '../status/status';
 import {addCustomTokenOption} from '../currencies/currencies';
+import {uniq} from 'lodash';
 
 export interface CreateOptions {
   network?: Network;
@@ -905,41 +907,65 @@ export const detectAndCreateTokensForEachEvmWallet =
           }
 
           for (const [index, tokenToAdd] of filteredTokens.entries()) {
-            try {
-              const newTokenWallet: AddWalletData = {
-                key,
-                associatedWallet: w,
-                currency: {
-                  chain: w.chain,
-                  currencyAbbreviation: tokenToAdd.symbol.toLowerCase(),
-                  isToken: true,
-                  tokenAddress: tokenToAdd.token_address,
-                  decimals: tokenToAdd.decimals,
-                },
-                options: {
-                  network: Network.mainnet,
-                  ...(account !== undefined && {
-                    account,
-                    customAccount,
-                  }),
-                },
-              };
-              const newWallet = await dispatch(addWallet(newTokenWallet));
-              if (newWallet) {
-                await dispatch(
-                  startUpdateWalletStatus({
-                    key,
-                    wallet: newWallet,
-                    force: true,
-                  }),
-                );
-              }
-            } catch (err) {
+            const existingTokenWallet = key.wallets.filter(wallet => {
+              return (
+                wallet.id ===
+                `${w.id}-${cloneDeep(tokenToAdd.token_address).toLowerCase()}`
+              );
+            });
+            if (existingTokenWallet[0]) {
+              // workaround for cases where the token was already created but for some reason was not included in the list of tokens in the associated wallet
               dispatch(
                 LogActions.debug(
-                  `Error[${index}] adding Token: ${tokenToAdd?.symbol} (${tokenToAdd.token_address}). Continue anyway...`,
+                  `Token ${tokenToAdd.symbol} (${tokenToAdd.token_address}) already created for this wallet. Adding to tokens list in the associated wallet`,
                 ),
               );
+
+              (w.tokens || []).push(existingTokenWallet[0].id);
+              w.tokens = uniq(w.tokens);
+
+              await dispatch(
+                successUpdateKey({
+                  key,
+                }),
+              );
+            } else {
+              try {
+                const newTokenWallet: AddWalletData = {
+                  key,
+                  associatedWallet: w,
+                  currency: {
+                    chain: w.chain,
+                    currencyAbbreviation: tokenToAdd.symbol.toLowerCase(),
+                    isToken: true,
+                    tokenAddress: tokenToAdd.token_address,
+                    decimals: tokenToAdd.decimals,
+                  },
+                  options: {
+                    network: Network.mainnet,
+                    ...(account !== undefined && {
+                      account,
+                      customAccount,
+                    }),
+                  },
+                };
+                const newWallet = await dispatch(addWallet(newTokenWallet));
+                if (newWallet) {
+                  await dispatch(
+                    startUpdateWalletStatus({
+                      key,
+                      wallet: newWallet,
+                      force: true,
+                    }),
+                  );
+                }
+              } catch (err) {
+                dispatch(
+                  LogActions.debug(
+                    `Error[${index}] adding Token: ${tokenToAdd?.symbol} (${tokenToAdd.token_address}). Continue anyway...`,
+                  ),
+                );
+              }
             }
           }
         }

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -63,8 +63,7 @@ import {
   AssetsByChainData,
   AssetsByChainListProps,
 } from '../../../navigation/wallet/screens/AccountDetails';
-import {DeviceEventEmitter} from 'react-native';
-import {DeviceEmitterEvents} from '../../../constants/device-emitter-events';
+import uniqBy from 'lodash.uniqby';
 
 export const mapAbbreviationAndName =
   (
@@ -1065,7 +1064,10 @@ export const buildAccountList = (
       currencyDisplay: 'symbol',
     });
 
-  const wallets = opts?.filterByCustomWallets || key.wallets;
+  const wallets = uniqBy(
+    opts?.filterByCustomWallets || key.wallets,
+    wallet => wallet.id,
+  );
 
   wallets.forEach(wallet => {
     if (opts?.filterByHideWallet && wallet.hideWallet) {


### PR DESCRIPTION
This workaround is for the app to check if the detected funded token has already been created previously, and if for some reason it was not added to the AssociatedWallet.tokens, then it adds it there and does not create it again.
It also adds a uniqBy(..., id) function so that only one wallet of said token is shown in account details, in case the same token has already been created more than once previously.