### PR TITLE
Fix: prevents call CONTENT_CARDS_UPDATED event ad infinitum

### DIFF
--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -450,7 +450,8 @@ export const initializeBrazeContent = (): Effect => (dispatch, getState) => {
 
     contentCardSubscription = Braze.addListener(
       Braze.Events.CONTENT_CARDS_UPDATED,
-      async () => {
+      async (update: Braze.ContentCardsUpdatedEvent) => {
+        const contentCards = update.cards;
         const isInitializing = currentRetry < MAX_RETRIES;
 
         dispatch(
@@ -462,8 +463,6 @@ export const initializeBrazeContent = (): Effect => (dispatch, getState) => {
                 'Braze content cards updated, fetching latest content cards...',
               ),
         );
-
-        const contentCards = await Braze.getContentCards();
 
         if (contentCards.length) {
           currentRetry = MAX_RETRIES;


### PR DESCRIPTION
New SDK doesn't require to call `getContentCards`.
Event `CONTENT_CARDS_UPDATED` listen for updates as a result of card refreshes. 
Keep `requestContentCardsRefresh()` to refresh manually if getting 0 cards.