### PR TITLE
Fix: buy crypto terms of services links

### DIFF
--- a/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
+++ b/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
@@ -664,7 +664,7 @@ export const WalletConnectStartModal = () => {
                               }}>
                               (+{availableAccountLength - 1})
                             </BaseText>
-                            <SelectorArrowRight 
+                            <SelectorArrowRight
                               {...{
                                 width: 13,
                                 height: 13,
@@ -673,7 +673,7 @@ export const WalletConnectStartModal = () => {
                             />
                           </AccountSettingsArrowContainer>
                         ) : <View>
-                        <SelectorArrowRight 
+                        <SelectorArrowRight
                           {...{
                             width: 13,
                             height: 13,

--- a/src/navigation/services/buy-crypto/components/terms/MoonpayTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/MoonpayTerms.tsx
@@ -48,38 +48,38 @@ const MoonpayTerms: React.FC<{
         {t(
           'Moonpay also charges a dynamic network fee on all BTC, ETH and ERC20 tokens purchases, based on the blockchain network conditions.',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                'https://support.moonpay.com/customers/docs/moonpay-fees',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, marginLeft: 2, top: 2}}>
-            {t('Read more')}
-          </Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
-      <ExchangeTermsText style={{marginTop: 4}}>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://support.moonpay.com/customers/docs/moonpay-fees',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>
+          {t('Read more')}
+        </Link>
+      </TouchableOpacity>
+      <ExchangeTermsText style={{marginTop: 6}}>
         {t(
           'This service is provided by a third party, and you are subject to their',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                country == 'US'
-                  ? 'https://www.moonpay.com/legal/terms_of_use_usa'
-                  : 'https://www.moonpay.com/legal/terms_of_use',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of use')}</Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              country == 'US'
+                ? 'https://www.moonpay.com/legal/terms_of_use_usa'
+                : 'https://www.moonpay.com/legal/terms_of_use',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of use')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };

--- a/src/navigation/services/buy-crypto/components/terms/RampTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/RampTerms.tsx
@@ -43,38 +43,38 @@ const RampTerms: React.FC<{
         {t(
           'Ramp Network also charges a dynamic network fee based on the blockchain network conditions, and a partner margin when purchasing crypto within their apps.',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                'https://support.ramp.network/en/articles/10415-what-fees-does-ramp-charge-for-buying-and-selling-crypto',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, marginLeft: 2, top: 2}}>
-            {t('Read more')}
-          </Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
-      <ExchangeTermsText style={{marginTop: 4}}>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://support.ramp.network/en/articles/10415-what-fees-does-ramp-charge-for-buying-and-selling-crypto',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>
+          {t('Read more')}
+        </Link>
+      </TouchableOpacity>
+      <ExchangeTermsText style={{marginTop: 6}}>
         {t(
           'This service is provided by a third party, and you are subject to their',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                country == 'US'
-                  ? 'https://ramp.network/terms-of-service/#us-terms-of-service'
-                  : 'https://ramp.network/terms-of-service/#global-terms-of-service',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of service')}</Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              country == 'US'
+                ? 'https://ramp.network/terms-of-service/#us-terms-of-service'
+                : 'https://ramp.network/terms-of-service/#global-terms-of-service',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of service')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };

--- a/src/navigation/services/buy-crypto/components/terms/SardineTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/SardineTerms.tsx
@@ -40,7 +40,7 @@ const SardineTerms: React.FC<{
       <ExchangeTermsText>
         {t('What service fees am I paying?')}
       </ExchangeTermsText>
-      <ExchangeTermsText>
+      <ExchangeTermsText style={{maxWidth: '80%'}}>
         {t('SardineTermsFeeInfo', {
           networkFee,
           transactionFee,
@@ -51,20 +51,20 @@ const SardineTerms: React.FC<{
           'The network fee is paid to crypto miners to ensure that the transaction is processed on the crypto network.',
         )}
       </ExchangeTermsText>
-      <ExchangeTermsText style={{marginTop: 4}}>
+      <ExchangeTermsText style={{marginTop: 6}}>
         {t(
           'This service is provided by a third party, and you are subject to their',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser('https://crypto.sardine.ai/terms'),
-            );
-          }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of service')}</Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser('https://crypto.sardine.ai/terms'),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of service')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };

--- a/src/navigation/services/buy-crypto/components/terms/SimplexTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/SimplexTerms.tsx
@@ -26,39 +26,41 @@ const SimplexTerms: React.FC<{
         <ExchangeTermsText>{t('1.5% of the amount.')}</ExchangeTermsText>
       ) : null}
       {paymentMethod?.method != 'sepaBankTransfer' ? (
-        <ExchangeTermsText>
-          {t(
-            'Can range from 3.5% to 5% of the transaction, depending on the volume of traffic (with a minimum of 10 USD or its equivalent in any other fiat currency) + 1% of the transaction.',
-          )}
+        <>
+          <ExchangeTermsText>
+            {t(
+              'Can range from 3.5% to 5% of the transaction, depending on the volume of traffic (with a minimum of 10 USD or its equivalent in any other fiat currency) + 1% of the transaction.',
+            )}
+          </ExchangeTermsText>
           <TouchableOpacity
-            onPress={() => {
-              haptic('impactLight');
-              dispatch(
-                openUrlWithInAppBrowser(
-                  'https://support.simplex.com/hc/en-gb/articles/360014078420-What-fees-am-I-paying-',
-                ),
-              );
-            }}>
-            <Link style={{fontSize: 12, marginLeft: 2, top: 2}}>
-              {t('Read more')}
-            </Link>
-          </TouchableOpacity>
-        </ExchangeTermsText>
-      ) : null}
-      <ExchangeTermsText style={{marginTop: 4}}>
-        {t(
-          'This service is provided by a third party, and you are subject to their',
-        )}
-        <TouchableOpacity
           onPress={() => {
             haptic('impactLight');
             dispatch(
-              openUrlWithInAppBrowser('https://www.simplex.com/terms-of-use/'),
+              openUrlWithInAppBrowser(
+                'https://support.simplex.com/hc/en-gb/articles/360014078420-What-fees-am-I-paying-',
+              ),
             );
           }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of use')}</Link>
+          <Link style={{fontSize: 12}}>
+            {t('Read more')}
+          </Link>
         </TouchableOpacity>
+        </>
+      ) : null}
+      <ExchangeTermsText style={{marginTop: 6}}>
+        {t(
+          'This service is provided by a third party, and you are subject to their',
+        )}
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser('https://www.simplex.com/terms-of-use/'),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of use')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };

--- a/src/navigation/services/buy-crypto/components/terms/TransakTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/TransakTerms.tsx
@@ -50,38 +50,38 @@ const TransakTerms: React.FC<{
         {t(
           'Transak also charges a dynamic network fee based on the blockchain network conditions, and a partner margin when purchasing crypto within their apps.',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                'https://support.transak.com/en/articles/7845942-how-does-transak-calculate-prices-and-fees',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, marginLeft: 2, top: 2}}>
-            {t('Read more')}
-          </Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
-      <ExchangeTermsText style={{marginTop: 4}}>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://support.transak.com/en/articles/7845942-how-does-transak-calculate-prices-and-fees',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>
+          {t('Read more')}
+        </Link>
+      </TouchableOpacity>
+      <ExchangeTermsText style={{marginTop: 6}}>
         {t(
           'This service is provided by a third party, and you are subject to their',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                country === 'US'
-                  ? 'https://transak.com/terms-of-service-us'
-                  : 'https://transak.com/terms-of-service',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of service')}</Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              country === 'US'
+                ? 'https://transak.com/terms-of-service-us'
+                : 'https://transak.com/terms-of-service',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of service')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };

--- a/src/navigation/services/buy-crypto/components/terms/banxaTerms.tsx
+++ b/src/navigation/services/buy-crypto/components/terms/banxaTerms.tsx
@@ -48,36 +48,36 @@ const BanxaTerms: React.FC<{
         {t(
           'Banxa also charges a service fee, which is included in the unit price for the transaction, based the cost of each payment method.',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                'https://support.banxa.com/en/support/solutions/articles/44002465167-how-does-banxa-set-the-price-of-cryptocurrency-',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, marginLeft: 2, top: 2}}>
-            {t('Read more')}
-          </Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
-      <ExchangeTermsText style={{marginTop: 4}}>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://support.banxa.com/en/support/solutions/articles/44002465167-how-does-banxa-set-the-price-of-cryptocurrency-',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>
+          {t('Read more')}
+        </Link>
+      </TouchableOpacity>
+      <ExchangeTermsText style={{marginTop: 6}}>
         {t(
           'This service is provided by a third party, and you are subject to their',
         )}
-        <TouchableOpacity
-          onPress={() => {
-            haptic('impactLight');
-            dispatch(
-              openUrlWithInAppBrowser(
-                'https://banxa.com/wp-content/uploads/2023/06/Customer-Terms-and-Conditions-19-June-2023.pdf',
-              ),
-            );
-          }}>
-          <Link style={{fontSize: 12, top: 2}}>{t('Terms of use')}</Link>
-        </TouchableOpacity>
       </ExchangeTermsText>
+      <TouchableOpacity
+        onPress={() => {
+          haptic('impactLight');
+          dispatch(
+            openUrlWithInAppBrowser(
+              'https://banxa.com/wp-content/uploads/2023/06/Customer-Terms-and-Conditions-19-June-2023.pdf',
+            ),
+          );
+        }}>
+        <Link style={{fontSize: 12}}>{t('Terms of use')}</Link>
+      </TouchableOpacity>
     </ExchangeTermsContainer>
   );
 };


### PR DESCRIPTION
Currently, the "Read More" and "Terms of Service" links in the Buy Crypto offers are no longer clickable. This PR fixes it.