### PR TITLE
[REF] use bws for sending wc transactions

### DIFF
--- a/src/components/modal/in-app-notification/InAppNotification.tsx
+++ b/src/components/modal/in-app-notification/InAppNotification.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import {Action, LightBlack} from '../../../styles/colors';
+import {Action, Black, LightBlack, White} from '../../../styles/colors';
 import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
 import {BlurContainer} from '../../blur/Blur';
 import {BaseText} from '../../styled/Text';
@@ -15,6 +15,7 @@ import {useNavigation} from '@react-navigation/native';
 import {getGasWalletByRequest} from '../../../store/wallet-connect-v2/wallet-connect-v2.effects';
 import {sleep} from '../../../utils/helper-methods';
 import {TouchableOpacity} from '@components/base/TouchableOpacity';
+import {useTheme} from '@react-navigation/native';
 
 export type InAppNotificationMessages = 'NEW_PENDING_REQUEST';
 
@@ -66,6 +67,7 @@ const InAppNotification: React.FC = () => {
   const inAppNotificationData = useAppSelector(
     ({APP}) => APP.inAppNotificationData,
   );
+  const theme = useTheme();
   const {context, message, request} = inAppNotificationData || {};
 
   const onBackdropPress = () => {
@@ -128,7 +130,11 @@ const InAppNotification: React.FC = () => {
           </MessageContainer>
           <CloseModalContainer>
             <CloseModalButton onPress={onBackdropPress}>
-              <CloseModal width={20} height={20} />
+              <CloseModal {...{
+                width: 20,
+                height: 20,
+                color: theme.dark ? White : Black,
+              }} />
             </CloseModalButton>
           </CloseModalContainer>
           <BlurContainer />

--- a/src/navigation/wallet-connect/constants/abis/abi-invoice.ts
+++ b/src/navigation/wallet-connect/constants/abis/abi-invoice.ts
@@ -1,0 +1,278 @@
+export const InvoiceAbi = [
+    {
+      constant: true,
+      inputs: [],
+      name: 'owner',
+      outputs: [
+        {
+          name: '',
+          type: 'address'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'quoteSigner',
+      outputs: [
+        {
+          name: '',
+          type: 'address'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [
+        {
+          name: '',
+          type: 'bytes32'
+        }
+      ],
+      name: 'isPaid',
+      outputs: [
+        {
+          name: '',
+          type: 'bool'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          name: 'valueSigner',
+          type: 'address'
+        }
+      ],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'constructor'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          name: 'hash',
+          type: 'bytes32'
+        },
+        {
+          indexed: true,
+          name: 'tokenContract',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          name: 'time',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256'
+        }
+      ],
+      name: 'PaymentAccepted',
+      type: 'event'
+    },
+    {
+      constant: true,
+      inputs: [
+        {
+          name: 'value',
+          type: 'uint256'
+        },
+        {
+          name: 'gasPrice',
+          type: 'uint256'
+        },
+        {
+          name: 'expiration',
+          type: 'uint256'
+        },
+        {
+          name: 'payload',
+          type: 'bytes32'
+        },
+        {
+          name: 'hash',
+          type: 'bytes32'
+        },
+        {
+          name: 'v',
+          type: 'uint8'
+        },
+        {
+          name: 'r',
+          type: 'bytes32'
+        },
+        {
+          name: 's',
+          type: 'bytes32'
+        },
+        {
+          name: 'tokenContract',
+          type: 'address'
+        }
+      ],
+      name: 'isValidPayment',
+      outputs: [
+        {
+          name: 'valid',
+          type: 'bool'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [
+        {
+          name: 'value',
+          type: 'uint256'
+        },
+        {
+          name: 'gasPrice',
+          type: 'uint256'
+        },
+        {
+          name: 'expiration',
+          type: 'uint256'
+        },
+        {
+          name: 'payload',
+          type: 'bytes32'
+        },
+        {
+          name: 'hash',
+          type: 'bytes32'
+        },
+        {
+          name: 'v',
+          type: 'uint8'
+        },
+        {
+          name: 'r',
+          type: 'bytes32'
+        },
+        {
+          name: 's',
+          type: 'bytes32'
+        },
+        {
+          name: 'tokenContract',
+          type: 'address'
+        }
+      ],
+      name: 'validatePayment',
+      outputs: [
+        {
+          name: 'valid',
+          type: 'bool'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        {
+          name: 'value',
+          type: 'uint256'
+        },
+        {
+          name: 'gasPrice',
+          type: 'uint256'
+        },
+        {
+          name: 'expiration',
+          type: 'uint256'
+        },
+        {
+          name: 'payload',
+          type: 'bytes32'
+        },
+        {
+          name: 'hash',
+          type: 'bytes32'
+        },
+        {
+          name: 'v',
+          type: 'uint8'
+        },
+        {
+          name: 'r',
+          type: 'bytes32'
+        },
+        {
+          name: 's',
+          type: 'bytes32'
+        },
+        {
+          name: 'tokenContract',
+          type: 'address'
+        }
+      ],
+      name: 'pay',
+      outputs: [],
+      payable: true,
+      stateMutability: 'payable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        {
+          name: 'tokenContract',
+          type: 'address'
+        }
+      ],
+      name: 'withdraw',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        {
+          name: 'newQuoteSigner',
+          type: 'address'
+        }
+      ],
+      name: 'setSigner',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        {
+          name: 'newAdmin',
+          type: 'address'
+        }
+      ],
+      name: 'setAdmin',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    }
+  ];
+  

--- a/src/navigation/wallet-connect/constants/abis/index.ts
+++ b/src/navigation/wallet-connect/constants/abis/index.ts
@@ -2,5 +2,6 @@ import {abiERC1155} from './abi-erc1155';
 import {abiERC20} from './abi-erc20';
 import {abiERC721} from './abi-erc721';
 import {abiFiatTokenV2} from './abi-fiat-tokenV2';
+import {InvoiceAbi} from './abi-invoice';
 
-export {abiERC20, abiERC721, abiERC1155, abiFiatTokenV2};
+export {abiERC20, abiERC721, abiERC1155, abiFiatTokenV2, InvoiceAbi};

--- a/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
@@ -628,7 +628,7 @@ const WalletConnectHome = () => {
           </ItemContainer>
           <Hr />
           {requestsV2 && requestsV2.length > 0 ? (
-            <Info style={{minHeight: 80, marginTop: 10}}>
+            <Info style={{minHeight: 80, marginTop: 20, marginBottom: 20}}>
               <InfoDescription>
                 {t(
                   'Complete or clear pending requests to allow new ones to come in',

--- a/src/store/wallet-connect-v2/wallet-connect-v2.effects.ts
+++ b/src/store/wallet-connect-v2/wallet-connect-v2.effects.ts
@@ -39,7 +39,7 @@ import {
   checkEncryptPassword,
   findWalletByAddress,
 } from '../wallet/utils/wallet';
-import {WrongPasswordError} from '../../navigation/wallet/components/ErrorMessages';
+import {CustomErrorMessage, WrongPasswordError} from '../../navigation/wallet/components/ErrorMessages';
 import {
   WCV2RequestType,
   WCV2SessionType,
@@ -55,6 +55,8 @@ import {sessionProposal} from './wallet-connect-v2.actions';
 import {buildApprovedNamespaces} from '@walletconnect/utils';
 import {getFeeLevelsUsingBwcClient} from '../wallet/effects/fee/fee';
 import {AppActions} from '../app';
+import { t } from 'i18next';
+import { BottomNotificationConfig } from '../../components/modal/bottom-notification/BottomNotification';
 
 const BWC = BwcProvider.getInstance();
 
@@ -272,7 +274,11 @@ export const walletConnectV2SubscribeToEvents =
       });
 
       try {
-        await emitSessionEvents(event, eip155ChainId);
+        if (EIP155_CHAINS[eip155ChainId as TEIP155Chain]) {
+          await emitSessionEvents(event, eip155ChainId);
+        } else {
+          throw new Error(`The requested chain (${eip155ChainId}) is not supported.`);
+        }
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
         dispatch(
@@ -280,6 +286,11 @@ export const walletConnectV2SubscribeToEvents =
             `[WC-V2/handleAutoApproval]: an error occurred while emiting session event: ${errMsg}`,
           ),
         );
+        const bottomNotificationConfig: BottomNotificationConfig = CustomErrorMessage({
+          errMsg: `An error occurred while emiting session event: ${errMsg}`,
+          title: t('Uh oh, something went wrong'),
+        });
+        dispatch(showBottomNotificationModal(bottomNotificationConfig));
       }
     };
 

--- a/src/store/wallet-connect-v2/wallet-connect-v2.effects.ts
+++ b/src/store/wallet-connect-v2/wallet-connect-v2.effects.ts
@@ -443,12 +443,14 @@ export const walletConnectV2SubscribeToEvents =
   };
 
 export const walletConnectV2ApproveCallRequest =
-  (request: WCV2RequestType, wallet: Wallet): Effect<Promise<void>> =>
+  (request: WCV2RequestType, wallet: Wallet, response?: JsonRpcResult<string>): Effect<Promise<void>> =>
   dispatch => {
     return new Promise(async (resolve, reject) => {
       const {topic, id} = request;
       try {
-        const response = await dispatch(approveEIP155Request(request, wallet));
+        if (!response) {
+          response = await dispatch(approveEIP155Request(request, wallet));
+        }
         await web3wallet.respondSessionRequest({
           topic,
           response,
@@ -725,6 +727,7 @@ const approveEIP155Request =
             delete types.EIP712Domain;
             const signedData = await signer._signTypedData(domain, types, data);
             resolve(formatJsonRpcResult(id, signedData));
+          // deprecated - using bws for sending transaction
           case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION:
             const provider = new providers.JsonRpcProvider(
               EIP155_CHAINS[chainId as TEIP155Chain].rpc,

--- a/src/store/wallet/effects/amount/amount.ts
+++ b/src/store/wallet/effects/amount/amount.ts
@@ -85,7 +85,7 @@ const countDecimals = (num: number): number => {
   }
   // count decimals for number in representation like "0.123456"
   if (Math.floor(num) !== num) {
-    return num.toString().split('.')[1].length || 0;
+    return num.toString().split('.')?.[1]?.length || 0;
   }
   return 0;
 };

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -62,7 +62,7 @@ import {
   GeneralError,
   WrongPasswordError,
 } from '../../../../navigation/wallet/components/ErrorMessages';
-import {BWCErrorName, getErrorName} from '../../../../constants/BWCError';
+import {BWCErrorMessage, BWCErrorName, getErrorName} from '../../../../constants/BWCError';
 import {Invoice} from '../../../shop/shop.models';
 import {GetPayProDetails, HandlePayPro, PayProOptions} from '../paypro/paypro';
 import {
@@ -2033,7 +2033,7 @@ const processInsufficientFunds = async (
   }
 };
 
-const handleDefaultError = (
+const processInsufficientFundsForFee = (
   proposalErrorProps: ProposalErrorHandlerProps,
   dispatch: any,
   onDismiss?: () => void,
@@ -2148,9 +2148,18 @@ export const handleCreateTxProposalError =
             dispatch,
             onDismiss,
           );
-
+        case BWCErrorName.INSUFFICIENT_FUNDS_FOR_FEE:
+        case BWCErrorName.INSUFFICIENT_ETH_FEE:
+        case BWCErrorName.INSUFFICIENT_MATIC_FEE:
+        case BWCErrorName.INSUFFICIENT_ARB_FEE:
+        case BWCErrorName.INSUFFICIENT_OP_FEE:
+        case BWCErrorName.INSUFFICIENT_BASE_FEE:
+          return processInsufficientFundsForFee(proposalErrorProps, dispatch, onDismiss, errorName, context);
         default:
-          return handleDefaultError(proposalErrorProps, dispatch, onDismiss, errorName, context);
+          return CustomErrorMessage({
+            errMsg: BWCErrorMessage(err),
+            title: t('Uh oh, something went wrong'),
+          })
       }
     } catch (err2) {
       return GeneralError();

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -6,6 +6,7 @@ import {Invoice} from '../shop/shop.models';
 import {Network} from '../../constants';
 import {FeeLevels} from './effects/fee/fee';
 import {TxActions} from './effects/transactions/transactions';
+import { WCV2RequestType } from '../wallet-connect-v2/wallet-connect-v2.models';
 
 /**
  * Currently supported hardware wallet sources.
@@ -251,9 +252,9 @@ export type TransactionOptionsContext =
 
 export interface TransactionOptions {
   wallet: Wallet;
-  invoice?: Invoice;
   recipient: Recipient;
   amount: number;
+  invoice?: Invoice;
   context?: TransactionOptionsContext;
   currency?: string;
   chain?: string;
@@ -293,6 +294,8 @@ export interface TransactionOptions {
   inputs?: Utxo[];
   // multisend
   recipientList?: Recipient[];
+  // walletconnect
+  request?: WCV2RequestType;
 }
 
 export interface Action {


### PR DESCRIPTION
We have more control over potential errors: nonce, insufficient funds, etc. by using Bitcore
Fixes custom data information to show WC icon on sent transactions.
Fixes handling other errors than insufficient funds correctly.
Handle auto approval errors correctly.
Decode the data using invoice abi in order to be able to display amount values