### PR TITLE
Fix: excessive top padding for global select component on iOS

### DIFF
--- a/src/navigation/coinbase/screens/CoinbaseAccount.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseAccount.tsx
@@ -211,7 +211,6 @@ const CoinbaseAccount = ({
   route,
 }: NativeStackScreenProps<CoinbaseGroupParamList, 'CoinbaseAccount'>) => {
   const {t} = useTranslation();
-  const insets = useSafeAreaInsets();
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
@@ -769,8 +768,7 @@ const CoinbaseAccount = ({
         isVisible={walletModalVisible}
         onBackdropPress={() => onDismiss()}
         fullscreen>
-        <GlobalSelectContainer
-          style={Platform.OS === 'ios' ? {paddingTop: insets.top} : {}}>
+        <GlobalSelectContainer>
           <GlobalSelect
             route={route}
             navigation={navigation}

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
@@ -127,7 +127,6 @@ const BuyCryptoRoot = ({
 }: NativeStackScreenProps<BuyCryptoGroupParamList, BuyCryptoScreens.ROOT>) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
-  const insets = useSafeAreaInsets();
   const theme = useTheme();
   const logger = useLogger();
   const allKeys = useAppSelector(({WALLET}: RootState) => WALLET.keys);
@@ -1050,8 +1049,7 @@ const BuyCryptoRoot = ({
         isVisible={walletSelectorModalVisible}
         onBackdropPress={() => onDismiss()}
         fullscreen>
-        <GlobalSelectContainer
-          style={Platform.OS === 'ios' ? {paddingTop: insets.top} : {}}>
+        <GlobalSelectContainer>
           <GlobalSelect
             route={route}
             navigation={navigation}

--- a/src/navigation/services/swap-crypto/components/FromWalletSelectorModal.tsx
+++ b/src/navigation/services/swap-crypto/components/FromWalletSelectorModal.tsx
@@ -65,7 +65,6 @@ const FromWalletSelectorModal: React.FC<FromWalletSelectorModalProps> = ({
   route,
 }) => {
   const {t} = useTranslation();
-  const insets = useSafeAreaInsets();
   const [swapCryptoHelpVisible, setSwapCryptoHelpVisible] = useState(false);
 
   const _customSupportedCurrencies = customSupportedCurrencies?.map(
@@ -82,8 +81,7 @@ const FromWalletSelectorModal: React.FC<FromWalletSelectorModalProps> = ({
       isVisible={isVisible}
       onBackdropPress={() => onDismiss(undefined)}
       fullscreen>
-      <GlobalSelectContainer
-        style={Platform.OS === 'ios' ? {paddingTop: insets.top} : {}}>
+      <GlobalSelectContainer>
         <GlobalSelect
           route={route}
           navigation={navigation}

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -223,7 +223,6 @@ const SwapCryptoRoot: React.FC = () => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
   const logger = useLogger();
-  const insets = useSafeAreaInsets();
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const locationData = useAppSelector(({LOCATION}) => LOCATION.locationData);
   const network = useAppSelector(({APP}) => APP.network);
@@ -1802,8 +1801,7 @@ const SwapCryptoRoot: React.FC = () => {
         isVisible={toWalletSelectorModalVisible}
         onBackdropPress={() => onDismiss()}
         fullscreen>
-        <GlobalSelectContainer
-          style={Platform.OS === 'ios' ? {paddingTop: insets.top} : {}}>
+        <GlobalSelectContainer>
           <GlobalSelect
             route={route}
             navigation={navigation}

--- a/src/navigation/wallet/screens/PaperWallet.tsx
+++ b/src/navigation/wallet/screens/PaperWallet.tsx
@@ -138,7 +138,6 @@ const PaperWallet: React.FC<PaperWalletProps> = ({navigation, route}) => {
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const logger = useLogger();
-  const insets = useSafeAreaInsets();
   const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const [buttonState, setButtonState] = useState<ButtonState>();
   const [balances, setBalances] = useState<
@@ -618,8 +617,7 @@ const PaperWallet: React.FC<PaperWalletProps> = ({navigation, route}) => {
           isVisible={walletSelectorVisible}
           onBackdropPress={() => onDismiss(undefined)}
           fullscreen>
-          <GlobalSelectContainer
-            style={Platform.OS === 'ios' ? {paddingTop: insets.top} : {}}>
+          <GlobalSelectContainer>
             <GlobalSelect
               route={route}
               navigation={navigation}


### PR DESCRIPTION
Safe area insets are now configured inside of the SheetModal component, so no need to also define them on each GlobalSelectContainer instance.