### PR TITLE
Fix: avoid typeError when mergeUtxoAndEvmAccounts is undefined

### DIFF
--- a/src/components/list/KeyWalletsRow.tsx
+++ b/src/components/list/KeyWalletsRow.tsx
@@ -199,7 +199,7 @@ const KeyWalletsRow = ({
               )}
             </KeyNameContainer>
           )}
-        {key?.mergedUtxoAndEvmAccounts.map((account, index) => {
+        {key?.mergedUtxoAndEvmAccounts?.map((account, index) => {
           const chain = account?.chain ?? account?.chains?.[0] ?? '';
           if (IsEVMChain(chain)) {
             let evmAccount = account as AccountRowProps & {


### PR DESCRIPTION
```
TypeError: Cannot read property 'map' of undefined

This error is located at:
    in KeyWalletsRow (created by WalletSelector)
```