### PR TITLE
Fix: add custom TouchableOpacity component to fix android modal pressability

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,6 +19,16 @@ const plugins = [
       allowUndefined: true,
     },
   ],
+  [
+    'module-resolver',
+    {
+      root: ['./src'],
+      extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
+      alias: {
+        '@components': './src/components'
+      }
+    }
+  ]
 ];
 
 if (prod) {

--- a/src/components/amount/AmountModal.tsx
+++ b/src/components/amount/AmountModal.tsx
@@ -9,7 +9,7 @@ import {Black, White} from '../../styles/colors';
 import SheetModal from '../modal/base/sheet/SheetModal';
 import Amount, {AmountProps, LimitsOpts} from './Amount';
 import {Platform} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ModalHeaderText = styled(BaseText)`
   font-size: 18px;

--- a/src/components/back/HeaderBackButton.tsx
+++ b/src/components/back/HeaderBackButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity} from '@components/base/TouchableOpacity';
+import {TouchableOpacity} from 'react-native-gesture-handler';
 import {useNavigation} from '@react-navigation/native';
 import Back from './Back';
 

--- a/src/components/back/HeaderBackButton.tsx
+++ b/src/components/back/HeaderBackButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useNavigation} from '@react-navigation/native';
 import Back from './Back';
 

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../styles/colors';
 import {H7, Link} from '../styled/Text';
 import {ActionContainer, ActiveOpacity, Row} from '../styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {SvgProps} from 'react-native-svg';
 
 const BANNER_HEIGHT = 80;

--- a/src/components/base/TouchableOpacity.tsx
+++ b/src/components/base/TouchableOpacity.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {TouchableOpacity as RNTouchableOpacity, TouchableOpacityProps as RNTouchableOpacityProps} from 'react-native';
+import {TouchableOpacity as GHTouchableOpacity, TouchableOpacityProps as GHTouchableOpacityProps} from 'react-native-gesture-handler';
+import {IS_ANDROID} from '../../constants';
+
+export const ActiveOpacity = 0.75;
+
+// Use intersection of both prop types to ensure compatibility
+export type TouchableOpacityProps = RNTouchableOpacityProps & GHTouchableOpacityProps;
+
+export const TouchableOpacity: React.FC<TouchableOpacityProps> = ({
+  activeOpacity = ActiveOpacity,
+  ...props
+}) => {
+  const TouchableComponent = IS_ANDROID ? RNTouchableOpacity : GHTouchableOpacity;
+  return <TouchableComponent activeOpacity={activeOpacity} {...props} />;
+};

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -33,7 +33,7 @@ import * as Icons from './ButtonIcons';
 import ButtonOverlay from './ButtonOverlay';
 import ButtonSpinner from './ButtonSpinner';
 import {StyleProp, ViewStyle} from 'react-native';
-import {TouchableOpacity} from '@components/base/TouchableOpacity';
+import {TouchableOpacity} from 'react-native-gesture-handler';
 
 export type ButtonState = 'loading' | 'success' | 'failed' | null | undefined;
 export type ButtonStyle =

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -33,7 +33,7 @@ import * as Icons from './ButtonIcons';
 import ButtonOverlay from './ButtonOverlay';
 import ButtonSpinner from './ButtonSpinner';
 import {StyleProp, ViewStyle} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type ButtonState = 'loading' | 'success' | 'failed' | null | undefined;
 export type ButtonStyle =

--- a/src/components/chain-search/ChainSearch.tsx
+++ b/src/components/chain-search/ChainSearch.tsx
@@ -32,7 +32,7 @@ import {
 import {AssetsByChainData} from '../../navigation/wallet/screens/AccountDetails';
 import {AccountRowProps} from '../list/AccountListRow';
 import {WalletRowProps} from '../list/WalletRow';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const SearchIconContainer = styled.View`
   margin: 14px;

--- a/src/components/custom-tab-bar/CustomTabBar.tsx
+++ b/src/components/custom-tab-bar/CustomTabBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { TouchableOpacity } from '@components/base/TouchableOpacity';
 import { useTheme } from 'styled-components/native';
 import { Action, LightBlack, NeutralSlate, SlateDark, White } from '../../styles/colors';
 import { BaseText } from '../styled/Text';

--- a/src/components/floating-action-button/FloatingActionButton.tsx
+++ b/src/components/floating-action-button/FloatingActionButton.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native';
 import {Action, Disabled, DisabledDark, White} from '../../styles/colors';
 import {ActiveOpacity} from '../styled/Containers';
 import {H5} from '../styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 type hAlign = 'left' | 'right' | 'center' | null | undefined;
 type vAlign = 'top' | 'bottom' | 'center' | null | undefined;

--- a/src/components/form/BoxInput.tsx
+++ b/src/components/form/BoxInput.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../styles/colors';
 import {ActiveOpacity} from '../styled/Containers';
 import {BaseText} from '../styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 type InputType = 'password' | 'phone' | 'search' | 'number';
 

--- a/src/components/home-card/HomeCard.tsx
+++ b/src/components/home-card/HomeCard.tsx
@@ -16,7 +16,7 @@ import {BaseText, H3} from '../styled/Text';
 import * as Svg from 'react-native-svg';
 import {shouldScale} from '../../utils/helper-methods';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const Arrow = ({isDark}: {isDark: boolean}) => {
   return (

--- a/src/components/list/AccountRow.tsx
+++ b/src/components/list/AccountRow.tsx
@@ -11,7 +11,7 @@ import {css} from 'styled-components/native';
 import {CurrencyImage} from '../currency-image/CurrencyImage';
 import {CurrencyListIcons} from '../../constants/SupportedCurrencyOptions';
 import {AddPillContainer} from '../../navigation/wallet/screens/AddCustomToken';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const AddressView = styled(View)`
   align-items: flex-end;

--- a/src/components/list/AccountSettingsRow.tsx
+++ b/src/components/list/AccountSettingsRow.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components/native';
 import {useTranslation} from 'react-i18next';
 import {AccountRowProps} from './AccountListRow';
 import {IsEVMChain} from '../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface Props {
   id: string;

--- a/src/components/list/ChainSelectionRow.tsx
+++ b/src/components/list/ChainSelectionRow.tsx
@@ -5,7 +5,7 @@ import {CurrencyImage} from '../currency-image/CurrencyImage';
 import {ScreenGutter} from '../styled/Containers';
 import {H7} from '../styled/Text';
 import {CurrencyOpts} from '../../constants/currencies';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ChainSelectionRowContainer = styled.View`
   border: 1px solid ${({theme}) => (theme.dark ? SlateDark : Slate30)};

--- a/src/components/list/CurrencySelectionRow.tsx
+++ b/src/components/list/CurrencySelectionRow.tsx
@@ -22,7 +22,7 @@ import haptic from '../haptic-feedback/haptic';
 import NestedArrowIcon from '../nested-arrow/NestedArrow';
 import {ScreenGutter} from '../styled/Containers';
 import {BaseText, H6, H7} from '../styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type CurrencySelectionItem = Pick<
   SupportedCurrencyOption,

--- a/src/components/list/KeyWalletsRow.tsx
+++ b/src/components/list/KeyWalletsRow.tsx
@@ -31,7 +31,7 @@ import {findWalletById} from '../../store/wallet/utils/wallet';
 import {useAppSelector} from '../../utils/hooks';
 import {BitpaySupportedCoins} from '../../constants/currencies';
 import {SearchableItem} from '../chain-search/ChainSearch';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface KeyWalletsRowContainerProps {
   isLast?: boolean;

--- a/src/components/list/TransactionProposalRow.tsx
+++ b/src/components/list/TransactionProposalRow.tsx
@@ -5,7 +5,7 @@ import {ScreenGutter} from '../styled/Containers';
 import {useTranslation} from 'react-i18next';
 import {GetContactName} from '../../store/wallet/effects/transactions/transactions';
 import {ContactRowProps} from './ContactRow';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const TransactionContainer = styled(TouchableOpacity)`
   flex: 1;

--- a/src/components/list/TransactionRow.tsx
+++ b/src/components/list/TransactionRow.tsx
@@ -7,7 +7,7 @@ import {TRANSACTION_ICON_SIZE} from '../../constants/TransactionIcons';
 import {CurrencyListIcons} from '../../constants/SupportedCurrencyOptions';
 import {CurrencyImage} from '../currency-image/CurrencyImage';
 export const TRANSACTION_ROW_HEIGHT = 75;
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const TransactionContainer = styled(TouchableOpacity)`
   flex-direction: row;

--- a/src/components/list/WalletSettingsRow.tsx
+++ b/src/components/list/WalletSettingsRow.tsx
@@ -9,7 +9,7 @@ import {
   HiddenContainer,
 } from '../styled/Containers';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export interface WalletSettingsRowProps {
   img: string | ((props: any) => ReactElement);

--- a/src/components/modal/biometric/BiometricModal.tsx
+++ b/src/components/modal/biometric/BiometricModal.tsx
@@ -20,7 +20,7 @@ import {
   NativeModules,
   DeviceEventEmitter,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {LOCK_AUTHORIZED_TIME} from '../../../constants/Lock';
 import {useTranslation} from 'react-i18next';
 import {DeviceEmitterEvents} from '../../../constants/device-emitter-events';

--- a/src/components/modal/chain-selector/ChainSelector.tsx
+++ b/src/components/modal/chain-selector/ChainSelector.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Platform, TouchableOpacity, View} from 'react-native';
+import {Platform, View} from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useTheme} from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import styled, {css} from 'styled-components/native';

--- a/src/components/modal/import-ledger-wallet/components/ViaTransportButton.tsx
+++ b/src/components/modal/import-ledger-wallet/components/ViaTransportButton.tsx
@@ -1,6 +1,6 @@
 import styled, {useTheme} from 'styled-components/native';
 import {TouchableOpacityProps} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {BaseButtonProps} from 'react-native-gesture-handler';
 import {ActiveOpacity} from '../../../../components/styled/Containers';
 import {Action, White} from '../../../../styles/colors';

--- a/src/components/modal/in-app-notification/InAppNotification.tsx
+++ b/src/components/modal/in-app-notification/InAppNotification.tsx
@@ -14,7 +14,7 @@ import {WIDTH} from '../../styled/Containers';
 import {useNavigation} from '@react-navigation/native';
 import {getGasWalletByRequest} from '../../../store/wallet-connect-v2/wallet-connect-v2.effects';
 import {sleep} from '../../../utils/helper-methods';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type InAppNotificationMessages = 'NEW_PENDING_REQUEST';
 

--- a/src/components/modal/pin/PinModal.tsx
+++ b/src/components/modal/pin/PinModal.tsx
@@ -8,7 +8,7 @@ import {
   View,
   NativeModules,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import styled, {useTheme} from 'styled-components/native';

--- a/src/components/modal/transact-menu/TransactMenu.tsx
+++ b/src/components/modal/transact-menu/TransactMenu.tsx
@@ -1,7 +1,7 @@
 import {useNavigation} from '@react-navigation/native';
 import React, {ReactElement, useState} from 'react';
 import {FlatList, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import TransactButtonIcon from '../../../../assets/img/tab-icons/transact-button.svg';
 import {

--- a/src/components/modal/wallet-connect/AccountWCV2RowModal.tsx
+++ b/src/components/modal/wallet-connect/AccountWCV2RowModal.tsx
@@ -19,7 +19,7 @@ import {useTheme} from 'styled-components/native';
 import Back from '../../back/Back';
 import {ScrollView} from 'react-native-gesture-handler';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface Props {
   isVisible: boolean;

--- a/src/components/modal/wallet-connect/VerifyModalContext.tsx
+++ b/src/components/modal/wallet-connect/VerifyModalContext.tsx
@@ -26,7 +26,7 @@ import InvalidDomainSvg from '../../../../assets/img/invalid-domain.svg';
 import DefaultImage from '../../../../assets/img/wallet-connect/default-icon.svg';
 import {View} from 'react-native';
 import {BottomNotificationCta} from '../bottom-notification/BottomNotification';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const CloseModalButton = styled(TouchableOpacity)`
   height: 40px;

--- a/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
+++ b/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
@@ -57,7 +57,7 @@ import {CurrencyListIcons} from '../../../constants/SupportedCurrencyOptions';
 import SelectorArrowRight from '../../../../assets/img/selector-arrow-right.svg';
 import Blockie from '../../blockie/Blockie';
 import {IsERCToken} from '../../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';
 import ExternalLinkSvg from '../../../../assets/img/external-link-small.svg';
 import TrustedDomainSvg from '../../../../assets/img/trusted-domain.svg';

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -3,7 +3,7 @@ import {Color, Rect, Svg, Ellipse, Circle} from 'react-native-svg';
 import styled, {useTheme} from 'styled-components/native';
 import {LightBlack, NeutralSlate, SlateDark, White} from '../../styles/colors';
 import {ActiveOpacity, HeaderRightContainer} from '../styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface SettingsSvgProps {
   color: Color | undefined;

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -3,7 +3,7 @@ import {Color, Rect, Svg, Ellipse, Circle} from 'react-native-svg';
 import styled, {useTheme} from 'styled-components/native';
 import {LightBlack, NeutralSlate, SlateDark, White} from '../../styles/colors';
 import {ActiveOpacity, HeaderRightContainer} from '../styled/Containers';
-import {TouchableOpacity} from '@components/base/TouchableOpacity';
+import {TouchableOpacity} from 'react-native-gesture-handler';
 
 interface SettingsSvgProps {
   color: Color | undefined;

--- a/src/components/styled/Containers.tsx
+++ b/src/components/styled/Containers.tsx
@@ -14,13 +14,13 @@ import {
   Slate30,
 } from '../../styles/colors';
 import {BaseText} from './Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '../base/TouchableOpacity';
+export {ActiveOpacity} from '../base/TouchableOpacity';
 
 export const {height: HEIGHT, width: WIDTH} = Dimensions.get('window');
 export const isNotMobile = HEIGHT / WIDTH < 1.6;
 
 export const ScreenGutter = '15px';
-export const ActiveOpacity = 0.75;
 // Nav
 export const HeaderRightContainer = styled.View`
   height: 40px;

--- a/src/components/styled/Containers.tsx
+++ b/src/components/styled/Containers.tsx
@@ -14,8 +14,8 @@ import {
   Slate30,
 } from '../../styles/colors';
 import {BaseText} from './Text';
-import {TouchableOpacity} from '../base/TouchableOpacity';
-export {ActiveOpacity} from '../base/TouchableOpacity';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
+export {ActiveOpacity} from '@components/base/TouchableOpacity';
 
 export const {height: HEIGHT, width: WIDTH} = Dimensions.get('window');
 export const isNotMobile = HEIGHT / WIDTH < 1.6;

--- a/src/components/swap-button/SwapButton.tsx
+++ b/src/components/swap-button/SwapButton.tsx
@@ -4,7 +4,7 @@ import {BaseText} from '../styled/Text';
 import {LightBlack, NotificationPrimary, White} from '../../styles/colors';
 import haptic from '../haptic-feedback/haptic';
 import SwapHorizontal from '../icons/swap-horizontal/SwapHorizontal';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const SwapButtonContainer = styled(TouchableOpacity)`
   flex-direction: row;

--- a/src/navigation/bitpay-id/components/AddressModal.tsx
+++ b/src/navigation/bitpay-id/components/AddressModal.tsx
@@ -29,7 +29,7 @@ import CopySvg from '../../../../assets/img/copy.svg';
 import CopiedSvg from '../../../../assets/img/copied-success.svg';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {CurrencyIconAndBadge} from '../../wallet/screens/send/confirm/Shared';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ModalContainer = styled.View`
   justify-content: center;

--- a/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
+++ b/src/navigation/bitpay-id/screens/EnableTwoFactor.tsx
@@ -10,7 +10,7 @@ import QRCode from 'react-native-qrcode-svg';
 import Button from '../../../components/button/Button';
 import BoxInput from '../../../components/form/BoxInput';
 import {View, Keyboard} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import yup from '../../../lib/yup';
 import {yupResolver} from '@hookform/resolvers/yup';
 import {Controller, useForm} from 'react-hook-form';

--- a/src/navigation/bitpay-id/screens/ProfileSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ProfileSettings.tsx
@@ -27,7 +27,7 @@ import {
   SlateDark,
 } from '../../../styles/colors';
 import {BitpayIdScreens, BitpayIdGroupParamList} from '../BitpayIdGroup';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useNavigation} from '@react-navigation/native';
 import ChevronRight from '../components/ChevronRight';
 import {BitPayIdEffects} from '../../../store/bitpay-id';

--- a/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../styles/colors';
 import AddSvg from '../../../../assets/img/add.svg';
 import AddWhiteSvg from '../../../../assets/img/add-white.svg';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Button from '../../../components/button/Button';
 import ChevronRight from '../components/ChevronRight';
 import SendToPill from '../../wallet/components/SendToPill';

--- a/src/navigation/card/components/CardDashboard.styled.tsx
+++ b/src/navigation/card/components/CardDashboard.styled.tsx
@@ -8,7 +8,7 @@ import {
   Slate,
   SlateDark,
 } from '../../../styles/colors';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const TransactionListHeader = styled.View`
 background-color: ${({theme}) => (theme.dark ? LightBlack : NeutralSlate)};

--- a/src/navigation/card/components/CardIntroHighlights.tsx
+++ b/src/navigation/card/components/CardIntroHighlights.tsx
@@ -11,7 +11,7 @@ import ChevronDownSvg from '../../../../assets/img/chevron-down.svg';
 import ChevronUpSvg from '../../../../assets/img/chevron-up.svg';
 import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';
 import {useAppDispatch} from '../../../utils/hooks';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface CardHighlight {
   icon: React.FC<SvgProps>;

--- a/src/navigation/card/components/CardOffers.tsx
+++ b/src/navigation/card/components/CardOffers.tsx
@@ -1,6 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
-import {Linking, TouchableOpacity} from 'react-native';
+import {Linking} from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Braze, {ContentCard} from '@braze/react-native-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import styled, {useTheme} from 'styled-components/native';

--- a/src/navigation/card/screens/settings/CustomizeVirtualCard.tsx
+++ b/src/navigation/card/screens/settings/CustomizeVirtualCard.tsx
@@ -2,7 +2,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {ScrollView, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {Color, SvgProps} from 'react-native-svg';
 import {useDispatch, useSelector} from 'react-redux';
 import BitPayBIcon from '../../../../../assets/img/logos/bitpay-b-blue.svg';

--- a/src/navigation/coinbase/components/CoinbaseBalanceCard.tsx
+++ b/src/navigation/coinbase/components/CoinbaseBalanceCard.tsx
@@ -24,7 +24,7 @@ import {
   BalanceCodeContainer,
 } from '../../tabs/home/components/Wallet';
 import {Balance, OptionName} from '../../wallet/components/DropdownOption';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface CoinbaseCardComponentProps {
   layout: HomeCarouselLayoutType;

--- a/src/navigation/coinbase/components/CoinbaseSettingsOption.tsx
+++ b/src/navigation/coinbase/components/CoinbaseSettingsOption.tsx
@@ -4,7 +4,7 @@ import {LightBlack, White, Cloud} from '../../../styles/colors';
 import {ActiveOpacity} from '../../../components/styled/Containers';
 import {Theme} from '@react-navigation/native';
 import Svg, {Path} from 'react-native-svg';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const SettingsSvgContainer = styled(TouchableOpacity)`
   margin: 0;

--- a/src/navigation/coinbase/screens/CoinbaseTransaction.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseTransaction.tsx
@@ -21,7 +21,7 @@ import CopiedSvg from '../../../../assets/img/copied-success.svg';
 import haptic from '../../../components/haptic-feedback/haptic';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {parseTransactionTitle} from './CoinbaseAccount';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const TransactionContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/intro/components/intro-button/IntroButton.tsx
+++ b/src/navigation/intro/components/intro-button/IntroButton.tsx
@@ -5,7 +5,7 @@ import ArrowRightSvg from '../../../../../assets/img/intro/arrow-right.svg';
 import {Action} from '../../../../styles/colors';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import {ActiveOpacity} from '../../../../components/styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const IntroButtonContainer = styled(TouchableOpacity)`
   background: ${Action};

--- a/src/navigation/onboarding/components/TermsBox.tsx
+++ b/src/navigation/onboarding/components/TermsBox.tsx
@@ -4,7 +4,7 @@ import haptic from '../../../components/haptic-feedback/haptic';
 import Checkbox from '../../../components/checkbox/Checkbox';
 import {LightBlack, NeutralSlate} from '../../../styles/colors';
 import {TermsOfUseModel} from '../screens/TermsOfUse';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 interface Props {
   emit: (id: number) => void;
   term: TermsOfUseModel;

--- a/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
+++ b/src/navigation/services/buy-crypto/components/PaymentMethodModal.tsx
@@ -44,7 +44,7 @@ import {WithdrawalMethod} from '../../sell-crypto/constants/SellCryptoConstants'
 import {showBottomNotificationModal} from '../../../../store/app/app.actions';
 import {sleep} from '../../../../utils/helper-methods';
 import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface PaymentMethodsModalProps {
   isVisible: boolean;

--- a/src/navigation/services/buy-crypto/components/terms/MoonpayTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/MoonpayTerms.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/components/terms/RampTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/RampTerms.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/components/terms/SardineTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/SardineTerms.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/components/terms/SimplexTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/SimplexTerms.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/components/terms/TransakTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/TransakTerms.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/components/terms/banxaTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/banxaTerms.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ExchangeTermsContainer,
   ExchangeTermsText,

--- a/src/navigation/services/buy-crypto/styled/BuyCryptoCard.tsx
+++ b/src/navigation/services/buy-crypto/styled/BuyCryptoCard.tsx
@@ -7,7 +7,7 @@ import {
   Slate30,
 } from '../../../../styles/colors';
 import {BaseText} from '../../../../components/styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const BuyCryptoItemCard = styled(TouchableOpacity)`
   border: 1px solid ${({theme: {dark}}) => (dark ? LightBlack : Slate30)};

--- a/src/navigation/services/sell-crypto/screens/MoonpaySellCheckout.tsx
+++ b/src/navigation/services/sell-crypto/screens/MoonpaySellCheckout.tsx
@@ -1,7 +1,7 @@
 import Transport from '@ledgerhq/hw-transport';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   useTheme,
   RouteProp,

--- a/src/navigation/services/sell-crypto/screens/SellCryptoOffers.tsx
+++ b/src/navigation/services/sell-crypto/screens/SellCryptoOffers.tsx
@@ -3,8 +3,8 @@ import {
   ActivityIndicator,
   Linking,
   ScrollView,
-  TouchableOpacity,
 } from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import uuid from 'react-native-uuid';
 import styled from 'styled-components/native';
 import {

--- a/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
+++ b/src/navigation/services/sell-crypto/screens/SellCryptoRoot.tsx
@@ -3,11 +3,11 @@ import {
   ActivityIndicator,
   Platform,
   ScrollView,
-  TouchableOpacity,
 } from 'react-native';
 import _ from 'lodash';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import styled, {useTheme} from 'styled-components/native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   useAppDispatch,
   useAppSelector,

--- a/src/navigation/services/sell-crypto/screens/SimplexSellCheckout.tsx
+++ b/src/navigation/services/sell-crypto/screens/SimplexSellCheckout.tsx
@@ -1,7 +1,7 @@
 import Transport from '@ledgerhq/hw-transport';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import InfoSvg from '../../../../../assets/img/info.svg';
 import {
   useTheme,

--- a/src/navigation/services/sell-crypto/styled/SellCryptoCard.tsx
+++ b/src/navigation/services/sell-crypto/styled/SellCryptoCard.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components/native';
 import {LightBlack, SlateDark, White, Slate30} from '../../../../styles/colors';
 import {BaseText} from '../../../../components/styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const SellCryptoExpandibleCard = styled(TouchableOpacity)`
   border: 1px solid ${({theme: {dark}}) => (dark ? LightBlack : Slate30)};

--- a/src/navigation/services/swap-crypto/SwapCryptoGroup.tsx
+++ b/src/navigation/services/swap-crypto/SwapCryptoGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {HeaderTitle} from '../../../components/styled/Text';
 import SwapCryptoRoot, {
   SwapCryptoRootScreenParams,

--- a/src/navigation/services/swap-crypto/components/ChangellyPoliciesModal.tsx
+++ b/src/navigation/services/swap-crypto/components/ChangellyPoliciesModal.tsx
@@ -11,7 +11,7 @@ import {useAppDispatch} from '../../../../utils/hooks';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import CloseModal from '../../../../../assets/img/close-modal-icon.svg';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ChangellyPoliciesContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/services/swap-crypto/screens/ChangellyCheckout.tsx
+++ b/src/navigation/services/swap-crypto/screens/ChangellyCheckout.tsx
@@ -1,7 +1,7 @@
 import Transport from '@ledgerhq/hw-transport';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   useTheme,
   RouteProp,

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoApproveErc20.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoApproveErc20.tsx
@@ -16,7 +16,7 @@ import {
   sleep,
 } from '../../../../utils/helper-methods';
 import {Image, ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import _ from 'lodash';
 import cloneDeep from 'lodash.clonedeep';
 import {TextAlign, SubText, BaseText} from '../../../../components/styled/Text';

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoOffers.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoOffers.tsx
@@ -4,7 +4,7 @@ import {
   ScrollView,
   View,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Slider from '@react-native-community/slider';
 import styled from 'styled-components/native';
 import {

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -3,13 +3,13 @@ import {
   ActivityIndicator,
   Platform,
   ScrollView,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import {useTheme, useNavigation, useRoute} from '@react-navigation/native';
 import {RouteProp} from '@react-navigation/core';
 import _ from 'lodash';
 import cloneDeep from 'lodash.clonedeep';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {SupportedCurrencyOptions} from '../../../../constants/SupportedCurrencyOptions';
 import {
   BitpaySupportedCoins,

--- a/src/navigation/services/swap-crypto/screens/ThorswapCheckout.tsx
+++ b/src/navigation/services/swap-crypto/screens/ThorswapCheckout.tsx
@@ -2,7 +2,7 @@ import Transport from '@ledgerhq/hw-transport';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import uuid from 'react-native-uuid';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {ethers} from 'ethers';
 import {
   useTheme,

--- a/src/navigation/services/swap-crypto/styled/SwapCryptoCheckout.styled.tsx
+++ b/src/navigation/services/swap-crypto/styled/SwapCryptoCheckout.styled.tsx
@@ -9,7 +9,7 @@ import {
   LinkBlue,
   Slate,
 } from '../../../../styles/colors';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const ItemDivisor = styled.View`
   border-bottom-color: ${({theme: {dark}}) => (dark ? LightBlack : Slate30)};

--- a/src/navigation/services/swap-crypto/styled/SwapCryptoRoot.styled.tsx
+++ b/src/navigation/services/swap-crypto/styled/SwapCryptoRoot.styled.tsx
@@ -1,4 +1,4 @@
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import {BaseText, H7} from '../../../../components/styled/Text';
 import {

--- a/src/navigation/tabs/TabScreenErrorFallback.tsx
+++ b/src/navigation/tabs/TabScreenErrorFallback.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Linking, ScrollView} from 'react-native';
 import ErrorBoundary from 'react-native-error-boundary';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import styled from 'styled-components/native';

--- a/src/navigation/tabs/contacts/screens/ContactsAdd.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsAdd.tsx
@@ -63,7 +63,7 @@ import {
   SupportedCoinsOptions,
 } from '../../../../constants/SupportedCurrencyOptions';
 import {Analytics} from '../../../../store/analytics/analytics.effects';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const InputContainer = styled.View<{hideInput?: boolean}>`
   display: ${({hideInput}) => (!hideInput ? 'flex' : 'none')};

--- a/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
@@ -33,7 +33,7 @@ import {useTranslation} from 'react-i18next';
 import CopiedSvg from '../../../../../assets/img/copied-success.svg';
 import {ContactRowProps} from '../../../../components/list/ContactRow';
 import {IsEVMChain} from '../../../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ContactsDetailsContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/tabs/contacts/screens/ContactsRoot.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsRoot.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import styled, {useTheme} from 'styled-components/native';
 import {FlatList, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useSelector} from 'react-redux';
 import {useForm, Controller} from 'react-hook-form';
 import {useNavigation} from '@react-navigation/core';

--- a/src/navigation/tabs/home/components/Crypto.tsx
+++ b/src/navigation/tabs/home/components/Crypto.tsx
@@ -37,7 +37,7 @@ import {
   SectionHeaderContainer,
 } from './Styled';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import CustomizeSvg from './CustomizeSvg';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import {Feather} from '../../../../styles/colors';

--- a/src/navigation/tabs/home/components/FeedbackCard.tsx
+++ b/src/navigation/tabs/home/components/FeedbackCard.tsx
@@ -14,7 +14,7 @@ import Close from '../../../../../assets/img/settings/feedback/close.svg';
 import {useTranslation} from 'react-i18next';
 import {saveUserFeedback} from '../../../../store/app/app.effects';
 import {APP_VERSION} from '../../../../constants/config';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const FeedbackContainer = styled.View`
   margin: 20px 16px 0 16px;

--- a/src/navigation/tabs/home/components/HeaderProfileButton.tsx
+++ b/src/navigation/tabs/home/components/HeaderProfileButton.tsx
@@ -1,6 +1,6 @@
 import {useNavigation} from '@react-navigation/native';
 import React from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useSelector} from 'react-redux';
 import Avatar from '../../../../components/avatar/BitPayIdAvatar';
 import {RootState} from '../../../../store';

--- a/src/navigation/tabs/home/components/HeaderScanButton.tsx
+++ b/src/navigation/tabs/home/components/HeaderScanButton.tsx
@@ -1,6 +1,6 @@
 import {useNavigation} from '@react-navigation/native';
 import React from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import * as Svg from 'react-native-svg';
 import {HeaderButtonContainer} from './Styled';
 import {

--- a/src/navigation/tabs/home/components/HomeSection.tsx
+++ b/src/navigation/tabs/home/components/HomeSection.tsx
@@ -4,7 +4,7 @@ import {
   TouchableWithoutFeedbackProps,
   ViewStyle,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import {
   ActiveOpacity,

--- a/src/navigation/tabs/home/components/LinkingButtons.tsx
+++ b/src/navigation/tabs/home/components/LinkingButtons.tsx
@@ -12,7 +12,7 @@ import {useRequireKeyAndWalletRedirect} from '../../../../utils/hooks/useRequire
 import {useTranslation} from 'react-i18next';
 import {WalletScreens} from '../../../wallet/WalletGroup';
 import {Analytics} from '../../../../store/analytics/analytics.effects';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ButtonsRow = styled.View`
   justify-content: center;

--- a/src/navigation/tabs/home/components/PortfolioBalance.tsx
+++ b/src/navigation/tabs/home/components/PortfolioBalance.tsx
@@ -18,7 +18,7 @@ import {
 import Percentage from '../../../../components/percentage/Percentage';
 import {COINBASE_ENV} from '../../../../api/coinbase/coinbase.constants';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const PortfolioContainer = styled.View`
   justify-content: center;

--- a/src/navigation/tabs/home/components/Wallet.tsx
+++ b/src/navigation/tabs/home/components/Wallet.tsx
@@ -31,7 +31,7 @@ import {useAppSelector} from '../../../../utils/hooks';
 import {useTranslation} from 'react-i18next';
 import AngleRightSvg from '../../../../../assets/img/angle-right.svg';
 import {Balance, OptionName} from '../../../wallet/components/DropdownOption';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface WalletCardComponentProps {
   wallets: Wallet[];

--- a/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
+++ b/src/navigation/tabs/home/components/advertisements/AdvertisementCard.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../../utils/braze';
 import {useAppDispatch, useUrlEventHandler} from '../../../../../utils/hooks';
 import {BoxShadow} from '../Styled';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface AdvertisementCardProps {
   contentCard: ContentCard;

--- a/src/navigation/tabs/home/components/cards/LinkCard.tsx
+++ b/src/navigation/tabs/home/components/cards/LinkCard.tsx
@@ -8,7 +8,7 @@ import {
 import {LightBlack, White} from '../../../../../styles/colors';
 import {BoxShadow} from '../Styled';
 import haptic from '../../../../../components/haptic-feedback/haptic';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 interface LinkCardProps {
   image?: any;
   description: string;

--- a/src/navigation/tabs/home/components/exchange-rates/ExchangeRateItem.tsx
+++ b/src/navigation/tabs/home/components/exchange-rates/ExchangeRateItem.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../../styles/colors';
 import {View} from 'react-native';
 import {useAppSelector} from '../../../../../utils/hooks';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const RowContainer = styled(TouchableOpacity)`
   flex-direction: row;

--- a/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
+++ b/src/navigation/tabs/home/components/quick-links/QuickLinksCard.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React from 'react';
 import {Linking} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Braze, {ContentCard} from '@braze/react-native-sdk';
 import FastImage, {Source} from 'react-native-fast-image';
 import styled, {useTheme} from 'styled-components/native';

--- a/src/navigation/tabs/settings/about/screens/SendFeedback.tsx
+++ b/src/navigation/tabs/settings/about/screens/SendFeedback.tsx
@@ -29,7 +29,7 @@ import {useTranslation} from 'react-i18next';
 import {APP_VERSION} from '../../../../../constants/config';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {AboutScreens, AboutStackParamList} from '../AboutGroup';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type FeedbackRateType = 'love' | 'ok' | 'disappointed' | 'default';
 

--- a/src/navigation/tabs/settings/about/screens/SessionLog.tsx
+++ b/src/navigation/tabs/settings/about/screens/SessionLog.tsx
@@ -35,7 +35,7 @@ import SendIcon from '../../../../../../assets/img/send-icon.svg';
 import SendIconWhite from '../../../../../../assets/img/send-icon-white.svg';
 import {ListHeader} from '../../general/screens/customize-home/Shared';
 import {storage} from '../../../../../store';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 type SessionLogsScreenProps = NativeStackScreenProps<
   AboutGroupParamList,

--- a/src/navigation/tabs/settings/components/Security.tsx
+++ b/src/navigation/tabs/settings/components/Security.tsx
@@ -30,7 +30,7 @@ import {useTranslation} from 'react-i18next';
 import {sleep} from '../../../../utils/helper-methods';
 import {LogActions} from '../../../../store/log';
 import {useLogger} from '../../../../utils/hooks';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const FingerprintSvg = {
   light: <FingerprintImg />,

--- a/src/navigation/tabs/settings/external-services/screens/BanxaDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/BanxaDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/BanxaSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/BanxaSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/ChangellyDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/ChangellyDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {useTheme} from '@react-navigation/native';

--- a/src/navigation/tabs/settings/external-services/screens/ChangellySettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/ChangellySettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useNavigation, useIsFocused} from '@react-navigation/native';
 import moment from 'moment';
 import {Link} from '../../../../../components/styled/Text';

--- a/src/navigation/tabs/settings/external-services/screens/MoonpayDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/MoonpayDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/MoonpaySellDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/MoonpaySellDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Platform, RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/MoonpaySettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/MoonpaySettings.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/RampDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/RampDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import moment from 'moment';

--- a/src/navigation/tabs/settings/external-services/screens/RampSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/RampSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/SardineDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SardineDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/SardineSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SardineSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/SimplexDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SimplexDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import moment from 'moment';

--- a/src/navigation/tabs/settings/external-services/screens/SimplexSellDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SimplexSellDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import moment from 'moment';

--- a/src/navigation/tabs/settings/external-services/screens/SimplexSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/SimplexSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/ThorswapDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/ThorswapDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {useTheme} from '@react-navigation/native';

--- a/src/navigation/tabs/settings/external-services/screens/ThorswapSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/ThorswapSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useNavigation, useIsFocused} from '@react-navigation/native';
 import moment from 'moment';
 import {Link} from '../../../../../components/styled/Text';

--- a/src/navigation/tabs/settings/external-services/screens/TransakDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/TransakDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {RefreshControl, Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/TransakSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/TransakSettings.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   RouteProp,
   useRoute,

--- a/src/navigation/tabs/settings/external-services/screens/WyreDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/screens/WyreDetails.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Text} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native';
 import moment from 'moment';

--- a/src/navigation/tabs/settings/external-services/styled/ExternalServicesDetails.tsx
+++ b/src/navigation/tabs/settings/external-services/styled/ExternalServicesDetails.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components/native';
 import FastImage from 'react-native-fast-image';
 import {BaseText} from '../../../../../components/styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const RowDataContainer = styled.View`
   display: flex;

--- a/src/navigation/tabs/settings/external-services/styled/ExternalServicesSettings.tsx
+++ b/src/navigation/tabs/settings/external-services/styled/ExternalServicesSettings.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/native';
 import {BaseText} from '../../../../../components/styled/Text';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const NoPrMsg = styled(BaseText)`
   font-size: 15px;

--- a/src/navigation/tabs/settings/general/screens/customize-home/Shared.tsx
+++ b/src/navigation/tabs/settings/general/screens/customize-home/Shared.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from 'styled-components/native';
 import {H7} from '../../../../../../components/styled/Text';
 import {ScreenGutter} from '../../../../../../components/styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {Key, Wallet} from '../../../../../../store/wallet/wallet.models';
 import {HomeCarouselConfig} from '../../../../../../store/app/app.models';
 import _ from 'lodash';

--- a/src/navigation/tabs/settings/notifications/screens/PushNotifications.tsx
+++ b/src/navigation/tabs/settings/notifications/screens/PushNotifications.tsx
@@ -16,7 +16,7 @@ import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import styled from 'styled-components/native';
 import {startOnGoingProcessModal} from '../../../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../../../store/app/app.actions';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const SettingsComponent = styled.ScrollView`
   flex: 1;

--- a/src/navigation/tabs/shop/bill/components/BillItem.tsx
+++ b/src/navigation/tabs/shop/bill/components/BillItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Image, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useTranslation} from 'react-i18next';
 import styled from 'styled-components/native';
 import {BaseText, H6, Paragraph} from '../../../../../components/styled/Text';

--- a/src/navigation/tabs/shop/bill/components/BillList.tsx
+++ b/src/navigation/tabs/shop/bill/components/BillList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useTranslation} from 'react-i18next';
 import {ActiveOpacity} from '../../../../../components/styled/Containers';
 import BillItem from './BillItem';

--- a/src/navigation/tabs/shop/bill/components/PaymentList.tsx
+++ b/src/navigation/tabs/shop/bill/components/PaymentList.tsx
@@ -19,7 +19,7 @@ import {
   White,
 } from '../../../../../styles/colors';
 import {RefreshControl, ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {ShopEffects} from '../../../../../store/shop';
 import {AppActions} from '../../../../../store/app';

--- a/src/navigation/tabs/shop/bill/screens/BillSettings.tsx
+++ b/src/navigation/tabs/shop/bill/screens/BillSettings.tsx
@@ -4,7 +4,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {useTranslation} from 'react-i18next';
 import {BillGroupParamList} from '../BillGroup';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {LightBlack, LinkBlue, Slate10} from '../../../../../styles/colors';
 import {BaseText} from '../../../../../components/styled/Text';
 import {

--- a/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
+++ b/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
@@ -3,7 +3,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import {useTranslation} from 'react-i18next';
 import {BillScreens, BillGroupParamList} from '../BillGroup';
 import {Linking, ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ScreenContainer,
   horizontalPadding,

--- a/src/navigation/tabs/shop/bill/screens/PayAllBills.tsx
+++ b/src/navigation/tabs/shop/bill/screens/PayAllBills.tsx
@@ -10,7 +10,7 @@ import {
 import styled from 'styled-components/native';
 import Button from '../../../../../components/button/Button';
 import {Linking, ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   LightBlack,
   LuckySevens,

--- a/src/navigation/tabs/shop/bill/screens/PayBill.tsx
+++ b/src/navigation/tabs/shop/bill/screens/PayBill.tsx
@@ -6,7 +6,7 @@ import {H5, Paragraph} from '../../../../../components/styled/Text';
 import styled from 'styled-components/native';
 import Button from '../../../../../components/button/Button';
 import {Linking, ScrollView, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   LightBlack,
   LuckySevens,

--- a/src/navigation/tabs/shop/components/Bills.tsx
+++ b/src/navigation/tabs/shop/components/Bills.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import styled from 'styled-components/native';
 import {Trans, useTranslation} from 'react-i18next';
 import {Linking, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Button, {ButtonState} from '../../../../components/button/Button';
 import {
   ActiveOpacity,

--- a/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardCatalog.tsx
@@ -4,7 +4,7 @@ import styled, {useTheme} from 'styled-components/native';
 import pickBy from 'lodash.pickby';
 import uniqBy from 'lodash.uniqby';
 import {Platform, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useForm, Controller} from 'react-hook-form';
 import {ActiveOpacity, WIDTH} from '../../../../components/styled/Containers';
 import ShopCarouselList, {ShopCarouselItem} from './ShopCarouselList';

--- a/src/navigation/tabs/shop/components/GiftCardDenomSelector.tsx
+++ b/src/navigation/tabs/shop/components/GiftCardDenomSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import MinusSvg from '../../../../../assets/img/minus.svg';
 import PlusSvg from '../../../../../assets/img/plus.svg';

--- a/src/navigation/tabs/shop/components/MyGiftCards.tsx
+++ b/src/navigation/tabs/shop/components/MyGiftCards.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../../lib/gift-cards/gift-card';
 import {useTranslation} from 'react-i18next';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const MyGiftCardsHeaderContainer = styled(SectionHeaderContainer)`
   margin-bottom: -10px;

--- a/src/navigation/tabs/shop/components/PhoneCountryModal.tsx
+++ b/src/navigation/tabs/shop/components/PhoneCountryModal.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Modal, FlatList} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled, {useTheme} from 'styled-components/native';
 import {BaseText} from '../../../../components/styled/Text';
 import {PhoneCountryCode} from '../../../../lib/gift-cards/gift-card';

--- a/src/navigation/tabs/shop/components/ShopOnline.tsx
+++ b/src/navigation/tabs/shop/components/ShopOnline.tsx
@@ -3,7 +3,7 @@ import debounce from 'lodash.debounce';
 import React, {useMemo, useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled, {useTheme} from 'styled-components/native';
 import {ActiveOpacity, WIDTH} from '../../../../components/styled/Containers';
 import {BaseText, Paragraph} from '../../../../components/styled/Text';

--- a/src/navigation/tabs/shop/components/styled/ShopTabComponents.tsx
+++ b/src/navigation/tabs/shop/components/styled/ShopTabComponents.tsx
@@ -20,7 +20,7 @@ import {
   SlateDark,
   White,
 } from '../../../../../styles/colors';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const horizontalPadding = 20;
 

--- a/src/navigation/tabs/shop/gift-card/screens/ArchivedGiftCards.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/ArchivedGiftCards.tsx
@@ -9,7 +9,7 @@ import {
 import {GiftCardGroupParamList, GiftCardScreens} from '../GiftCardGroup';
 import {GiftCard} from '../../../../../store/shop/shop.models';
 import GiftCardCreditsItem from '../../components/GiftCardCreditsItem';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useAppSelector} from '../../../../../utils/hooks';
 import {sortByDescendingDate} from '../../../../../lib/gift-cards/gift-card';
 

--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useLayoutEffect, useState} from 'react';
 import {Platform, ScrollView, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import LinearGradient from 'react-native-linear-gradient';

--- a/src/navigation/tabs/shop/gift-card/screens/EnterPhone.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/EnterPhone.tsx
@@ -4,7 +4,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useState} from 'react';
 import {Controller, useForm} from 'react-hook-form';
 import {Keyboard, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useDispatch} from 'react-redux';
 import styled from 'styled-components/native';
 import Button from '../../../../../components/button/Button';

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -6,9 +6,9 @@ import {
   RefreshControl,
   Image,
   DeviceEventEmitter,
-  TouchableOpacity,
   Platform,
 } from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import RNPrint from 'react-native-print';
 import RenderHtml from 'react-native-render-html';
 import TimeAgo from 'react-native-timeago';

--- a/src/navigation/tabs/shop/merchant/screens/MerchantCategory.tsx
+++ b/src/navigation/tabs/shop/merchant/screens/MerchantCategory.tsx
@@ -1,6 +1,6 @@
 import React, {useLayoutEffect} from 'react';
 import {ScrollView} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import styled from 'styled-components/native';
 import {MerchantScreens, MerchantGroupParamList} from '../MerchantGroup';

--- a/src/navigation/wallet-connect/screens/WalletConnectConfirm.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectConfirm.tsx
@@ -72,7 +72,7 @@ import TrustedDomainSvg from '../../../../assets/img/trusted-domain.svg';
 import InvalidDomainSvg from '../../../../assets/img/invalid-domain.svg';
 import DefaultImage from '../../../../assets/img/wallet-connect/default-icon.svg';
 import VerifyContextModal from '../../../components/modal/wallet-connect/VerifyModalContext';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const HeaderRightContainer = styled.View``;
 

--- a/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
@@ -67,7 +67,7 @@ import SheetModal from '../../../components/modal/base/sheet/SheetModal';
 import Button from '../../../components/button/Button';
 import DefaultImage from '../../../../assets/img/wallet-connect/default-icon.svg';
 import InfoSvg from '../../../../assets/img/info.svg';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const WalletConnectConnectionsContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
@@ -67,7 +67,7 @@ import {InAppNotificationContextType} from '../../../store/app/app.models';
 import Blockie from '../../../components/blockie/Blockie';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import Button from '../../../components/button/Button';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useTheme} from '@react-navigation/native';
 import WarningOutlineSvg from '../../../../assets/img/warning-outline.svg';
 import TrustedDomainSvg from '../../../../assets/img/trusted-domain.svg';

--- a/src/navigation/wallet-connect/screens/WalletConnectIntro.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectIntro.tsx
@@ -5,7 +5,7 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import React, {useCallback, useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
 import styled from 'styled-components/native';
 import {Link, Paragraph} from '../../../components/styled/Text';

--- a/src/navigation/wallet-connect/screens/WalletConnectRequestDetails.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectRequestDetails.tsx
@@ -44,7 +44,7 @@ import {
 import {EVM_BLOCKCHAIN_ID} from '../../../constants/config';
 import {View} from 'react-native';
 import Blockie from '../../../components/blockie/Blockie';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type WalletConnectRequestDetailsParamList = {
   request: any;

--- a/src/navigation/wallet-connect/styled/WalletConnectContainers.tsx
+++ b/src/navigation/wallet-connect/styled/WalletConnectContainers.tsx
@@ -1,7 +1,7 @@
 import {Platform} from 'react-native';
 import styled, {css} from 'styled-components/native';
 import {ScreenGutter} from '../../../components/styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const WalletConnectContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet/components/AddressCard.tsx
+++ b/src/navigation/wallet/components/AddressCard.tsx
@@ -10,7 +10,7 @@ import {
 import {TxDetailsSendingTo} from '../../../store/wallet/wallet.models';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import ContactIcon from '../../tabs/contacts/components/ContactIcon';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface AddressCardComponentProps {
   recipient: TxDetailsSendingTo;

--- a/src/navigation/wallet/components/DeleteConfirmationModal.tsx
+++ b/src/navigation/wallet/components/DeleteConfirmationModal.tsx
@@ -6,7 +6,7 @@ import CautionSvg from '../../../../assets/img/error.svg';
 import {H4, Link, Paragraph} from '../../../components/styled/Text';
 import {SlateDark, White} from '../../../styles/colors';
 import haptic from '../../../components/haptic-feedback/haptic';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useTranslation} from 'react-i18next';
 
 interface ConfirmationModalProps {

--- a/src/navigation/wallet/components/DropdownOption.tsx
+++ b/src/navigation/wallet/components/DropdownOption.tsx
@@ -22,7 +22,7 @@ import {formatFiatAmountObj} from '../../../utils/helper-methods';
 import AngleRight from '../../../../assets/img/angle-right.svg';
 import {getRemainingWalletCount} from '../../../store/wallet/utils/wallet';
 import {WalletRowProps} from '../../../components/list/WalletRow';
-import { TouchableOpacity } from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface Props {
   optionId: string;

--- a/src/navigation/wallet/components/MultipleOutputsTx.tsx
+++ b/src/navigation/wallet/components/MultipleOutputsTx.tsx
@@ -40,7 +40,7 @@ import {
   SendToPillContainer,
 } from '../screens/send/confirm/Shared';
 import {RootState} from '../../../store';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const MisunderstoodOutputsText = styled(H7)`
   margin-bottom: 5px;

--- a/src/navigation/wallet/components/OptionsSheet.tsx
+++ b/src/navigation/wallet/components/OptionsSheet.tsx
@@ -10,7 +10,7 @@ import {
 import {Platform, Image, ImageSourcePropType} from 'react-native';
 import {Action, Black, Slate, White} from '../../../styles/colors';
 import {sleep} from '../../../utils/helper-methods';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const OptionsTitleContainer = styled.View`
   margin-bottom: 25px;

--- a/src/navigation/wallet/components/PaymentSent.tsx
+++ b/src/navigation/wallet/components/PaymentSent.tsx
@@ -7,7 +7,7 @@ import PaymentCompleteSvg from '../../../../assets/img/wallet/payment-complete.s
 import {BaseText} from '../../../components/styled/Text';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const PaymentSentContainer = styled.View`
   flex: 1;

--- a/src/navigation/wallet/components/RangeDateSelector.tsx
+++ b/src/navigation/wallet/components/RangeDateSelector.tsx
@@ -12,7 +12,7 @@ import {ActiveOpacity} from '../../../components/styled/Containers';
 import {titleCasing} from '../../../utils/helper-methods';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {DateRanges} from '../../../store/rate/rate.models';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface Props {
   onPress: (dateRange: DateRanges) => void;

--- a/src/navigation/wallet/components/ReceiveAddress.tsx
+++ b/src/navigation/wallet/components/ReceiveAddress.tsx
@@ -54,7 +54,7 @@ import {
   TitleContainer,
   viewOnBlockchain,
 } from './SendingToERC20Warning';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const BchAddressTypes = ['Cash Address', 'Legacy'];
 

--- a/src/navigation/wallet/components/ReceiveAddressHeader.tsx
+++ b/src/navigation/wallet/components/ReceiveAddressHeader.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native';
 import {BaseText, H4} from '../../../components/styled/Text';
 import {Action, NeutralSlate, SlateDark} from '../../../styles/colors';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const Header = styled.View`
   margin-bottom: 30px;

--- a/src/navigation/wallet/components/RecoveryPhrase.tsx
+++ b/src/navigation/wallet/components/RecoveryPhrase.tsx
@@ -88,7 +88,7 @@ import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 import {Analytics} from '../../../store/analytics/analytics.effects';
 import {IS_ANDROID, IS_IOS} from '../../../constants';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ScrollViewContainer = styled(KeyboardAwareScrollView)`
   margin-top: 20px;

--- a/src/navigation/wallet/components/SendToAddress.tsx
+++ b/src/navigation/wallet/components/SendToAddress.tsx
@@ -24,7 +24,8 @@ import {
   ValidateCoinAddress,
   ValidateURI,
 } from '../../../store/wallet/utils/validations';
-import {FlatList, TouchableOpacity, View} from 'react-native';
+import {FlatList, View} from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import haptic from '../../../components/haptic-feedback/haptic';
 import ScanSvg from '../../../../assets/img/onboarding/scan.svg';
 import {

--- a/src/navigation/wallet/components/SendingToERC20Warning.tsx
+++ b/src/navigation/wallet/components/SendingToERC20Warning.tsx
@@ -25,7 +25,7 @@ import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';
 import {Effect} from '../../../store';
 import {useAppDispatch} from '../../../utils/hooks';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export const BchAddressTypes = ['Cash Address', 'Legacy'];
 

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -32,7 +32,7 @@ import {
   SectionList,
   View,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   Badge,
   Balance,

--- a/src/navigation/wallet/screens/AccountSettings.tsx
+++ b/src/navigation/wallet/screens/AccountSettings.tsx
@@ -40,7 +40,7 @@ import HeaderBackButton from '../../../components/back/HeaderBackButton';
 import {IsEVMChain} from '../../../store/wallet/utils/currency';
 import {startOnGoingProcessModal} from '../../../store/app/app.effects';
 import {dismissOnGoingProcessModal} from '../../../store/app/app.actions';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const AccountSettingsContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet/screens/AddCustomToken.tsx
+++ b/src/navigation/wallet/screens/AddCustomToken.tsx
@@ -83,7 +83,7 @@ import {PillText} from '../components/SendToPill';
 import {ChainSelectionRow} from '../../../components/list/ChainSelectionRow';
 import {RootState} from '../../../store';
 import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type AddCustomTokenParamList = {
   key: Key;

--- a/src/navigation/wallet/screens/AddWallet.tsx
+++ b/src/navigation/wallet/screens/AddWallet.tsx
@@ -41,7 +41,7 @@ import {yupResolver} from '@hookform/resolvers/yup';
 import yup from '../../../lib/yup';
 import {NeutralSlate, SlateDark, White} from '../../../styles/colors';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {getProtocolName, sleep} from '../../../utils/helper-methods';
 import Haptic from '../../../components/haptic-feedback/haptic';
 import ChevronUpSvg from '../../../../assets/img/chevron-up.svg';

--- a/src/navigation/wallet/screens/Copayers.tsx
+++ b/src/navigation/wallet/screens/Copayers.tsx
@@ -9,8 +9,8 @@ import {
   ScrollView,
   RefreshControl,
   Share,
-  TouchableOpacity,
 } from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   Paragraph,
   BaseText,

--- a/src/navigation/wallet/screens/CreateMultisig.tsx
+++ b/src/navigation/wallet/screens/CreateMultisig.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import {Caution, SlateDark, White, Action, Slate} from '../../../styles/colors';
 import {

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -18,7 +18,7 @@ import {
   sleep,
 } from '../../../utils/helper-methods';
 import {Platform, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import GlobalSelectRow from '../../../components/list/GlobalSelectRow';
 import SheetModal from '../../../components/modal/base/sheet/SheetModal';
 import {

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -14,7 +14,7 @@ import {
 } from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import {LogBox, RefreshControl} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -14,7 +14,7 @@ import {
 } from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import {LogBox, RefreshControl} from 'react-native';
-import {TouchableOpacity} from '@components/base/TouchableOpacity';
+import {TouchableOpacity} from 'react-native-gesture-handler';
 import styled from 'styled-components/native';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {

--- a/src/navigation/wallet/screens/KeySettings.tsx
+++ b/src/navigation/wallet/screens/KeySettings.tsx
@@ -18,7 +18,7 @@ import {useNavigation, useRoute} from '@react-navigation/native';
 import {RouteProp} from '@react-navigation/core';
 import {WalletGroupParamList} from '../WalletGroup';
 import {View, ScrollView, FlatList} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import {
   ActiveOpacity,

--- a/src/navigation/wallet/screens/PaperWallet.tsx
+++ b/src/navigation/wallet/screens/PaperWallet.tsx
@@ -45,7 +45,7 @@ import {SatToUnit} from '../../../store/wallet/effects/amount/amount';
 import {StackActions} from '@react-navigation/native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Platform} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const PAPER_WALLET_SUPPORTED_COINS = ['btc', 'bch', 'doge', 'ltc'];
 

--- a/src/navigation/wallet/screens/RecoveryPhrase.tsx
+++ b/src/navigation/wallet/screens/RecoveryPhrase.tsx
@@ -22,7 +22,7 @@ import {
   SlateDark,
 } from '../../../styles/colors';
 import {Platform} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {useDispatch} from 'react-redux';
 import {showBottomNotificationModal} from '../../../store/app/app.actions';

--- a/src/navigation/wallet/screens/SelectInputs.tsx
+++ b/src/navigation/wallet/screens/SelectInputs.tsx
@@ -40,7 +40,7 @@ import {GetPrecision} from '../../../store/wallet/utils/currency';
 import {useAppDispatch, useAppSelector, useLogger} from '../../../utils/hooks';
 import Button from '../../../components/button/Button';
 import {LayoutAnimation} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   dismissOnGoingProcessModal,
   showBottomNotificationModal,

--- a/src/navigation/wallet/screens/SendToOptions.tsx
+++ b/src/navigation/wallet/screens/SendToOptions.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../store/wallet/wallet.models';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import {ActiveOpacity, Hr} from '../../../components/styled/Containers';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import WalletIcons from '../components/WalletIcons';
 import _ from 'lodash';
 import AmountModal from '../../../components/amount/AmountModal';

--- a/src/navigation/wallet/screens/TransactionDetails.tsx
+++ b/src/navigation/wallet/screens/TransactionDetails.tsx
@@ -34,7 +34,7 @@ import {
   GetBlockExplorerUrl,
   IsCustomERCToken,
 } from '../../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {TransactionIcons} from '../../../constants/TransactionIcons';
 import Button from '../../../components/button/Button';
 import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';

--- a/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
+++ b/src/navigation/wallet/screens/TransactionProposalNotifications.tsx
@@ -64,7 +64,7 @@ import SwipeButton from '../../../components/swipe-button/SwipeButton';
 import {publishAndSignMultipleProposals} from '../../../store/wallet/effects/send/send';
 import {Analytics} from '../../../store/analytics/analytics.effects';
 import {TransactionIcons} from '../../../constants/TransactionIcons';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const NotificationsContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -20,8 +20,8 @@ import {
   Share,
   Text,
   View,
-  TouchableOpacity,
 } from 'react-native';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import Settings from '../../../components/settings/Settings';
 import {

--- a/src/navigation/wallet/screens/WalletSettings.tsx
+++ b/src/navigation/wallet/screens/WalletSettings.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../../store/wallet/effects/status/status';
 import {useTranslation} from 'react-i18next';
 import {IsEVMChain} from '../../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const WalletSettingsContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet/screens/request-specific-amount/RequestSpecificAmountQR.tsx
+++ b/src/navigation/wallet/screens/request-specific-amount/RequestSpecificAmountQR.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../../../store/wallet/effects/amount/amount';
 import {useAppDispatch} from '../../../../utils/hooks';
 import {useTranslation} from 'react-i18next';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const SpecificAmtQRContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/wallet/screens/send/SendTo.tsx
+++ b/src/navigation/wallet/screens/send/SendTo.tsx
@@ -36,7 +36,7 @@ import {
   ValidateURI,
 } from '../../../../store/wallet/utils/validations';
 import {Linking, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import {GetPayProUrl} from '../../../../store/wallet/utils/decode-uri';
 import KeyWalletsRow, {

--- a/src/navigation/wallet/screens/send/TransactionLevel.tsx
+++ b/src/navigation/wallet/screens/send/TransactionLevel.tsx
@@ -32,7 +32,7 @@ import {
 import SheetModal from '../../../../components/modal/base/sheet/SheetModal';
 import Back from '../../../../components/back/Back';
 import {View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {DetailsList} from './confirm/Shared';
 import Button from '../../../../components/button/Button';
 import {

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -82,7 +82,7 @@ import {
   ScreenGutter,
 } from '../../../../../components/styled/Containers';
 import {Platform} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   GetFeeOptions,
   getFeeRatePerKb,

--- a/src/navigation/wallet/screens/send/confirm/Memo.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Memo.tsx
@@ -2,7 +2,7 @@ import {useTheme} from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {TextInput} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import styled from 'styled-components/native';
 import {Hr, ImportTextInput} from '../../../../../components/styled/Containers';
 import {H7} from '../../../../../components/styled/Text';

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -17,7 +17,7 @@ import {
 import React, {ReactChild, useCallback, useEffect, useState} from 'react';
 import styled from 'styled-components/native';
 import {Pressable, ScrollView, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {CurrencyImage} from '../../../../../components/currency-image/CurrencyImage';
 import ChevronRightSvg from '../../../../../../assets/img/angle-right.svg';
 import InfoSvg from '../../../../../../assets/img/info.svg';

--- a/src/navigation/wallet/screens/wallet-settings/Addresses.tsx
+++ b/src/navigation/wallet/screens/wallet-settings/Addresses.tsx
@@ -42,7 +42,7 @@ import haptic from '../../../../components/haptic-feedback/haptic';
 import CopiedSvg from '../../../../../assets/img/copied-success.svg';
 import {setWalletScanning} from '../../../../store/wallet/wallet.actions';
 import {isSingleAddressChain} from '../../../../store/wallet/utils/currency';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const ADDRESS_LIMIT = 5;
 

--- a/src/navigation/wallet/screens/wallet-settings/AllAddresses.tsx
+++ b/src/navigation/wallet/screens/wallet-settings/AllAddresses.tsx
@@ -24,7 +24,7 @@ import haptic from '../../../../components/haptic-feedback/haptic';
 import CopiedSvg from '../../../../../assets/img/copied-success.svg';
 import {LogActions} from '../../../../store/log';
 import {FlashList} from '@shopify/flash-list';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 export type AllAddressesParamList = {
   walletName: string;

--- a/src/navigation/wallet/screens/wallet-settings/ExportWallet.tsx
+++ b/src/navigation/wallet/screens/wallet-settings/ExportWallet.tsx
@@ -31,7 +31,7 @@ import {sleep} from '../../../../utils/helper-methods';
 import {useTranslation} from 'react-i18next';
 import {LogActions} from '../../../../store/log';
 import Mailer from 'react-native-mail';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const BWC = BwcProvider.getInstance();
 

--- a/src/navigation/wallet/screens/wallet-settings/WalletInformation.tsx
+++ b/src/navigation/wallet/screens/wallet-settings/WalletInformation.tsx
@@ -27,7 +27,7 @@ import {useAppDispatch, useLogger} from '../../../../utils/hooks';
 import {useTranslation} from 'react-i18next';
 import haptic from '../../../../components/haptic-feedback/haptic';
 import CopiedSvg from '../../../../../assets/img/copied-success.svg';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 const InfoContainer = styled.SafeAreaView`
   flex: 1;

--- a/src/navigation/zenledger/components/ZenLedgerKeyWalletsRow.tsx
+++ b/src/navigation/zenledger/components/ZenLedgerKeyWalletsRow.tsx
@@ -18,7 +18,7 @@ import {
   ZenLedgerKey,
   ZenLedgerWalletObj,
 } from '../../../store/zenledger/zenledger.models';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 
 interface KeyWalletsRowContainerProps {
   isLast?: boolean;

--- a/src/navigation/zenledger/screens/ZenLedgerIntro.tsx
+++ b/src/navigation/zenledger/screens/ZenLedgerIntro.tsx
@@ -9,7 +9,7 @@ import Button from '../../../components/button/Button';
 import {H4, Link, Paragraph, TextAlign} from '../../../components/styled/Text';
 import {useTranslation} from 'react-i18next';
 import {Platform, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {useAppDispatch} from '../../../utils/hooks';
 import {
   dismissBottomNotificationModal,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     /* Basic Options */
@@ -41,6 +40,7 @@
     "paths": {
       "@test/*": ["test/*"],
       "@/*": ["src/*"],
+      "@components/*": ["src/components/*"]
     },                                        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
Uses TouchableOpacity from react-native on android (unless the component is inside of a navigation header), and uses TouchableOpacity from react-native-gesture-handler everywhere else (since the onPress handler for TouchableOpacity from react-native doesn't always fire on Mac desktop)