### PR TITLE
Fix: disconnecting Coinbase crashes the app (Android)

### DIFF
--- a/src/navigation/coinbase/components/CoinbaseDashboard.tsx
+++ b/src/navigation/coinbase/components/CoinbaseDashboard.tsx
@@ -268,29 +268,31 @@ const CoinbaseDashboard = () => {
         )}
       </BalanceContainer>
       <Hr />
-      <FlashList
-        contentContainerStyle={{
-          paddingBottom: 50,
-        }}
-        refreshControl={
-          <RefreshControl
-            tintColor={theme.dark ? White : SlateDark}
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-          />
-        }
-        ListHeaderComponent={() => {
-          return (
-            <WalletListHeader>
-              <H5>{t('My Wallets')}</H5>
-            </WalletListHeader>
-          );
-        }}
-        data={accounts}
-        renderItem={renderItem}
-        estimatedItemSize={70}
-        ListFooterComponent={listFooterComponent}
-      />
+      {accounts && accounts.length > 0 ? (
+        <FlashList
+          contentContainerStyle={{
+            paddingBottom: 50,
+          }}
+          refreshControl={
+            <RefreshControl
+              tintColor={theme.dark ? White : SlateDark}
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+            />
+          }
+          ListHeaderComponent={() => {
+            return (
+              <WalletListHeader>
+                <H5>{t('My Wallets')}</H5>
+              </WalletListHeader>
+            );
+          }}
+          data={accounts}
+          renderItem={renderItem}
+          estimatedItemSize={70}
+          ListFooterComponent={listFooterComponent}
+        />
+      ) : null}
       <SheetModal
         isVisible={showKeyDropdown}
         placement={'top'}


### PR DESCRIPTION
Error: 
```
[Info] coinbaseDisconnectAccount: success
console.js:589 Warning: TypeError: Cannot read property 'length' of null

This error is located at:
    in FlashList (created by CoinbaseDashboard)
    in RCTView (created by View)
    in View
    in StyledNativeComponent (created by Styled(View))
    in Styled(View) (created by CoinbaseDashboard)
    in CoinbaseDashboard (created by CoinbaseRoot)
    in CoinbaseRoot (created by SceneView)
    in StaticContainer
    in EnsureSingleNavigator (created by SceneView)
    in SceneView (created by SceneView)
    in RCTView (created by View)
    in View (created by DebugContainer)
    in DebugContainer (created by MaybeNestedStack)
    in MaybeNestedStack (created by SceneView)
``` 

Source: https://github.com/Shopify/flash-list/issues/954 