### PR TITLE
Fix: prevent encrypt pass prompt for tokens in external services

### DIFF
--- a/src/navigation/coinbase/screens/CoinbaseAccount.tsx
+++ b/src/navigation/coinbase/screens/CoinbaseAccount.tsx
@@ -629,14 +629,16 @@ const CoinbaseAccount = ({
       onSelectedWallet(newWallet);
     } else if (createNewWalletData) {
       try {
-        if (createNewWalletData.key.isPrivKeyEncrypted) {
+        if (createNewWalletData.key.isPrivKeyEncrypted && !(createNewWalletData.currency?.isToken && createNewWalletData.associatedWallet)) {
           logger.debug('Key is Encrypted. Trying to decrypt...');
           await sleep(500);
           const password = await dispatch(
             getDecryptPassword(createNewWalletData.key),
           );
           createNewWalletData.options.password = password;
-        }
+      } else {
+        logger.debug('Key is Encrypted, but not neccessary for tokens. Trying to create wallet...');
+      }
 
         await sleep(500);
         await dispatch(startOnGoingProcessModal('ADDING_WALLET'));

--- a/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
+++ b/src/navigation/services/buy-crypto/screens/BuyCryptoRoot.tsx
@@ -811,13 +811,15 @@ const BuyCryptoRoot = ({
       setWallet(newWallet);
     } else if (createNewWalletData) {
       try {
-        if (createNewWalletData.key.isPrivKeyEncrypted) {
-          logger.debug('Key is Encrypted. Trying to decrypt...');
-          await sleep(500);
-          const password = await dispatch(
-            getDecryptPassword(createNewWalletData.key),
-          );
-          createNewWalletData.options.password = password;
+        if (createNewWalletData.key.isPrivKeyEncrypted && !(createNewWalletData.currency?.isToken && createNewWalletData.associatedWallet)) {
+            logger.debug('Key is Encrypted. Trying to decrypt...');
+            await sleep(500);
+            const password = await dispatch(
+              getDecryptPassword(createNewWalletData.key),
+            );
+            createNewWalletData.options.password = password;
+        } else {
+          logger.debug('Key is Encrypted, but not neccessary for tokens. Trying to create wallet...');
         }
 
         await sleep(500);

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -1375,13 +1375,15 @@ const SwapCryptoRoot: React.FC = () => {
       setToWallet(toWallet);
     } else if (createToWalletData) {
       try {
-        if (createToWalletData.key.isPrivKeyEncrypted) {
-          logger.debug('Key is Encrypted. Trying to decrypt...');
-          await sleep(500);
-          const password = await dispatch(
-            getDecryptPassword(createToWalletData.key),
-          );
-          createToWalletData.options.password = password;
+        if (createToWalletData.key.isPrivKeyEncrypted && !(createToWalletData.currency?.isToken && createToWalletData.associatedWallet)) {
+            logger.debug('Key is Encrypted. Trying to decrypt...');
+            await sleep(500);
+            const password = await dispatch(
+              getDecryptPassword(createToWalletData.key),
+            );
+            createToWalletData.options.password = password;
+        } else {
+          logger.debug('Key is Encrypted, but not neccessary for tokens. Trying to create wallet...');
         }
 
         await sleep(500);


### PR DESCRIPTION
Prevent encrypt pass prompt for external services if token is created with associatedWallet. Otherwise BWC requieres the encrypt, to be able to create the wallet with the same mnemonics.