### PR TITLE
Fix: undefined testnet4 BCH prefix

### DIFF
--- a/src/constants/currencies.ts
+++ b/src/constants/currencies.ts
@@ -80,7 +80,7 @@ export interface CurrencyOpts {
   };
   paymentInfo: {
     paymentCode: string;
-    protocolPrefix: {livenet: string; testnet: string; regtest: string};
+    protocolPrefix: {livenet: string; testnet: string; testnet4?: string; regtest: string;};
     // Urls
     ratesApi: string;
     blockExplorerUrls: string;
@@ -1254,6 +1254,7 @@ export const BitpaySupportedUtxoCoins: {[key in string]: CurrencyOpts} = {
       protocolPrefix: {
         livenet: 'bitcoincash',
         testnet: 'bchtest',
+        testnet4: 'bchtest',
         regtest: 'bchreg',
       },
       ratesApi: `${BASE_BWS_URL}/v3/fiatrates/bch`,


### PR DESCRIPTION
When sending testnet4 BCH to multiple recipients, the transaction proposal screen currently displays an `undefined` address prefix for each receiving address. This PR ensures the prefix shows as `bchtest`.