### PR TITLE
Ref: new max limits for Moonpay-buy

### DIFF
--- a/src/navigation/services/buy-crypto/utils/moonpay-utils.ts
+++ b/src/navigation/services/buy-crypto/utils/moonpay-utils.ts
@@ -226,7 +226,7 @@ export const getMoonpayPaymentMethodFormat = (
 export const getMoonpayFiatAmountLimits = () => {
   return {
     min: 30,
-    max: 12000,
+    max: 30000,
   };
 };
 


### PR DESCRIPTION
>Luke Kennedy (From MoonPay team): Maximum Buy Limit - Looks like the maximum buy is hardcoded to $20,000. Those who want to put large transactions through would be happy to know that we support transaction sizes up to $30,000; it could be worth somehow indicating this to users for the MoonPay option in your upstream UI.