### PR TITLE
Fix: wallet connect pressables on android

### DIFF
--- a/src/components/base/TouchableOpacity.tsx
+++ b/src/components/base/TouchableOpacity.tsx
@@ -6,12 +6,16 @@ import {IS_ANDROID} from '../../constants';
 export const ActiveOpacity = 0.75;
 
 // Use intersection of both prop types to ensure compatibility
-export type TouchableOpacityProps = RNTouchableOpacityProps & GHTouchableOpacityProps;
+export type TouchableOpacityProps = RNTouchableOpacityProps & GHTouchableOpacityProps & {
+  touchableLibrary?: 'react-native' | 'react-native-gesture-handler';
+};
 
 export const TouchableOpacity: React.FC<TouchableOpacityProps> = ({
   activeOpacity = ActiveOpacity,
+  touchableLibrary,
   ...props
 }) => {
-  const TouchableComponent = IS_ANDROID ? RNTouchableOpacity : GHTouchableOpacity;
+  const specifiedTouchable = touchableLibrary && (touchableLibrary === 'react-native' ? RNTouchableOpacity : GHTouchableOpacity);
+  const TouchableComponent = specifiedTouchable || (IS_ANDROID ? RNTouchableOpacity : GHTouchableOpacity);
   return <TouchableComponent activeOpacity={activeOpacity} {...props} />;
 };

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -33,7 +33,7 @@ import * as Icons from './ButtonIcons';
 import ButtonOverlay from './ButtonOverlay';
 import ButtonSpinner from './ButtonSpinner';
 import {StyleProp, ViewStyle} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity, TouchableOpacityProps} from '@components/base/TouchableOpacity';
 
 export type ButtonState = 'loading' | 'success' | 'failed' | null | undefined;
 export type ButtonStyle =
@@ -57,6 +57,7 @@ interface ButtonProps extends BaseButtonProps {
   style?: StyleProp<ViewStyle>;
   action?: boolean;
   accessibilityLabel?: string;
+  touchableLibrary?: TouchableOpacityProps['touchableLibrary'];
 }
 
 interface ButtonOptionProps {
@@ -301,6 +302,7 @@ const Button: React.FC<React.PropsWithChildren<ButtonProps>> = props => {
     style,
     action,
     accessibilityLabel,
+    touchableLibrary,
   } = props;
   const secondary = buttonStyle === 'secondary';
   const outline = buttonOutline;
@@ -373,6 +375,7 @@ const Button: React.FC<React.PropsWithChildren<ButtonProps>> = props => {
 
   return (
     <ButtonContainer
+      touchableLibrary={touchableLibrary || 'react-native-gesture-handler'}
       accessibilityLabel={accessibilityLabel}
       style={style as any}
       buttonType={buttonType}

--- a/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
+++ b/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
@@ -682,6 +682,7 @@ export const WalletConnectStartModal = () => {
                 <Button
                   state={buttonState}
                   disabled={!(allKeys && allKeys[0]?.accounts[0])}
+                  touchableLibrary={'react-native'}
                   onPress={() => {
                     haptic('impactLight');
                     approveSessionProposal();
@@ -692,6 +693,7 @@ export const WalletConnectStartModal = () => {
               <ActionContainer>
                 <Button
                   buttonStyle="secondary"
+                  touchableLibrary={'react-native'}
                   onPress={() => {
                     haptic('impactLight');
                     if (proposal) {

--- a/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
@@ -189,6 +189,7 @@ const WalletConnectConnections = () => {
       headerRight: () => {
         return (
           <AddConnectionContainer
+            touchableLibrary={'react-native-gesture-handler'}
             onPress={() => {
               navigation.navigate('WalletConnectRoot', {});
             }}>
@@ -505,6 +506,7 @@ const WalletConnectConnections = () => {
               <Button
                 buttonStyle="danger"
                 buttonOutline={true}
+                touchableLibrary={'react-native'}
                 onPress={async () => {
                   haptic('impactLight');
                   setShowSessionOptions(false);


### PR DESCRIPTION
Currently, TouchableOpacity pressability inside of a sheet modal only works on android if it is imported from react-native, whereas TouchableOpacity inside of a header only works if it is imported from react-native-gesture-handler. This PR adds a new optional `touchableLibrary` param to the custom TouchableOpacity component that makes it possible to configure the import paths of TouchableOpacity components appropriately based on where they are placed to ensure onPress handlers fire on android.