### PR TITLE
Fix: prevent double "Gift Card" text in header title

### DIFF
--- a/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
+++ b/src/navigation/tabs/shop/gift-card/screens/BuyGiftCard.tsx
@@ -184,7 +184,7 @@ const BuyGiftCard = ({
   );
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: t('BuyGiftCard', {displayName: cardConfig.displayName}),
+      headerTitle: t('BuyGiftCard', {displayName: cardConfig.displayName.replace(' Gift Card', '')}),
     });
   });
   useEffect(() => {


### PR DESCRIPTION
If a gift card already has "Gift Card" in the name, remove it in the header title of BuyGiftCard.tsx to prevent a situation where the header title says "Buy Example Gift Card Gift Card."