### PR TITLE
Fix: checks for price charts and fiatCurrency in rate cache

### DIFF
--- a/src/store/rate/rate.actions.ts
+++ b/src/store/rate/rate.actions.ts
@@ -12,6 +12,7 @@ export const successGetRates = (payload: {
 export const successGetHistoricalRates = (payload: {
   ratesByDateRange: RatesByDateRange;
   dateRange: number;
+  fiatCode: string;
 }): RateActionType => ({
   type: RateActionTypes.SUCCESS_GET_HISTORICAL_RATES,
   payload,

--- a/src/store/rate/rate.reducer.ts
+++ b/src/store/rate/rate.reducer.ts
@@ -12,6 +12,7 @@ export interface RateState {
   balanceCacheKey: {[key in string]: number | undefined};
   ratesCacheKey: {[key in number]: DateRanges | undefined};
   ratesHistoricalCacheKey: {[key in number]: DateRanges | undefined};
+  cachedValuesFiatCode: string | undefined;
 }
 
 const initialState: RateState = {
@@ -25,6 +26,7 @@ const initialState: RateState = {
   balanceCacheKey: {},
   ratesCacheKey: {},
   ratesHistoricalCacheKey: {},
+  cachedValuesFiatCode: undefined,
 };
 
 export const rateReducer = (
@@ -46,7 +48,11 @@ export const rateReducer = (
     }
 
     case RateActionTypes.SUCCESS_GET_HISTORICAL_RATES: {
-      const {ratesByDateRange, dateRange = DEFAULT_DATE_RANGE} = action.payload;
+      const {
+        ratesByDateRange,
+        dateRange = DEFAULT_DATE_RANGE,
+        fiatCode,
+      } = action.payload;
       return {
         ...state,
         ratesByDateRange: {
@@ -57,6 +63,7 @@ export const rateReducer = (
           ...state.ratesHistoricalCacheKey,
           [dateRange]: Date.now(),
         },
+        cachedValuesFiatCode: fiatCode,
       };
     }
 

--- a/src/store/rate/rate.types.ts
+++ b/src/store/rate/rate.types.ts
@@ -22,6 +22,7 @@ interface successGetHistoricalRates {
   payload: {
     ratesByDateRange?: RatesByDateRange;
     dateRange?: DateRanges;
+    fiatCode?: string;
   };
 }
 

--- a/src/store/wallet/effects/rates/rates.ts
+++ b/src/store/wallet/effects/rates/rates.ts
@@ -332,7 +332,11 @@ export const fetchHistoricalRates =
   async (dispatch, getState) => {
     return new Promise(async (resolve, reject) => {
       const {
-        RATE: {ratesHistoricalCacheKey, ratesByDateRange: cachedRates},
+        RATE: {
+          ratesHistoricalCacheKey,
+          ratesByDateRange: cachedRates,
+          cachedValuesFiatCode,
+        },
       } = getState();
 
       const cachedRatesByCoin =
@@ -345,9 +349,14 @@ export const fetchHistoricalRates =
           ratesHistoricalCacheKey[dateRange],
           HISTORIC_RATES_CACHE_DURATION,
         ) &&
-        cachedRatesByCoin.length > 0
+        cachedRatesByCoin.length > 0 &&
+        cachedValuesFiatCode?.toUpperCase() === fiatIsoCode?.toUpperCase()
       ) {
-        dispatch(LogActions.info('[rates]: using cached rates'));
+        dispatch(
+          LogActions.info(
+            `[rates]: using cached rates. currencyAbbreviation: ${currencyAbbreviation} | fiatIsoCode: ${fiatIsoCode}`,
+          ),
+        );
         return resolve(cachedRatesByCoin);
       }
 
@@ -368,7 +377,11 @@ export const fetchHistoricalRates =
         const url = `${BASE_BWS_URL}/v2/fiatrates/${fiatIsoCode}?ts=${firstDateTs}`;
         const {data: rates} = await axios.get(url);
         dispatch(
-          successGetHistoricalRates({ratesByDateRange: rates, dateRange}),
+          successGetHistoricalRates({
+            ratesByDateRange: rates,
+            dateRange,
+            fiatCode: fiatIsoCode,
+          }),
         );
         dispatch(
           LogActions.info('[rates]: fetched historical rates successfully'),


### PR DESCRIPTION
This PR should also correct an inconsistency between the chart and the selected fiat currency.
Without this fix, if you change the fiat currency in settings and go to the charts before the cached time expires, it will display the current value correctly but the chart of the previously selected fiat currency.

![iPhone_15_Pro](https://github.com/user-attachments/assets/a6e1e243-4503-4aa4-a780-ab971d7828a9)


