### PR TITLE
Perf: migrate shop catalog data from `SHOP` to `SHOP_CATALOG`

### DIFF
--- a/src/navigation/tabs/shop/ShopHome.tsx
+++ b/src/navigation/tabs/shop/ShopHome.tsx
@@ -18,7 +18,7 @@ import {
   selectCategoriesAndCurations,
   selectCategoriesWithIntegrations,
   selectIntegrations,
-} from '../../../store/shop/shop.selectors';
+} from '../../../store/shop-catalog';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ShopScreens, ShopStackParamList} from './ShopStack';
@@ -30,7 +30,6 @@ import {HEIGHT} from '../../../components/styled/Containers';
 import {useTheme} from 'styled-components/native';
 import {SlateDark, White} from '../../../styles/colors';
 import {sleep} from '../../../utils/helper-methods';
-import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {withErrorFallback} from '../TabScreenErrorFallback';
 import TabContainer from '../TabContainer';
 
@@ -101,8 +100,9 @@ const ShopHome: React.FC<
 > = ({route}) => {
   const {t} = useTranslation();
   const theme = useTheme();
-  const availableCardMap = useAppSelector(({SHOP}) => SHOP.availableCardMap);
-  const supportedCardMap = useAppSelector(({SHOP}) => SHOP.supportedCardMap);
+  const availableCardMap = useAppSelector(({SHOP_CATALOG}) => SHOP_CATALOG.availableCardMap); 
+  const supportedCardMap = useAppSelector(({SHOP_CATALOG}) => SHOP_CATALOG.supportedCardMap);
+
   const user = useAppSelector(
     ({APP, BITPAY_ID}) => BITPAY_ID.user[APP.network],
   );

--- a/src/navigation/tabs/shop/gift-card/GiftCardDeeplink.tsx
+++ b/src/navigation/tabs/shop/gift-card/GiftCardDeeplink.tsx
@@ -1,7 +1,7 @@
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useEffect, useRef} from 'react';
 import {Analytics} from '../../../../store/analytics/analytics.effects';
-import {selectAvailableGiftCards} from '../../../../store/shop/shop.selectors';
+import {selectAvailableGiftCards} from '../../../../store/shop-catalog/shop-catalog.selectors';
 import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
 import {GiftCardGroupParamList} from './GiftCardGroup';
 

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -350,7 +350,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
   const [needActionPendingTxps, setNeedActionPendingTxps] = useState<any[]>([]);
   const [needActionUnsentTxps, setNeedActionUnsentTxps] = useState<any[]>([]);
   const [isScrolling, setIsScrolling] = useState<boolean>(false);
-  const supportedCardMap = useAppSelector(({SHOP}) => SHOP.supportedCardMap);
+  const supportedCardMap = useAppSelector(({SHOP_CATALOG}) => SHOP_CATALOG.supportedCardMap);
   const [showReceiveAddressBottomModal, setShowReceiveAddressBottomModal] =
     useState(false);
   const {rates} = useAppSelector(({RATE}) => RATE);

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -308,7 +308,7 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
   const {walletId, skipInitializeHistory, copayerId} = route.params;
   const {keys} = useAppSelector(({WALLET}) => WALLET);
   const {rates} = useAppSelector(({RATE}) => RATE);
-  const supportedCardMap = useAppSelector(({SHOP}) => SHOP.supportedCardMap);
+  const supportedCardMap = useAppSelector(({SHOP_CATALOG}) => SHOP_CATALOG.supportedCardMap);
 
   const locationData = useAppSelector(({LOCATION}) => LOCATION.locationData);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,6 +37,7 @@ import {
 } from './location/location.reducer';
 import {logReducer, logReduxPersistBlackList} from './log/log.reducer';
 import {shopReducer, shopReduxPersistBlackList} from './shop/shop.reducer';
+import {shopCatalogReducer} from './shop-catalog/shop-catalog.reducer';
 import {
   swapCryptoReducer,
   swapCryptoReduxPersistBlackList,
@@ -100,6 +101,7 @@ const reducerPersistBlackLists: Record<keyof typeof reducers, string[]> = {
   LOG: logReduxPersistBlackList,
   SELL_CRYPTO: sellCryptoReduxPersistBlackList,
   SHOP: shopReduxPersistBlackList,
+  SHOP_CATALOG: [],
   SWAP_CRYPTO: swapCryptoReduxPersistBlackList,
   WALLET: walletReduxPersistBlackList,
   RATE: rateReduxPersistBlackList,
@@ -124,6 +126,7 @@ const reducers = {
   LOG: logReducer,
   SELL_CRYPTO: sellCryptoReducer,
   SHOP: shopReducer,
+  SHOP_CATALOG: shopCatalogReducer,
   SWAP_CRYPTO: swapCryptoReducer,
   WALLET: walletReducer,
   RATE: rateReducer,
@@ -155,6 +158,13 @@ const logger = createLogger({
       SHOP: {
         ...state.SHOP,
         availableCardMap: null,
+        integrations: null,
+        supportedCardMap: null,
+      },
+      SHOP_CATALOG: {
+        ...state.SHOP_CATALOG,
+        availableCardMap: null,
+        categoriesAndCurations: null,
         integrations: null,
         supportedCardMap: null,
       },
@@ -215,7 +225,7 @@ const getStore = () => {
             ),
           );
         },
-        unencryptedStores: ['RATE'],
+        unencryptedStores: ['RATE', 'SHOP_CATALOG'],
       }),
     ],
   };

--- a/src/store/shop-catalog/index.ts
+++ b/src/store/shop-catalog/index.ts
@@ -1,0 +1,5 @@
+export * from './shop-catalog.actions';
+export * from './shop-catalog.models';
+export * from './shop-catalog.reducer';
+export * from './shop-catalog.selectors';
+export * from './shop-catalog.types';

--- a/src/store/shop-catalog/shop-catalog.actions.ts
+++ b/src/store/shop-catalog/shop-catalog.actions.ts
@@ -1,0 +1,20 @@
+import {CardConfigMap, CategoriesAndCurations, DirectIntegrationMap} from '../shop/shop.models';
+import {ShopCatalogActionTypes} from './shop-catalog.types';
+
+export const successFetchCatalog = (payload: {
+  availableCardMap: CardConfigMap;
+  supportedCardMap?: CardConfigMap;
+  categoriesAndCurations: CategoriesAndCurations;
+  integrations: DirectIntegrationMap;
+}) => ({
+  type: ShopCatalogActionTypes.SUCCESS_FETCH_CATALOG as const,
+  payload,
+});
+
+export const failedFetchCatalog = () => ({
+  type: ShopCatalogActionTypes.FAILED_FETCH_CATALOG as const,
+});
+
+export const setShopMigrationComplete = () => ({
+  type: ShopCatalogActionTypes.SET_SHOP_MIGRATION_COMPLETE as const,
+});

--- a/src/store/shop-catalog/shop-catalog.models.ts
+++ b/src/store/shop-catalog/shop-catalog.models.ts
@@ -1,0 +1,9 @@
+import {CardConfigMap, CategoriesAndCurations, DirectIntegrationMap} from '../shop/shop.models';
+
+export interface ShopCatalogState {
+  availableCardMap: CardConfigMap;
+  supportedCardMap: CardConfigMap;
+  categoriesAndCurations: CategoriesAndCurations;
+  integrations: DirectIntegrationMap;
+  shopMigrationComplete: boolean;
+}

--- a/src/store/shop-catalog/shop-catalog.reducer.ts
+++ b/src/store/shop-catalog/shop-catalog.reducer.ts
@@ -1,0 +1,43 @@
+import {ShopCatalogState} from './shop-catalog.models';
+import {ShopCatalogActionType, ShopCatalogActionTypes} from './shop-catalog.types';
+
+export const initialShopCatalogState: ShopCatalogState = {
+  availableCardMap: {},
+  supportedCardMap: {},
+  categoriesAndCurations: {curated: {}, categories: {}},
+  integrations: {},
+  shopMigrationComplete: false,
+};
+
+export function shopCatalogReducer(
+  state: ShopCatalogState = initialShopCatalogState,
+  action: ShopCatalogActionType,
+): ShopCatalogState {
+  switch (action.type) {
+    case ShopCatalogActionTypes.SUCCESS_FETCH_CATALOG:
+      const {availableCardMap, supportedCardMap, categoriesAndCurations, integrations} = action.payload;
+      return {
+        ...state,
+        availableCardMap,
+        supportedCardMap: {
+          ...(state.supportedCardMap || {}),
+          ...(supportedCardMap || {}),
+          ...availableCardMap,
+        },
+        categoriesAndCurations,
+        integrations,
+      };
+
+    case ShopCatalogActionTypes.FAILED_FETCH_CATALOG:
+      return state;
+
+    case ShopCatalogActionTypes.SET_SHOP_MIGRATION_COMPLETE:
+      return {
+        ...state,
+        shopMigrationComplete: true,
+      };
+
+    default:
+      return state;
+  }
+}

--- a/src/store/shop-catalog/shop-catalog.selectors.ts
+++ b/src/store/shop-catalog/shop-catalog.selectors.ts
@@ -1,0 +1,67 @@
+import {createSelector} from 'reselect';
+import {AppSelector} from '..';
+import {getGiftCardConfigList} from '../../lib/gift-cards/gift-card';
+import {
+  CardConfigMap,
+  CategoriesAndCurations,
+  Category,
+  DirectIntegrationApiObject,
+  DirectIntegrationMap,
+} from '../shop/shop.models';
+
+export const selectAvailableCardMap: AppSelector<CardConfigMap> = ({SHOP_CATALOG}) => {
+  return SHOP_CATALOG.availableCardMap;
+};
+
+export const getAvailableGiftCards = (availableCardMap: CardConfigMap) =>
+  getGiftCardConfigList(availableCardMap).filter(config => !config.hidden);
+
+export const selectAvailableGiftCards = createSelector(
+  [selectAvailableCardMap],
+  availableCardMap => getAvailableGiftCards(availableCardMap),
+);
+
+export const selectCategoriesAndCurations: AppSelector<
+  CategoriesAndCurations
+> = ({SHOP_CATALOG}) => {
+  return SHOP_CATALOG.categoriesAndCurations;
+};
+
+export const selectCategories = createSelector(
+  [selectCategoriesAndCurations],
+  categoriesAndCurations => {
+    return Object.values(categoriesAndCurations.categories);
+  },
+);
+
+export const selectIntegrationsMap: AppSelector<DirectIntegrationMap> = ({
+  SHOP_CATALOG,
+}) => {
+  return SHOP_CATALOG.integrations as DirectIntegrationMap;
+};
+
+export const selectIntegrations = createSelector(
+  [selectIntegrationsMap],
+  integrationsMap => {
+    return Object.values(integrationsMap);
+  },
+);
+
+export const getCategoriesWithIntegrations = (
+  categories: Category[],
+  integrations: DirectIntegrationApiObject[],
+) =>
+  categories
+    .map(category => ({
+      ...category,
+      integrations: integrations.filter(integration =>
+        category.tags?.some((tag: string) => integration.tags.includes(tag)),
+      ),
+    }))
+    .filter(category => category.integrations.length);
+
+export const selectCategoriesWithIntegrations = createSelector(
+  [selectCategories, selectIntegrations],
+  (categories, integrations) =>
+    getCategoriesWithIntegrations(categories, integrations),
+);

--- a/src/store/shop-catalog/shop-catalog.types.ts
+++ b/src/store/shop-catalog/shop-catalog.types.ts
@@ -1,0 +1,30 @@
+import {CardConfigMap, CategoriesAndCurations, DirectIntegrationMap} from '../shop/shop.models';
+
+export enum ShopCatalogActionTypes {
+  SUCCESS_FETCH_CATALOG = 'SHOP_CATALOG/SUCCESS_FETCH_CATALOG',
+  FAILED_FETCH_CATALOG = 'SHOP_CATALOG/FAILED_FETCH_CATALOG',
+  SET_SHOP_MIGRATION_COMPLETE = 'SHOP_CATALOG/SET_SHOP_MIGRATION_COMPLETE',
+}
+
+export interface successFetchCatalog {
+  type: typeof ShopCatalogActionTypes.SUCCESS_FETCH_CATALOG;
+  payload: {
+    availableCardMap: CardConfigMap;
+    supportedCardMap?: CardConfigMap;
+    categoriesAndCurations: CategoriesAndCurations;
+    integrations: DirectIntegrationMap;
+  };
+}
+
+export interface failedFetchCatalog {
+  type: typeof ShopCatalogActionTypes.FAILED_FETCH_CATALOG;
+}
+
+export interface setShopMigrationComplete {
+  type: typeof ShopCatalogActionTypes.SET_SHOP_MIGRATION_COMPLETE;
+}
+
+export type ShopCatalogActionType = 
+  | successFetchCatalog 
+  | failedFetchCatalog 
+  | setShopMigrationComplete;

--- a/src/store/shop/shop.actions.ts
+++ b/src/store/shop/shop.actions.ts
@@ -145,6 +145,10 @@ export const clearedGiftCards = (): ShopActionType => ({
   type: ShopActionTypes.CLEARED_GIFT_CARDS,
 });
 
+export const clearedShopCatalogFields = (): ShopActionType => ({
+  type: ShopActionTypes.CLEARED_SHOP_CATALOG_FIELDS,
+});
+
 export const isJoinedWaitlist = (
   isJoinedWaitlist: boolean,
 ): ShopActionType => ({

--- a/src/store/shop/shop.effects.ts
+++ b/src/store/shop/shop.effects.ts
@@ -26,6 +26,8 @@ import {DeviceEventEmitter} from 'react-native';
 import {DeviceEmitterEvents} from '../../constants/device-emitter-events';
 import {LogActions} from '../log';
 import {getBillPayAccountDescription} from '../../navigation/tabs/shop/bill/utils';
+import {successFetchCatalog} from '../shop-catalog/shop-catalog.actions';
+
 export const startFetchCatalog = (): Effect => async (dispatch, getState) => {
   try {
     const {APP, BITPAY_ID, LOCATION, SHOP} = getState();
@@ -49,7 +51,7 @@ export const startFetchCatalog = (): Effect => async (dispatch, getState) => {
     const {data: categoriesAndCurations} = directoryResponse;
     const {data: integrations} = integrationsResponse;
     dispatch(
-      ShopActions.successFetchCatalog({
+      successFetchCatalog({
         availableCardMap: getCardConfigMapFromApiConfigMap(availableCardMap),
         categoriesAndCurations,
         integrations,

--- a/src/store/shop/shop.reducer.ts
+++ b/src/store/shop/shop.reducer.ts
@@ -13,13 +13,13 @@ import {
 import {ShopActionType, ShopActionTypes} from './shop.types';
 
 type ShopReduxPersistBlackList = string[];
-export const shopReduxPersistBlackList: ShopReduxPersistBlackList = ['integrations'];
+export const shopReduxPersistBlackList: ShopReduxPersistBlackList = [];
 
 export interface ShopState {
-  availableCardMap: CardConfigMap;
-  supportedCardMap: CardConfigMap;
-  categoriesAndCurations: CategoriesAndCurations;
-  integrations: DirectIntegrationMap;
+  availableCardMap: CardConfigMap; // Legacy field that should now be empty after being moved to the SHOP_CATALOG store
+  supportedCardMap: CardConfigMap; // Legacy field that should now be empty after being moved to the SHOP_CATALOG store
+  categoriesAndCurations: CategoriesAndCurations; // Legacy field that should now be empty after being moved to the SHOP_CATALOG store
+  integrations: DirectIntegrationMap; // Legacy field that should now be empty after being moved to the SHOP_CATALOG store
   email: string;
   phone: string;
   phoneCountryInfo: PhoneCountryInfo;
@@ -242,6 +242,16 @@ export const shopReducer = (
           [Network.regtest]: [],
         },
       };
+
+    case ShopActionTypes.CLEARED_SHOP_CATALOG_FIELDS:
+      return {
+        ...state,
+        supportedCardMap: {},
+        availableCardMap: {},
+        categoriesAndCurations: {curated: {}, categories: {}},
+        integrations: {},
+      };
+
     case ShopActionTypes.IS_JOINED_WAITLIST:
       return {
         ...state,

--- a/src/store/shop/shop.selectors.ts
+++ b/src/store/shop/shop.selectors.ts
@@ -1,67 +1,6 @@
-import {createSelector} from 'reselect';
 import {AppSelector} from '..';
 import {getGiftCardConfigList} from '../../lib/gift-cards/gift-card';
-import {
-  CardConfigMap,
-  CategoriesAndCurations,
-  Category,
-  DirectIntegrationApiObject,
-  DirectIntegrationMap,
-} from './shop.models';
-
-export const selectAvailableCardMap: AppSelector<CardConfigMap> = ({SHOP}) => {
-  return SHOP.availableCardMap;
-};
+import {CardConfigMap} from './shop.models';
 
 export const getAvailableGiftCards = (availableCardMap: CardConfigMap) =>
   getGiftCardConfigList(availableCardMap).filter(config => !config.hidden);
-
-export const selectAvailableGiftCards = createSelector(
-  [selectAvailableCardMap],
-  availableCardMap => getAvailableGiftCards(availableCardMap),
-);
-
-export const selectCategoriesAndCurations: AppSelector<
-  CategoriesAndCurations
-> = ({SHOP}) => {
-  return SHOP.categoriesAndCurations;
-};
-
-export const selectCategories = createSelector(
-  [selectCategoriesAndCurations],
-  categoriesAndCurations => {
-    return Object.values(categoriesAndCurations.categories);
-  },
-);
-
-export const selectIntegrationsMap: AppSelector<DirectIntegrationMap> = ({
-  SHOP,
-}) => {
-  return SHOP.integrations as DirectIntegrationMap;
-};
-
-export const selectIntegrations = createSelector(
-  [selectIntegrationsMap],
-  integrationsMap => {
-    return Object.values(integrationsMap);
-  },
-);
-
-export const getCategoriesWithIntegrations = (
-  categories: Category[],
-  integrations: DirectIntegrationApiObject[],
-) =>
-  categories
-    .map(category => ({
-      ...category,
-      integrations: integrations.filter(integration =>
-        category.tags?.some((tag: string) => integration.tags.includes(tag)),
-      ),
-    }))
-    .filter(category => category.integrations.length);
-
-export const selectCategoriesWithIntegrations = createSelector(
-  [selectCategories, selectIntegrations],
-  (categories, integrations) =>
-    getCategoriesWithIntegrations(categories, integrations),
-);

--- a/src/store/shop/shop.types.ts
+++ b/src/store/shop/shop.types.ts
@@ -31,6 +31,7 @@ export enum ShopActionTypes {
   TOGGLED_GIFT_CARD_ARCHIVED_STATUS = 'SHOP/TOGGLED_GIFT_CARD_ARCHIVED_STATUS',
   TOGGLED_SYNC_GIFT_CARD_PURCHASES_WITH_BITPAY_ID = 'SHOP/TOGGLED_SYNC_GIFT_CARD_PURCHASES_WITH_BITPAY_ID',
   CLEARED_GIFT_CARDS = 'SHOP/CLEARED_GIFT_CARDS',
+  CLEARED_SHOP_CATALOG_FIELDS = 'SHOP/CLEARED_SHOP_CATALOG_FIELDS',
   IS_JOINED_WAITLIST = 'SHOP/IS_JOINED_WAITLIST',
 }
 
@@ -146,7 +147,9 @@ interface updatedPhone {
 interface clearedGiftCards {
   type: typeof ShopActionTypes.CLEARED_GIFT_CARDS;
 }
-
+interface clearedSupportedCardMap {
+  type: typeof ShopActionTypes.CLEARED_SHOP_CATALOG_FIELDS;
+}
 interface isJoinedWaitlist {
   type: ShopActionTypes.IS_JOINED_WAITLIST;
   payload: {isJoinedWaitlist: boolean};
@@ -172,4 +175,5 @@ export type ShopActionType =
   | updatedGiftCardStatus
   | updatedPhone
   | clearedGiftCards
+  | clearedSupportedCardMap
   | isJoinedWaitlist;


### PR DESCRIPTION
Shop catalog data is large and doesn't require encryption, so this PR moves it out of the encrypted `SHOP` store to the new unencrypted `SHOP_CATALOG` store to boost performance, while keeping the remaining data in the `SHOP` store encrypted.