### PR TITLE
Perf: only encrypt sensitive wallet store fields to improve performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "@testing-library/jest-native": "^4.0.4",
     "@testing-library/react-native": "^8.0.0",
     "@types/bitauth": "0.4.1",
+    "@types/crypto-js": "^4.2.2",
     "@types/jest": "29.4.0",
     "@types/lodash.clonedeep": "4.5.6",
     "@types/lodash.debounce": "4.0.6",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,9 +16,11 @@ import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import {encryptTransform} from 'redux-persist-transform-encrypt'; // https://github.com/maxdeviant/redux-persist-transform-encrypt
 import thunkMiddleware, {ThunkAction} from 'redux-thunk'; // https://github.com/reduxjs/redux-thunk
 import {Selector} from 'reselect';
-import {bindWalletKeys, transformContacts} from './transforms/transforms';
-
-import {appReducer, appReduxPersistBlackList} from './app/app.reducer';
+import {bindWalletKeys, transformContacts, encryptSpecificFields} from './transforms/transforms';
+import {
+  appReducer,
+  appReduxPersistBlackList,
+} from './app/app.reducer';
 import {
   bitPayIdReducer,
   bitPayIdReduxPersistBlackList,
@@ -216,6 +218,7 @@ const getStore = async () => {
 
         return inboundState;
       }),
+      encryptSpecificFields(secretKey),
       encryptTransform({
         secretKey,
         onError: err => {
@@ -228,7 +231,7 @@ const getStore = async () => {
             ),
           );
         },
-        unencryptedStores: ['RATE', 'SHOP_CATALOG'],
+        unencryptedStores: ['RATE', 'SHOP_CATALOG', 'WALLET'],
       }),
     ],
   };

--- a/src/store/transforms/encrypt.ts
+++ b/src/store/transforms/encrypt.ts
@@ -1,0 +1,97 @@
+import Aes from 'crypto-js/aes.js';
+import CryptoJsCore from 'crypto-js/core.js';
+
+const encryptedPrefix = 'encrypted:';
+
+export const encryptValue = (value: any, secretKey: string): string => {
+  // Skip encryption for already encrypted values
+  if (typeof value === 'string' && value.startsWith(encryptedPrefix)) {
+    return value;
+  }
+
+  try {
+    const encrypted = Aes.encrypt(String(value), secretKey).toString();
+    const result = `${encryptedPrefix}${encrypted}`;
+    return result;
+  } catch (err) {
+    return value;
+  }
+};
+
+export const decryptValue = (value: any, secretKey: string): any => {
+  // Skip decryption for non-encrypted values
+  if (typeof value !== 'string' || !value.startsWith(encryptedPrefix)) {
+    return value;
+  }
+  try {
+    const encryptedText = value.replace(encryptedPrefix, '');
+    const result = Aes.decrypt(encryptedText, secretKey).toString(
+      CryptoJsCore.enc.Utf8,
+    );
+    if (!result) {
+      throw new Error('Decrypted string is empty');
+    }
+    return result;
+  } catch (err) {
+    return value;
+  }
+};
+
+// Generic function to transform wallet store (encrypt or decrypt)
+const transformWalletStore = (
+  state: any,
+  secretKey: string,
+  transformer: (value: any, secretKey: string) => any,
+  checkCondition: (value: string) => boolean,
+): any => {
+  if (!state || !state.keys) return state;
+
+  // Create a copy of the state to maintain immutability
+  const newState = {...state};
+
+  Object.keys(state.keys).forEach(keyId => {
+    const properties = state.keys[keyId]?.properties;
+    if (!properties) return;
+
+    const fieldsToTransform = [
+      'mnemonic',
+      'mnemonicEncrypted',
+      'xPrivKey',
+      'xPrivKeyEncrypted',
+    ];
+    const updatedProperties = fieldsToTransform.reduce(
+      (latestProperties, field) => {
+        const value = properties[field];
+        if (value && typeof value === 'string' && checkCondition(value)) {
+          latestProperties[field] = transformer(value, secretKey);
+        }
+        return latestProperties;
+      },
+      {...properties},
+    );
+    newState.keys = {
+      ...newState.keys,
+      [keyId]: {
+        ...newState.keys[keyId],
+        properties: updatedProperties,
+      },
+    };
+  });
+
+  return newState;
+};
+
+export const encryptWalletStore = (state: any, secretKey: string): any => {
+  return transformWalletStore(
+    state,
+    secretKey,
+    encryptValue,
+    value => !value.startsWith(encryptedPrefix),
+  );
+};
+
+export const decryptWalletStore = (state: any, secretKey: string): any => {
+  return transformWalletStore(state, secretKey, decryptValue, value =>
+    value.startsWith(encryptedPrefix),
+  );
+};

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -12,6 +12,7 @@ import {buildWalletObj} from '../wallet/utils/wallet';
 import {ContactRowProps} from '../../components/list/ContactRow';
 import {AddLog} from '../log/log.types';
 import {LogActions} from '../log';
+import {encryptWalletStore, decryptWalletStore} from './encrypt';
 
 const BWCProvider = BwcProvider.getInstance();
 const initLogs: AddLog[] = [];
@@ -151,3 +152,26 @@ export const transformContacts = createTransform<ContactState, ContactState>(
   },
   {whitelist: ['CONTACT']},
 );
+
+export const encryptSpecificFields = (secretKey: string) => {
+  return createTransform(
+    // Encrypt specified fields on inbound (saving to storage)
+    (inboundState, key) => {
+      if (key === 'WALLET') {
+        try {
+          return encryptWalletStore(inboundState, secretKey);
+        } catch (error) {}
+      }
+      return inboundState;
+    },
+    // Decrypt specified fields on outbound (loading from storage)
+    (outboundState, key) => {
+      if (key === 'WALLET') {
+        try {
+          return decryptWalletStore(outboundState, secretKey);
+        } catch (error) {}
+      }
+      return outboundState;
+    }
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4377,6 +4377,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/crypto-js@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
 "@types/express-serve-static-core@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.0.1.tgz#3c9997ae9d00bc236e45c6374e84f2596458d9db"


### PR DESCRIPTION
Moves `WALLET` store to `unencryptedStores`, and adds a new redux-persist transform that encrypts only sensitive `WALLET` fields before persisting the `WALLET` state. This greatly reduces encryption/decryption time, which boosts overall app performance, especially on older devices.