### PR TITLE
Fix: prevent keyboard from blocking numpad when sending to multiple addresses

### DIFF
--- a/src/navigation/wallet/screens/SendToOptions.tsx
+++ b/src/navigation/wallet/screens/SendToOptions.tsx
@@ -1,7 +1,7 @@
 import React, {useLayoutEffect, useState} from 'react';
+import {Keyboard} from 'react-native';
 import styled from 'styled-components/native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
-import {ScreenOptions} from '../../../styles/tabNavigator';
 import {H5, H7, HeaderTitle} from '../../../components/styled/Text';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
@@ -210,6 +210,7 @@ const SendToOptions = () => {
     if (recipient.amount && !updateRecipient) {
       setRecipientListContext(recipient);
     } else {
+      Keyboard.dismiss();
       setRecipientAmount({showModal: true, recipient, index, updateRecipient});
     }
   };


### PR DESCRIPTION
Currently, the native keyboard stays open and blocks the numpad in the amount modal after an address is pasted into the search input of the "Transfer to multiple recipients" flow. The native keyboard also cannot be dismissed by tapping elsewhere on the screen. This PR hides the native keyboard right before the amount modal is shown.