### PR TITLE
Perf: add ability to specify unencrypted stores to boost perfomance

### DIFF
--- a/patches/redux-persist-transform-encrypt+3.0.1.patch
+++ b/patches/redux-persist-transform-encrypt+3.0.1.patch
@@ -1,0 +1,43 @@
+diff --git a/node_modules/redux-persist-transform-encrypt/lib/sync.d.ts b/node_modules/redux-persist-transform-encrypt/lib/sync.d.ts
+index 9951f2c..3f38ed2 100644
+--- a/node_modules/redux-persist-transform-encrypt/lib/sync.d.ts
++++ b/node_modules/redux-persist-transform-encrypt/lib/sync.d.ts
+@@ -3,5 +3,6 @@
+ export interface EncryptTransformConfig {
+     secretKey: string;
+     onError?: (err: Error) => void;
++    unencryptedStores?: string[];
+ }
+ export declare const encryptTransform: (config: EncryptTransformConfig) => import("redux-persist").Transform<unknown, string, any, any>;
+diff --git a/node_modules/redux-persist-transform-encrypt/lib/sync.js b/node_modules/redux-persist-transform-encrypt/lib/sync.js
+index cbb30ff..4b2a4fd 100644
+--- a/node_modules/redux-persist-transform-encrypt/lib/sync.js
++++ b/node_modules/redux-persist-transform-encrypt/lib/sync.js
+@@ -39,12 +39,27 @@ exports.encryptTransform = function (config) {
+         throw makeError('No secret key provided.');
+     }
+     var onError = typeof config.onError === 'function' ? config.onError : console.warn;
++    const unencryptedStores = config.unencryptedStores || [];
++
+     return redux_persist_1.createTransform(function (inboundState, _key) {
++        // Skip encryption for unencrypted stores
++        if (unencryptedStores.includes(_key)) {
++            return json_stringify_safe_1.default(inboundState);
++        }
+         return Aes.encrypt(json_stringify_safe_1.default(inboundState), secretKey).toString();
+     }, function (outboundState, _key) {
+         if (typeof outboundState !== 'string') {
+             return onError(makeError('Expected outbound state to be a string.'));
+         }
++
++        // For unencrypted stores, try parsing first
++        if (unencryptedStores.includes(_key)) {
++            try {
++                return JSON.parse(outboundState);
++            } catch (_e) {} // If parsing fails, try decryption below
++        }
++
++        // Handle both encrypted stores and failed unencrypted parses
+         try {
+             var decryptedString = Aes.decrypt(outboundState, secretKey).toString(CryptoJsCore.enc.Utf8);
+             if (!decryptedString) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -215,6 +215,7 @@ const getStore = () => {
             ),
           );
         },
+        unencryptedStores: ['RATE'],
       }),
     ],
   };

--- a/src/store/rate/rate.reducer.ts
+++ b/src/store/rate/rate.reducer.ts
@@ -3,7 +3,7 @@ import {RateActionType, RateActionTypes} from './rate.types';
 import {DEFAULT_DATE_RANGE} from '../../constants/rate';
 
 type RateReduxPersistBlackList = string[];
-export const rateReduxPersistBlackList: RateReduxPersistBlackList = [];
+export const rateReduxPersistBlackList: RateReduxPersistBlackList = ['ratesByDateRange'];
 
 export interface RateState {
   lastDayRates: Rates;
@@ -34,21 +34,19 @@ export const rateReducer = (
   switch (action.type) {
     case RateActionTypes.SUCCESS_GET_RATES: {
       const {rates, lastDayRates} = action.payload;
-
       return {
         ...state,
-        rates: {...state.rates, ...rates},
+        rates: {...initialState.rates, ...rates},
         ratesCacheKey: {
-          ...state.ratesCacheKey,
+          ...initialState.ratesCacheKey,
           [DEFAULT_DATE_RANGE]: Date.now(),
         },
-        lastDayRates: {...state.lastDayRates, ...lastDayRates},
+        lastDayRates: {...initialState.lastDayRates, ...lastDayRates},
       };
     }
 
     case RateActionTypes.SUCCESS_GET_HISTORICAL_RATES: {
       const {ratesByDateRange, dateRange = DEFAULT_DATE_RANGE} = action.payload;
-
       return {
         ...state,
         ratesByDateRange: {
@@ -66,7 +64,7 @@ export const rateReducer = (
       const {cacheKey, dateRange = DEFAULT_DATE_RANGE} = action.payload;
       return {
         ...state,
-        [cacheKey]: {...state.ratesCacheKey, [dateRange]: Date.now()},
+        [cacheKey]: {...initialState.ratesCacheKey, [dateRange]: Date.now()},
       };
     }
 
@@ -74,7 +72,7 @@ export const rateReducer = (
       const {cacheKey, dateRange = DEFAULT_DATE_RANGE} = action.payload;
       return {
         ...state,
-        [cacheKey]: {...state.ratesHistoricalCacheKey, [dateRange]: Date.now()},
+        [cacheKey]: {...initialState.ratesHistoricalCacheKey, [dateRange]: Date.now()},
       };
     }
 

--- a/src/store/shop/shop.reducer.ts
+++ b/src/store/shop/shop.reducer.ts
@@ -12,8 +12,8 @@ import {
 } from './shop.models';
 import {ShopActionType, ShopActionTypes} from './shop.types';
 
-type ShopReduxPersistBlackList = [];
-export const shopReduxPersistBlackList: ShopReduxPersistBlackList = [];
+type ShopReduxPersistBlackList = string[];
+export const shopReduxPersistBlackList: ShopReduxPersistBlackList = ['integrations'];
 
 export interface ShopState {
   availableCardMap: CardConfigMap;

--- a/src/store/wallet/effects/init/init.ts
+++ b/src/store/wallet/effects/init/init.ts
@@ -17,7 +17,7 @@ export const startWalletStoreInit =
         await dispatch(
           getAndDispatchUpdatedWalletBalances({
             context: 'init',
-            skipRateUpdate: true, // Skip rate update on initial load to improve performance
+            skipRateUpdate: false,
           }),
         );
       }


### PR DESCRIPTION
Adds the `RATE` store to the list of `unencryptedStores` since rates are not sensitive and do not require encryption, which can lead to performance issues on older devices.