### PR TITLE
Fix: headerRight height rendering on android 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2097,7 +2097,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.6.0):
+  - RNScreens (3.35.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2118,9 +2118,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.6.0)
+    - RNScreens/common (= 3.35.0)
     - Yoga
-  - RNScreens/common (4.6.0):
+  - RNScreens/common (3.35.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2696,7 +2696,7 @@ SPEC CHECKSUMS:
   RNRate: ef3bcff84f39bb1d1e41c5593d3eea4aab2bd73a
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
   RNReanimated: 7f11fff1964b5d073961b54167c22ebf3bd5aaff
-  RNScreens: 3d9895696d5716e9a780237a9c2589c7aa3d199f
+  RNScreens: f493b156fe5de2434806b5a2c410800b2cd76c0e
   RNShare: 0cc7cc40681d2a858390552cf8b757f9bb4d460c
   RNSVG: feeb4eb546e718d6c6fb70d10fd31e0c5c2d0d90
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "react-native-restart": "0.0.27",
     "react-native-rounded-checkbox": "0.3.3",
     "react-native-safe-area-context": "4.14.0",
-    "react-native-screens": "4.6.0",
+    "react-native-screens": "3.35.0",
     "react-native-share": "11.1.0",
     "react-native-skeleton-placeholder": "5.2.4",
     "react-native-svg": "15.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14649,10 +14649,10 @@ react-native-safe-area-context@4.14.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.14.0.tgz#138f4b2e180cb7517c78bd5f4d4cf91325ba0b1a"
   integrity sha512-/SyYpCulWQOnnXhRq6wepkhoyQMowHm1ptDyRz20s+YS/R9mbd+mK+jFyFCyXFJn8jp7vFl43VUCgspuOiEbwA==
 
-react-native-screens@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.6.0.tgz#2b60ab6f4cd5010c6f9cb01b034f2aa0e17ccf4b"
-  integrity sha512-PqGtR/moJLiTMSavhfo5spKXNHZrlxffq3g5UUVPmyuu7MmazFlPvYqiAYnR2iB9tkJYgvZO6sbjYAE7619M0A==
+react-native-screens@3.35.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.35.0.tgz#4acf4c7d331d47d33d0214d415779540b7664e0e"
+  integrity sha512-rmkqb/M/SQIrXwygk6pXcOhgHltYAhidf1WceO7ujAxkr6XtwmgFyd1HIztsrJa568GrAuwPdQ11I7TpVk+XsA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
Downgrades react-native-screens to `3.35.0`.