### PR TITLE
[FIX] account creation on key's without evm wallets

### DIFF
--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -398,9 +398,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     keyOptions.push({
       img: <Icons.Wallet width="15" height="15" />,
       title: t('Add EVM Chain'),
-      description: t(
-        'Choose another evm chain you would like to add to your account.',
-      ),
+      description: t('Add all supported chains to this account.'),
       onPress: async () => {
         haptic('impactLight');
         await sleep(500);
@@ -438,8 +436,10 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     onPress: async () => {
       haptic('impactLight');
       await sleep(500);
-      navigation.navigate('KeySettings', {
+      navigation.navigate('AccountSettings', {
         key,
+        selectedAccountAddress: accountItem.receiveAddress,
+        context: 'accountDetails',
       });
     },
   });

--- a/src/navigation/wallet/screens/AddingOptions.tsx
+++ b/src/navigation/wallet/screens/AddingOptions.tsx
@@ -97,8 +97,7 @@ const AddingOptions: React.FC = () => {
           const accounts = evmWallets.map(
             ({credentials}) => credentials.account,
           );
-          const currentAccountNumber = Math.max(...accounts);
-
+          const account = accounts.length > 0 ? Math.max(...accounts) + 1 : 0;
           await dispatch(startOnGoingProcessModal('ADDING_CHAINS'));
           const wallets = await dispatch(
             createMultipleWallets({
@@ -107,7 +106,7 @@ const AddingOptions: React.FC = () => {
               options: {
                 network,
                 password,
-                account: currentAccountNumber + 1,
+                account,
                 customAccount: true,
               },
             }),

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -631,7 +631,9 @@ export const startOnGoingProcessModal =
         currentStore.APP.onGoingProcessModalMessage !==
           i18n.t('Importing... this process may take a few minutes') &&
         currentStore.APP.onGoingProcessModalMessage !==
-          i18n.t('Scanning Funds... this process may take a few minutes')
+          i18n.t('Scanning Funds... this process may take a few minutes') &&
+        currentStore.APP.onGoingProcessModalMessage !==
+          i18n.t("Creating Key... just a second, we're setting a few things up")
       ) {
         dispatch(AppActions.dismissOnGoingProcessModal());
         await sleep(500);


### PR DESCRIPTION
- This update fixes the issue with adding an EVM account to keys that don’t yet have an EVM wallet.
- Updated option text description.
- Corrected the navigation to direct to Account Settings instead of Key Settings from the account view.
- Added CREATING_KEY to the list of ongoingprocess that will not be dismissed after 60 seconds