### PR TITLE
Fix: scrollable bottom sheet notifications on android

### DIFF
--- a/src/components/modal/bottom-notification/BottomNotification.tsx
+++ b/src/components/modal/bottom-notification/BottomNotification.tsx
@@ -32,6 +32,7 @@ export interface BottomNotificationConfig {
   type: 'success' | 'info' | 'warning' | 'error' | 'question' | 'wait';
   title: string;
   message: string;
+  modalLibrary?: 'bottom-sheet' | 'modal';
   actions: Array<{
     text: string;
     primary?: boolean;
@@ -141,12 +142,13 @@ const BottomNotification = () => {
     actions,
     enableBackdropDismiss,
     message2,
+    modalLibrary,
     onBackdropDismiss,
   } = config || {};
 
   return (
     <SheetModal
-      modalLibrary={'bottom-sheet'}
+      modalLibrary={modalLibrary || 'bottom-sheet'}
       enableBackdropDismiss={enableBackdropDismiss}
       isVisible={isVisible}
       onBackdropPress={() => {

--- a/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
+++ b/src/navigation/tabs/shop/bill/screens/ConnectBillsOptions.tsx
@@ -151,6 +151,7 @@ const ConnectBillsOptions = ({
         title: t('Confirm Your Info'),
         message: '',
         message2: <UserInfo />,
+        modalLibrary: 'modal',
         enableBackdropDismiss: true,
         onBackdropDismiss: () => {},
         actions: [

--- a/src/navigation/tabs/shop/components/Bills.tsx
+++ b/src/navigation/tabs/shop/components/Bills.tsx
@@ -180,6 +180,7 @@ export const Bills = () => {
         title: t('Confirm Your Info'),
         message: '',
         message2: <UserInfo />,
+        modalLibrary: 'modal',
         enableBackdropDismiss: true,
         onBackdropDismiss: () => {},
         actions: [

--- a/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/GiftCardDetails.tsx
@@ -292,6 +292,7 @@ const GiftCardDetails = ({
     return AppActions.showBottomNotificationModal({
       type: 'success',
       title: t('Copied: ', {copiedValue}),
+      modalLibrary: 'modal',
       message: '',
       message2: (
         <ScrollableBottomNotificationMessageContainer


### PR DESCRIPTION
Uses the react-native-modal library for bottom sheet notifications that contain scrollable content to fix an issue where these notifications don't scroll on android, such as in the bill pay user info confirmation sheet and gift card redeem instructions.