### PR TITLE
[REF] Update BTC & BCH testnet labels to Testnet4

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -121,10 +121,10 @@ export const PROTOCOL_NAME: {[key in string]: any} = {
     [Network.testnet]: 'Sepolia',
   },
   btc: {
-    [Network.testnet]: 'Testnet3',
+    [Network.testnet]: 'Testnet4',
   },
   bch: {
-    [Network.testnet]: 'Testnet3',
+    [Network.testnet]: 'Testnet4',
   },
   doge: {
     [Network.testnet]: 'Testnet3',


### PR DESCRIPTION
This is part of the migration from testnet3 -> testnet4 for both BCH and BTC.