### PR TITLE
Fix: WalletConnect screens to simplify modals and remove unused code

### DIFF
--- a/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
+++ b/src/components/modal/wallet-connect/WalletConnectStartModal.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import styled from 'styled-components/native';
 import Button, {ButtonState} from '../../button/Button';
 import {H6, H3, BaseText, Paragraph, Link, H7} from '../../styled/Text';
@@ -70,7 +70,6 @@ import AccountWCV2RowModal from './AccountWCV2RowModal';
 import WCErrorBottomNotification from './WCErrorBottomNotification';
 import WarningBrownSvg from '../../../../assets/img/warning-brown.svg';
 import {getNavigationTabName, RootStacks} from '../../../Root';
-import {SettingsScreens} from '../../../navigation/tabs/settings/SettingsGroup';
 import {SvgProps} from 'react-native-svg';
 
 export type WalletConnectStartParamList = {
@@ -297,14 +296,11 @@ export const WalletConnectStartModal = () => {
       dispatch(Analytics.track('WalletConnect Session Request Approved', {}));
       navigation.dispatch(
         CommonActions.reset({
-          index: 2,
+          index: 1,
           routes: [
             {
               name: RootStacks.TABS,
               params: {screen: getNavigationTabName()},
-            },
-            {
-              name: SettingsScreens.SETTINGS_HOME,
             },
             {
               name: WalletConnectScreens.WC_CONNECTIONS,

--- a/src/navigation/wallet-connect/screens/WalletConnectConfirm.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectConfirm.tsx
@@ -266,10 +266,7 @@ const WalletConnectConfirm = () => {
   const rejectCallRequest = useCallback(async () => {
     haptic('impactLight');
     try {
-      dispatch(startOnGoingProcessModal('REJECTING_CALL_REQUEST'));
       await dispatch(walletConnectV2RejectCallRequest(request));
-      dispatch(dismissOnGoingProcessModal());
-      await sleep(1000);
       navigation.goBack();
     } catch (err) {
       dispatch(dismissOnGoingProcessModal());
@@ -350,12 +347,10 @@ const WalletConnectConfirm = () => {
           {
             text: t('DELETE'),
             action: async () => {
+              dispatch(dismissBottomNotificationModal());
+              await sleep(600);
               try {
                 if (sessionV2) {
-                  dispatch(dismissBottomNotificationModal());
-                  await sleep(600);
-                  dispatch(startOnGoingProcessModal('LOADING'));
-                  await sleep(600);
                   await dispatch(
                     walletConnectV2OnUpdateSession({
                       session: sessionV2,
@@ -363,13 +358,9 @@ const WalletConnectConfirm = () => {
                       action: 'disconnect',
                     }),
                   );
-                  dispatch(dismissOnGoingProcessModal());
-                  await sleep(600);
                   setAccountDisconnected(true);
                 }
               } catch (err) {
-                dispatch(dismissOnGoingProcessModal());
-                await sleep(500);
                 await showErrorMessage(
                   CustomErrorMessage({
                     errMsg: BWCErrorMessage(err),

--- a/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectConnections.tsx
@@ -28,10 +28,8 @@ import FastImage from 'react-native-fast-image';
 import haptic from '../../../components/haptic-feedback/haptic';
 import {
   dismissBottomNotificationModal,
-  dismissOnGoingProcessModal,
   showBottomNotificationModal,
 } from '../../../store/app/app.actions';
-import {startOnGoingProcessModal} from '../../../store/app/app.effects';
 import {sleep} from '../../../utils/helper-methods';
 import {BottomNotificationConfig} from '../../../components/modal/bottom-notification/BottomNotification';
 import {CustomErrorMessage} from '../../wallet/components/ErrorMessages';
@@ -50,13 +48,10 @@ import {
   CtaContainerAbsolute,
   Info,
   InfoImageContainer,
-  InfoTriangle,
   SearchRoundContainer,
   SearchRoundInput,
   SheetContainer,
-  WIDTH,
 } from '../../../components/styled/Containers';
-import BoxInput from '../../../components/form/BoxInput';
 import SearchSvg from '../../../../assets/img/search.svg';
 import {buildAccountList} from '../../../store/wallet/utils/wallet';
 import {AccountRowProps} from '../../../components/list/AccountListRow';
@@ -78,14 +73,6 @@ const EmptyListContainer = styled.View`
   justify-content: space-between;
   align-items: center;
   margin-top: 50px;
-`;
-
-const horizontalPadding = 20;
-
-const SearchBox = styled(BoxInput)`
-  width: ${WIDTH - horizontalPadding * 2}px;
-  font-size: 16px;
-  position: relative;
 `;
 
 const AccountSettingsContainer = styled(TouchableOpacity)`
@@ -332,21 +319,16 @@ const WalletConnectConnections = () => {
           {
             text: t('DELETE'),
             action: async () => {
+              dispatch(dismissBottomNotificationModal());
+              await sleep(600);
               try {
-                dispatch(dismissBottomNotificationModal());
-                await sleep(600);
-                dispatch(startOnGoingProcessModal('LOADING'));
-                await sleep(600);
                 await dispatch(
                   walletConnectV2OnDeleteSession(
                     session.topic,
                     session.pairingTopic,
                   ),
                 );
-                dispatch(dismissOnGoingProcessModal());
               } catch (err) {
-                dispatch(dismissOnGoingProcessModal());
-                await sleep(500);
                 await showErrorMessage(
                   CustomErrorMessage({
                     errMsg: BWCErrorMessage(err),
@@ -378,11 +360,9 @@ const WalletConnectConnections = () => {
           {
             text: t('DELETE'),
             action: async () => {
+              dispatch(dismissBottomNotificationModal());
+              await sleep(600);
               try {
-                dispatch(dismissBottomNotificationModal());
-                await sleep(600);
-                dispatch(startOnGoingProcessModal('LOADING'));
-                await sleep(600);
                 for (const session of sessions) {
                   await dispatch(
                     walletConnectV2OnDeleteSession(
@@ -391,10 +371,7 @@ const WalletConnectConnections = () => {
                     ),
                   );
                 }
-                dispatch(dismissOnGoingProcessModal());
               } catch (err) {
-                dispatch(dismissOnGoingProcessModal());
-                await sleep(500);
                 await showErrorMessage(
                   CustomErrorMessage({
                     errMsg: BWCErrorMessage(err),
@@ -469,16 +446,7 @@ const WalletConnectConnections = () => {
         </View>
       </ScrollView>
       {sessions.length > 0 ? (
-        <CtaContainerAbsolute
-          background={true}
-          style={{
-            shadowColor: '#000',
-            shadowOffset: {width: 0, height: 4},
-            shadowOpacity: 0.1,
-            shadowRadius: 12,
-            elevation: 5,
-            bottom: 20,
-          }}>
+        <CtaContainerAbsolute background={true}>
           <Button
             buttonStyle="danger"
             buttonOutline={true}
@@ -493,6 +461,7 @@ const WalletConnectConnections = () => {
 
       {selectedSession ? (
         <SheetModal
+          modalLibrary={'modal'}
           isVisible={showSessionOptions}
           onBackdropPress={() => {
             setShowSessionOptions(false);

--- a/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
+++ b/src/navigation/wallet-connect/screens/WalletConnectHome.tsx
@@ -24,7 +24,6 @@ import {
   CurrencyImageContainer,
   Hr,
   Info,
-  InfoTriangle,
   Row,
   RowContainer,
 } from '../../../components/styled/Containers';
@@ -33,9 +32,10 @@ import {
   IconContainer,
   ItemContainer,
   ItemTitleContainer,
+  ScrollView,
   WalletConnectContainer,
 } from '../styled/WalletConnectContainers';
-import {FlatList, Platform, View} from 'react-native';
+import {FlatList, Platform} from 'react-native';
 import FastImage from 'react-native-fast-image';
 import {sleep} from '../../../utils/helper-methods';
 import haptic from '../../../components/haptic-feedback/haptic';
@@ -48,7 +48,6 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import CopiedSvg from '../../../../assets/img/copied-success.svg';
 import {Wallet} from '../../../store/wallet/wallet.models';
 import {useTranslation} from 'react-i18next';
-import {startOnGoingProcessModal} from '../../../store/app/app.effects';
 import {
   getAddressFrom,
   walletConnectV2OnDeleteSession,
@@ -68,7 +67,6 @@ import Blockie from '../../../components/blockie/Blockie';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
 import Button from '../../../components/button/Button';
 import {TouchableOpacity} from '@components/base/TouchableOpacity';
-import {useTheme} from '@react-navigation/native';
 import WarningOutlineSvg from '../../../../assets/img/warning-outline.svg';
 import TrustedDomainSvg from '../../../../assets/img/trusted-domain.svg';
 import InvalidDomainSvg from '../../../../assets/img/invalid-domain.svg';
@@ -171,7 +169,6 @@ const processRequest = (request: WCV2RequestType, keys: Keys) => {
 const WalletConnectHome = () => {
   const {t} = useTranslation();
   const navigation = useNavigation();
-  const theme = useTheme();
   const dispatch = useAppDispatch();
   const {keys} = useAppSelector(({WALLET}) => WALLET);
   const [accountDisconnected, setAccountDisconnected] = useState(false);
@@ -275,7 +272,7 @@ const WalletConnectHome = () => {
     [dispatch],
   );
 
-  const disconnectAccount = async () => {
+  const disconnectAccount = useCallback(async () => {
     if (!sessionV2) {
       return;
     }
@@ -290,21 +287,16 @@ const WalletConnectHome = () => {
           {
             text: t('DELETE'),
             action: async () => {
+              dispatch(dismissBottomNotificationModal());
+              await sleep(600);
               try {
-                dispatch(dismissBottomNotificationModal());
-                await sleep(600);
-                dispatch(startOnGoingProcessModal('LOADING'));
-                await sleep(600);
                 await dispatch(
                   walletConnectV2OnDeleteSession(
                     sessionV2.topic,
                     sessionV2.pairingTopic,
                   ),
                 );
-                dispatch(dismissOnGoingProcessModal());
               } catch (err) {
-                dispatch(dismissOnGoingProcessModal());
-                await sleep(500);
                 await showErrorMessage(
                   CustomErrorMessage({
                     errMsg: BWCErrorMessage(err),
@@ -322,7 +314,7 @@ const WalletConnectHome = () => {
         ],
       }),
     );
-  };
+  }, [dispatch, sessionV2]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -558,7 +550,7 @@ const WalletConnectHome = () => {
 
   return (
     <WalletConnectContainer>
-      <View style={{marginTop: 20, padding: 16, flex: 1}}>
+      <ScrollView>
         <SummaryContainer hasRequest={requestsV2 && requestsV2.length > 0}>
           <HeaderTitle>{t('Summary')}</HeaderTitle>
           <Hr />
@@ -655,17 +647,8 @@ const WalletConnectHome = () => {
             </ItemContainer>
           )}
         </PRContainer>
-      </View>
-      <CtaContainerAbsolute
-        background={true}
-        style={{
-          shadowColor: '#000',
-          shadowOffset: {width: 0, height: 4},
-          shadowOpacity: 0.1,
-          shadowRadius: 12,
-          elevation: 5,
-          bottom: 20,
-        }}>
+      </ScrollView>
+      <CtaContainerAbsolute background={true}>
         <Button
           buttonStyle="danger"
           buttonOutline={true}


### PR DESCRIPTION
Bug fixes:

* After connected to a valid URI, goBack function causes a double title in "Settings" tab
* Removed redundant "onGoingProcess" modals, that produces a persistent "backdrop" that blocks all the screen
* Use "ScrollView" component instead fixed "View"
* Avoid the float screen effect on the WalletConnectConnection and WalletConnectHome screen caused by the "CtaContainerAbsolute".