### PR TITLE
Fix: wallets dropdown state in account details

### DIFF
--- a/src/components/list/AssetsByChainRow.tsx
+++ b/src/components/list/AssetsByChainRow.tsx
@@ -93,6 +93,7 @@ const AssetsByChainRow = ({
     setShowChainAssets({[chain]: !showChainAssets[chain]});
     dispatch(
       setLocalAssetsDropdown({
+        ...selectedLocalAssetsDropdown,
         [accountItem.accountAddress]: {
           ...selectedLocalAssetsDropdown?.[accountItem.accountAddress],
           [chain]: !showChainAssets[chain],


### PR DESCRIPTION
This PR fixes the following UI bug:
If you drop down to show wallets for a particular chain within AccountView, and then navigate to another account and drop down there, the first account resets its state, hiding the wallets.