### PR TITLE
Fix: svg crash on iOS when navigating to buy/swap/sell 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2163,7 +2163,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.9.0):
+  - RNSVG (15.11.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2183,9 +2183,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.9.0)
+    - RNSVG/common (= 15.11.2)
     - Yoga
-  - RNSVG/common (15.9.0):
+  - RNSVG/common (15.11.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2698,7 +2698,7 @@ SPEC CHECKSUMS:
   RNReanimated: 7f11fff1964b5d073961b54167c22ebf3bd5aaff
   RNScreens: f493b156fe5de2434806b5a2c410800b2cd76c0e
   RNShare: 0cc7cc40681d2a858390552cf8b757f9bb4d460c
-  RNSVG: feeb4eb546e718d6c6fb70d10fd31e0c5c2d0d90
+  RNSVG: c2bdc41865cd5f94098dd05453dadaae6176b2dd
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react-native-screens": "3.35.0",
     "react-native-share": "11.1.0",
     "react-native-skeleton-placeholder": "5.2.4",
-    "react-native-svg": "15.9.0",
+    "react-native-svg": "15.11.2",
     "react-native-svg-transformer": "1.5.0",
     "react-native-tab-view": "3.1.1",
     "react-native-text-input-mask": "3.1.4",

--- a/src/components/modal/ongoing-process/OngoingProcess.tsx
+++ b/src/components/modal/ongoing-process/OngoingProcess.tsx
@@ -102,18 +102,32 @@ const OnGoingProcessModal: React.FC = () => {
     };
   });
   useEffect(() => {
+    let dismissTimeout: NodeJS.Timeout;
+    let opacityTimeout: NodeJS.Timeout;
+
     if (isVisible && appWasInit) {
       bottomSheetModalRef.current?.present();
-      setTimeout(() => {
+      opacityTimeout = setTimeout(() => {
         opacity.value = withTiming(1, {duration: opacityFadeDuration});
       }, 300);
     } else {
       opacity.value = withTiming(0, {duration: opacityFadeDuration});
-      setTimeout(() => {
-        bottomSheetModalRef.current?.dismiss();
-      }, opacityFadeDuration - 50);
+      dismissTimeout = setTimeout(() => {
+        if (bottomSheetModalRef.current) {
+          bottomSheetModalRef.current.dismiss();
+        }
+      }, opacityFadeDuration);
     }
-  }, [appWasInit, isVisible, opacity]);
+
+    return () => {
+      if (dismissTimeout) {
+        clearTimeout(dismissTimeout);
+      }
+      if (opacityTimeout) {
+        clearTimeout(opacityTimeout);
+      }
+    };
+  }, [appWasInit, isVisible, opacity, opacityFadeDuration]);
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop

--- a/yarn.lock
+++ b/yarn.lock
@@ -14719,10 +14719,10 @@ react-native-svg-transformer@1.5.0:
     "@svgr/plugin-svgo" "^8.1.0"
     path-dirname "^1.0.2"
 
-react-native-svg@15.9.0:
-  version "15.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.9.0.tgz#a742a63cb463502ce591fdfcf7b9e80544f0a8c2"
-  integrity sha512-pwo7hteAM0P8jNpPGQtiSd0SnbBhE8tNd94LT8AcZcbnH5AJdXBIcXU4+tWYYeGUjiNAH2E5d0T5XIfnvaz1gA==
+react-native-svg@15.11.2:
+  version "15.11.2"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.11.2.tgz#7540e8e1eabc4dcd3b1e35ada5a1d9f1b96d37c4"
+  integrity sha512-+YfF72IbWQUKzCIydlijV1fLuBsQNGMT6Da2kFlo1sh+LE3BIm/2Q7AR1zAAR6L0BFLi1WaQPLfFUC9bNZpOmw==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
Fixes sporadic SVG related crash on iOS when navigating to buy/swap/sell by upgrading `react-native-svg` to 15.11.2. Also improves setTimeout handling in the ongoing process component.