### PR TITLE
Fix: Slide button and PaymentSent screen

### DIFF
--- a/src/navigation/wallet/WalletGroup.tsx
+++ b/src/navigation/wallet/WalletGroup.tsx
@@ -329,6 +329,7 @@ const WalletGroup: React.FC<WalletProps> = ({Wallet}) => {
       />
       <Wallet.Screen
         options={{
+          gestureEnabled: false,
           headerTitle: () => <HeaderTitle>{t('Add Funds')}</HeaderTitle>,
         }}
         name={WalletScreens.DEBIT_CARD_CONFIRM}
@@ -336,6 +337,7 @@ const WalletGroup: React.FC<WalletProps> = ({Wallet}) => {
       />
       <Wallet.Screen
         options={{
+          gestureEnabled: false,
           headerTitle: () => <HeaderTitle>{t('Confirm Payment')}</HeaderTitle>,
         }}
         name={WalletScreens.PAY_PRO_CONFIRM}
@@ -343,6 +345,7 @@ const WalletGroup: React.FC<WalletProps> = ({Wallet}) => {
       />
       <Wallet.Screen
         options={{
+          gestureEnabled: false,
           headerTitle: () => (
             <HeaderTitle>{t('Two-Step Verification')}</HeaderTitle>
           ),

--- a/src/navigation/wallet/components/PaymentSent.tsx
+++ b/src/navigation/wallet/components/PaymentSent.tsx
@@ -7,7 +7,7 @@ import PaymentCompleteSvg from '../../../../assets/img/wallet/payment-complete.s
 import {BaseText} from '../../../components/styled/Text';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from 'react-native';
 
 const PaymentSentContainer = styled.View`
   flex: 1;

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -47,7 +47,7 @@ import {
   Amount,
   ConfirmContainer,
   ConfirmScrollView,
-  DetailsListNoScroll,
+  DetailsList,
   ExchangeRate,
   Fee,
   Header,
@@ -60,7 +60,7 @@ import {
   CustomErrorMessage,
   WrongPasswordError,
 } from '../../../components/ErrorMessages';
-import {URL} from '../../../../../constants';
+import {IS_ANDROID, URL} from '../../../../../constants';
 import {BWCErrorMessage} from '../../../../../constants/BWCError';
 import TransactionLevel from '../TransactionLevel';
 import {
@@ -590,12 +590,12 @@ const Confirm = () => {
 
   return (
     <>
-      <ConfirmContainer>
+      <ConfirmContainer style={IS_ANDROID ? {paddingBottom: 50} : undefined}>
         <ConfirmScrollView
           extraScrollHeight={50}
           contentContainerStyle={{paddingBottom: 50}}
           keyboardShouldPersistTaps={'handled'}>
-          <DetailsListNoScroll>
+          <DetailsList keyboardShouldPersistTaps={'handled'}>
             <Header>Summary</Header>
             <SendingTo
               recipient={recipientData}
@@ -727,7 +727,7 @@ const Confirm = () => {
                 dispatch(showConfirmAmountInfoSheet('total'));
               }}
             />
-          </DetailsListNoScroll>
+          </DetailsList>
 
           <PaymentSent
             isVisible={showPaymentSentModal}


### PR DESCRIPTION
* Disable gestures on all Confirm Screens
* Revert back to `react-native` plugin for TouchableOpacity on PaymentSent screen
* Normal confirm requires an extra padding on Android devices