### PR TITLE
Fix: GlobalSelect should check coin/chain from credentials instead CurrencyAbbreviation

### DIFF
--- a/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
@@ -173,27 +173,28 @@ const ContactsDetails = ({
       // Remove prefix
       newAddress = ToCashAddress(contact.address, false);
     }
-    if (!IsEVMChain(contact.chain)) {
-      contactOptions.push({
-        img: theme.dark ? <SendIconWhite /> : <SendIcon />,
-        title: t('Send ') + contact.coin.toUpperCase(),
-        onPress: async () => {
-          setShowIconOptions(false);
-          await sleep(500);
-          navigation.navigate('GlobalSelect', {
-            context: 'contact',
-            recipient: {
-              name: contact.name,
-              address: newAddress,
-              currency: contact.coin,
-              chain: contact.chain,
-              network: contact.network,
-              destinationTag: contact.tag || contact.destinationTag,
+    contactOptions.push({
+      img: theme.dark ? <SendIconWhite /> : <SendIcon />,
+      title: t('Send to this contact'),
+      onPress: async () => {
+        setShowIconOptions(false);
+        await sleep(500);
+        navigation.navigate('GlobalSelect', {
+          context: 'contact',
+          recipient: {
+            name: contact.name,
+            address: newAddress,
+            currency: contact.coin,
+            chain: contact.chain,
+            network: contact.network,
+            destinationTag: contact.tag || contact.destinationTag,
+            opts: {
+              showEVMWalletsAndTokens: true,
             },
-          });
-        },
-      });
-    }
+          },
+        });
+      },
+    });
   }
 
   contactOptions.push({

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -644,7 +644,7 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
           (wallet.credentials.coin === recipient?.currency &&
             wallet.credentials.chain === recipient?.chain) ||
           (recipient?.opts?.showEVMWalletsAndTokens &&
-            BitpaySupportedEvmCoins[wallet.credentials.coin]),
+            BitpaySupportedEvmCoins[wallet.credentials.chain]),
       );
     }
     if (recipient?.network) {

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -641,10 +641,10 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
     if (recipient.currency && recipient.chain) {
       wallets = wallets.filter(
         wallet =>
-          (wallet.currencyAbbreviation === recipient?.currency &&
-            wallet.chain === recipient?.chain) ||
+          (wallet.credentials.coin === recipient?.currency &&
+            wallet.credentials.chain === recipient?.chain) ||
           (recipient?.opts?.showEVMWalletsAndTokens &&
-            BitpaySupportedEvmCoins[wallet.currencyAbbreviation]),
+            BitpaySupportedEvmCoins[wallet.credentials.coin]),
       );
     }
     if (recipient?.network) {
@@ -665,7 +665,7 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
       ),
     ];
     wallets = wallets.filter(wallet =>
-      supportedCurrencies.includes(wallet.currencyAbbreviation),
+      supportedCurrencies.includes(wallet.credentials.coin),
     );
   }
 
@@ -700,7 +700,10 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
           _filterByCustomWallets = wallets.filter(
             w =>
               allCurrencies.includes(
-                getExternalServiceSymbol(w.currencyAbbreviation, w.chain),
+                getExternalServiceSymbol(
+                  w.credentials.coin,
+                  w.credentials.chain,
+                ),
               ) && w.keyId === key.id,
           );
         } else {
@@ -708,7 +711,10 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
             const isContextValid =
               !['coinbaseDeposit'].includes(context) ||
               allCurrencies.includes(
-                getCurrencyAbbreviation(w.currencyAbbreviation, w.chain),
+                getCurrencyAbbreviation(
+                  w.credentials.coin,
+                  w.credentials.chain,
+                ),
               );
 
             return isContextValid && w.keyId === key.id;
@@ -879,8 +885,7 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
               wallet,
               sendTo,
               sendMaxEnabled: ['contact', 'scanner'].includes(context),
-              cryptoCurrencyAbbreviation:
-                wallet.currencyAbbreviation.toUpperCase(),
+              cryptoCurrencyAbbreviation: wallet.credentials.coin.toUpperCase(),
               chain: wallet.chain,
               tokenAddress: wallet.tokenAddress,
               onAmountSelected: async (amount, setButtonState, opts) => {

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -15,7 +15,6 @@ import {
   BitpaySupportedMaticTokens,
   BitpaySupportedUtxoCoins,
   OtherBitpaySupportedCoins,
-  SUPPORTED_CURRENCIES,
 } from '../../../constants/currencies';
 import {CurrencyListIcons} from '../../../constants/SupportedCurrencyOptions';
 import {BwcProvider} from '../../../lib/bwc';
@@ -25,7 +24,6 @@ import {
   GetProtocolPrefix,
   IsERCToken,
   IsEVMChain,
-  IsUtxoChain,
 } from './currency';
 import {
   addTokenChainSuffix,


### PR DESCRIPTION
* For Matic (Polygon), the app uses `CurrencyAbbreviation` to show it as POL instead of MATIC. 
* The result is that some External Service (like Coinbase) doesn't find any `matic` wallet if it checks against CurrencyAbbreviarion (that's `pol`).