### PR TITLE
Fix: replaces Flatlist by Flashlist

### DIFF
--- a/src/components/list/AssetsByChainRow.tsx
+++ b/src/components/list/AssetsByChainRow.tsx
@@ -7,7 +7,8 @@ import {
   RowContainer,
 } from '../styled/Containers';
 import {AssetsByChainData} from '../../navigation/wallet/screens/AccountDetails';
-import {FlatList, View} from 'react-native';
+import {View} from 'react-native';
+import {FlashList} from '@shopify/flash-list';
 import {H5} from '../styled/Text';
 import WalletRow, {WalletRowProps} from './WalletRow';
 import {CurrencyImage} from '../currency-image/CurrencyImage';
@@ -137,7 +138,8 @@ const AssetsByChainRow = ({
         </Column>
       </RowContainer>
       {showChainAssets[chain] ? (
-        <FlatList<WalletRowProps>
+        <FlashList<WalletRowProps>
+          estimatedItemSize={90}
           data={chainAssetsList}
           renderItem={memoizedRenderItem}
         />


### PR DESCRIPTION
Fixed error:

```
VirtualizedLists should never be nested inside plain ScrollViews with the same orientation because it can break windowing and other functionality - use another VirtualizedList-backed container instead. Error Component Stack
```