### PR TITLE
Perf: only encrypt sensitive APP and SHOP store fields to boost performance

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -231,7 +231,7 @@ const getStore = async () => {
             ),
           );
         },
-        unencryptedStores: ['APP', 'RATE', 'SHOP_CATALOG', 'WALLET'],
+        unencryptedStores: ['APP', 'RATE', 'SHOP', 'SHOP_CATALOG', 'WALLET'],
       }),
     ],
   };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -231,7 +231,7 @@ const getStore = async () => {
             ),
           );
         },
-        unencryptedStores: ['RATE', 'SHOP_CATALOG', 'WALLET'],
+        unencryptedStores: ['APP', 'RATE', 'SHOP_CATALOG', 'WALLET'],
       }),
     ],
   };

--- a/src/store/shop/shop.effects.ts
+++ b/src/store/shop/shop.effects.ts
@@ -217,7 +217,6 @@ export const startCreateGiftCardInvoice =
         invoiceId: cardOrder.invoiceId,
         name: params.brand,
         totalDiscount: cardOrder.totalDiscount,
-        invoice: invoice,
         status: 'UNREDEEMED',
         ...(user && user.eid && {userEid: user.eid}),
       } as UnsoldGiftCard;

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -12,7 +12,7 @@ import {buildWalletObj} from '../wallet/utils/wallet';
 import {ContactRowProps} from '../../components/list/ContactRow';
 import {AddLog} from '../log/log.types';
 import {LogActions} from '../log';
-import {encryptWalletStore, decryptWalletStore} from './encrypt';
+import {encryptWalletStore, decryptWalletStore, encryptAppStore, decryptAppStore} from './encrypt';
 
 const BWCProvider = BwcProvider.getInstance();
 const initLogs: AddLog[] = [];
@@ -162,6 +162,11 @@ export const encryptSpecificFields = (secretKey: string) => {
           return encryptWalletStore(inboundState, secretKey);
         } catch (error) {}
       }
+      if (key === 'APP') {
+        try {
+          return encryptAppStore(inboundState, secretKey);
+        } catch (error) {}
+      }
       return inboundState;
     },
     // Decrypt specified fields on outbound (loading from storage)
@@ -169,6 +174,11 @@ export const encryptSpecificFields = (secretKey: string) => {
       if (key === 'WALLET') {
         try {
           return decryptWalletStore(outboundState, secretKey);
+        } catch (error) {}
+      }
+      if (key === 'APP') {
+        try {
+          return decryptAppStore(outboundState, secretKey);
         } catch (error) {}
       }
       return outboundState;

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -12,7 +12,14 @@ import {buildWalletObj} from '../wallet/utils/wallet';
 import {ContactRowProps} from '../../components/list/ContactRow';
 import {AddLog} from '../log/log.types';
 import {LogActions} from '../log';
-import {encryptWalletStore, decryptWalletStore, encryptAppStore, decryptAppStore} from './encrypt';
+import {
+  encryptAppStore,
+  decryptAppStore,
+  encryptShopStore,
+  decryptShopStore,
+  encryptWalletStore,
+  decryptWalletStore,
+} from './encrypt';
 
 const BWCProvider = BwcProvider.getInstance();
 const initLogs: AddLog[] = [];
@@ -167,6 +174,11 @@ export const encryptSpecificFields = (secretKey: string) => {
           return encryptAppStore(inboundState, secretKey);
         } catch (error) {}
       }
+      if (key === 'SHOP') {
+        try {
+          return encryptShopStore(inboundState, secretKey);
+        } catch (error) {}
+      }
       return inboundState;
     },
     // Decrypt specified fields on outbound (loading from storage)
@@ -181,7 +193,12 @@ export const encryptSpecificFields = (secretKey: string) => {
           return decryptAppStore(outboundState, secretKey);
         } catch (error) {}
       }
+      if (key === 'SHOP') {
+        try {
+          return decryptShopStore(outboundState, secretKey);
+        } catch (error) {}
+      }
       return outboundState;
-    }
+    },
   );
 };


### PR DESCRIPTION
Moves `APP` and `SHOP` stores to `unencryptedStores` and updates the `encryptSpecificFields` transform to only encrypt `APP.identity.priv` and sensitive `SHOP` store fields to reduce encryption/decryption time. Also ensures that gift card invoice objects are never persisted to the store as they are not used anywhere in the current codebase.