### PR TITLE
Fix: BitPay ID receive settings

### DIFF
--- a/src/components/list/KeyWalletsRow.tsx
+++ b/src/components/list/KeyWalletsRow.tsx
@@ -240,7 +240,7 @@ const KeyWalletsRow = ({
                   </Column>
                 </AccountChainsContainer>
                 {showChainAssets?.[evmAccount?.receiveAddress] !== false &&
-                  (evmAccount)?.assetsByChain?.map(({ chain, chainImg, chainName, chainAssetsList }: {chain: string, chainImg: string | ((props?: any) => ReactElement), chainName: string, chainAssetsList: WalletRowProps[]}) => (
+                  (evmAccount)?.assetsByChain?.filter(({chainAssetsList}) => chainAssetsList.length > 0).map(({ chain, chainImg, chainName, chainAssetsList }: {chain: string, chainImg: string | ((props?: any) => ReactElement), chainName: string, chainAssetsList: WalletRowProps[]}) => (
                     <View key={chain}>
                       <AccountChainTitleContainer>
                         <CurrencyImageContainer>

--- a/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ReceiveSettings.tsx
@@ -1,7 +1,11 @@
 import React, {useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
 import _ from 'lodash';
+import uniqBy from 'lodash.uniqby';
 import styled from 'styled-components/native';
 import {useNavigation, useTheme} from '@react-navigation/native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {
   ActiveOpacity,
   Br,
@@ -18,7 +22,6 @@ import {
 } from '../../../styles/colors';
 import AddSvg from '../../../../assets/img/add.svg';
 import AddWhiteSvg from '../../../../assets/img/add-white.svg';
-import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import Button from '../../../components/button/Button';
 import ChevronRight from '../components/ChevronRight';
 import SendToPill from '../../wallet/components/SendToPill';
@@ -45,16 +48,14 @@ import {ReceivingAddress} from '../../../store/bitpay-id/bitpay-id.models';
 import {WalletScreens} from '../../wallet/WalletGroup';
 import AddressModal from '../components/AddressModal';
 import {keyBackupRequired} from '../../tabs/home/components/Crypto';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import TwoFactorRequiredModal from '../components/TwoFactorRequiredModal';
 import {getCurrencyCodeFromCoinAndChain} from '../utils/bitpay-id-utils';
 import {
   BitpaySupportedCoins,
   BitpaySupportedTokens,
 } from '../../../constants/currencies';
+import {IsEVMChain} from '../../../store/wallet/utils/currency';
 import DefaultImage from '../../../../assets/img/currencies/default.svg';
-import {useTranslation} from 'react-i18next';
-import uniqBy from 'lodash.uniqby';
 
 const ReceiveSettingsContainer = styled.SafeAreaView`
   flex: 1;
@@ -88,6 +89,7 @@ const AddressItem = styled.View`
 
 const AddressItemText = styled(Paragraph)`
   flex-grow: 1;
+  flex-shrink: 1;
   margin-left: 1px;
 `;
 
@@ -140,6 +142,30 @@ const createAddressMap = (receivingAddresses: ReceivingAddress[]) => {
   return _.keyBy(receivingAddresses, ({coin, chain}) =>
     getReceivingAddressKey(coin, chain),
   );
+};
+
+const matchesChainAndCurrency = (
+  wallet: Wallet,
+  chain: string,
+  currencyAbbreviation: string,
+) => {
+  return (
+    wallet.currencyAbbreviation?.toLowerCase() ===
+      currencyAbbreviation?.toLowerCase() && wallet.chain === chain
+  );
+};
+
+const hasAccountOrWalletsMatchChainAndCurrency = (
+  chain: string,
+  currencyAbbreviation: string,
+) => {
+  return account => {
+    return account.currencyAbbreviation
+      ? matchesChainAndCurrency(account, chain, currencyAbbreviation)
+      : account.wallets?.some(wallet =>
+          matchesChainAndCurrency(wallet, chain, currencyAbbreviation),
+        );
+  };
 };
 
 type ReceiveSettingsProps = NativeStackScreenProps<
@@ -212,6 +238,7 @@ const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
     keys,
     network: Network.mainnet,
     defaultAltCurrencyIsoCode: defaultAltCurrency.isoCode,
+    filterWalletsByBalance: false,
     rates,
     dispatch,
   });
@@ -220,20 +247,38 @@ const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
     (keyWalletMap, {currencyAbbreviation, chain}) => ({
       ...keyWalletMap,
       [getReceivingAddressKey(currencyAbbreviation, chain)]: keyWallets
-        .map(keyWallet => ({
-          ...keyWallet,
-          accounts: keyWallet.accounts
-            .map(account => ({
-              ...account,
-              wallets: account.wallets.filter(
-                wallet =>
-                  wallet.currencyAbbreviation === currencyAbbreviation &&
-                  wallet.chain === chain,
-              ),
-            }))
-            .filter(account => account.wallets.length > 0),
-        }))
-        .filter(keyWallet => keyWallet.accounts.length > 0),
+        .filter(keyWallet =>
+          keyWallet.mergedUtxoAndEvmAccounts?.some(
+            hasAccountOrWalletsMatchChainAndCurrency(
+              chain,
+              currencyAbbreviation,
+            ),
+          ),
+        )
+        .map(keyWallet => {
+          return {
+            ...keyWallet,
+            mergedUtxoAndEvmAccounts: keyWallet.mergedUtxoAndEvmAccounts
+              ?.filter(
+                hasAccountOrWalletsMatchChainAndCurrency(
+                  chain,
+                  currencyAbbreviation,
+                ),
+              )
+              .map(account => ({
+                ...account,
+                wallets: account.wallets?.filter(wallet =>
+                  matchesChainAndCurrency(wallet, chain, currencyAbbreviation),
+                ),
+                assetsByChain: account.assetsByChain?.map(chainAssets => ({
+                  ...chainAssets,
+                  chainAssetsList: chainAssets.chainAssetsList.filter(asset =>
+                    matchesChainAndCurrency(asset, chain, currencyAbbreviation),
+                  ),
+                })),
+              })),
+          };
+        }),
     }),
     {} as {[key: string]: any[]},
   );
@@ -386,7 +431,7 @@ const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
             <>
               <SectionHeader>{t('Receiving Addresses')}</SectionHeader>
               {unusedActiveWallets.map(
-                ({currencyAbbreviation: coin, chain}) => {
+                ({currencyAbbreviation: coin, chain, chainName}) => {
                   return (
                     <TouchableOpacity
                       activeOpacity={ActiveOpacity}
@@ -402,9 +447,14 @@ const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
                           chain={chain}
                           size={25}
                         />
-                        <AddressItemText>
+                        <AddressItemText
+                          ellipsizeMode={'tail'}
+                          numberOfLines={1}>
                           Select a{' '}
-                          <WalletName>{coin.toUpperCase()} Wallet</WalletName>
+                          <WalletName>
+                            {coin.toUpperCase()} Wallet
+                            {IsEVMChain(chain) ? ` (${chainName})` : ''}
+                          </WalletName>
                         </AddressItemText>
                         <ChevronRight />
                       </AddressItem>
@@ -520,6 +570,7 @@ const ReceiveSettings = ({navigation}: ReceiveSettingsProps) => {
           shadowOpacity: 0.1,
           shadowRadius: 12,
           elevation: 5,
+          marginBottom: -10,
         }}>
         <Button
           onPress={() =>

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -172,8 +172,10 @@ export interface WalletSelectMenuHeaderContainerParams {
 }
 
 export const WalletSelectMenuHeaderContainer = styled.View<WalletSelectMenuHeaderContainerParams>`
+  flex-direction: row;
   padding: 16px;
   padding-bottom: ${({currency}) => (currency ? 14 : 0)}px;
+  padding-left: 5;
   justify-content: ${({currency}) => (currency ? 'flex-start' : 'center')};
   border-bottom-color: ${({theme: {dark}}) => (dark ? LightBlack : '#ECEFFD')};
   border-bottom-width: ${({currency}) => (currency ? 1 : 0)}px;

--- a/src/navigation/wallet/screens/send/confirm/Shared.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Shared.tsx
@@ -644,6 +644,7 @@ export const WalletSelector = ({
         <WalletSelectMenuBodyContainer>
           <KeyWalletsRow<KeyWallet>
             currency={currency}
+            showChainAssets={true}
             keyAccounts={walletsAndAccounts.keyWallets}
             hideBalance={hideAllBalances}
             onPress={wallet => selectOption(() => onWalletSelect(wallet), true)}
@@ -678,9 +679,7 @@ export const CurrencyIconAndBadge = ({
   size: number;
 }) => {
   const fullCurrencyAbbreviation = getCurrencyAbbreviation(coin, chain);
-  const badgeImg = IsERCToken(coin, chain)
-    ? getBadgeImg(coin, chain)
-    : undefined;
+  const badgeImg = getBadgeImg(coin, chain);
   const CurrencyIcon =
     CurrencyListIcons[fullCurrencyAbbreviation.toLowerCase()];
 

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -580,6 +580,7 @@ export const BuildKeysAndWalletsList = ({
   network,
   payProOptions,
   defaultAltCurrencyIsoCode = 'USD',
+  filterWalletsByBalance = true,
   rates,
   dispatch,
 }: {
@@ -587,6 +588,7 @@ export const BuildKeysAndWalletsList = ({
   network?: Network;
   payProOptions?: PayProOptions;
   defaultAltCurrencyIsoCode?: string;
+  filterWalletsByBalance?: boolean;
   rates: Rates;
   dispatch: AppDispatch;
 }) => {
@@ -606,7 +608,7 @@ export const BuildKeysAndWalletsList = ({
         paymentOptions,
         filterWalletsByPaymentOptions: true,
         filterByHideWallet: true,
-        filterWalletsByBalance: true,
+        filterWalletsByBalance,
         network,
       },
     );


### PR DESCRIPTION
This PR fixes an issue that led to a "No compatible wallets" error when trying to select a wallet in BitPay ID receive settings.