### PR TITLE
Fix: account details settings icon press handling on android

### DIFF
--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -816,6 +816,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
               ) : null}
               {hasAllChains ? (
                 <TouchableOpacity
+                  touchableLibrary={'react-native-gesture-handler'}
                   onPress={() =>
                     navigation.navigate('AccountSettings', {
                       key,


### PR DESCRIPTION
Currently, the onPress handler of the settings header button in account details is not firing on android. This PR ensures the settings header button is useable on android.