### PR TITLE
Fix: ensure terms checkbox is pressable on all devices

### DIFF
--- a/src/navigation/onboarding/components/TermsBox.tsx
+++ b/src/navigation/onboarding/components/TermsBox.tsx
@@ -40,7 +40,7 @@ const TermsBox = ({term, emit}: Props) => {
     }
   };
   return (
-    <TermsBoxContainer activeOpacity={1.0} onPress={acknowledge}>
+    <TermsBoxContainer activeOpacity={1.0} onPressIn={acknowledge}>
       <CheckBoxContainer>
         <Checkbox checked={checked} onPress={acknowledge} />
       </CheckBoxContainer>


### PR DESCRIPTION
Temporary workaround on older android devices for a press handling issue that occurs when a pressable checkbox element group contains nested links that are themselves pressable and have their own onPress handlers, such as the `Wallet Terms of Use` link. This workaround will no longer be needed once https://github.com/bitpay/bitpay-app/pull/1712 is merged.