### PR TITLE
Fix: avoid duplicated entry when creating a new BitPay Account in Braze

### DIFF
--- a/src/lib/Braze/index.ts
+++ b/src/lib/Braze/index.ts
@@ -151,7 +151,6 @@ export const BrazeWrapper = (() => {
     userId?: string;
     attributes?: BrazeUserAttributes;
   } = {};
-  let mergingUser = false;
 
   return {
     init() {
@@ -162,9 +161,6 @@ export const BrazeWrapper = (() => {
       userId: string | undefined,
       attributes?: BrazeUserAttributes | undefined,
     ) {
-      if (mergingUser) {
-        return;
-      }
       if (!lastSeenIdentity) {
         lastSeenIdentity = {};
       }
@@ -192,14 +188,6 @@ export const BrazeWrapper = (() => {
       };
     },
 
-    startMergingUser() {
-      mergingUser = true;
-    },
-
-    endMergingUser() {
-      mergingUser = false;
-    },
-
     merge(userToMerge: string, userToKeep: string) {
       return mergeUsers(userToMerge, userToKeep);
     },
@@ -210,16 +198,11 @@ export const BrazeWrapper = (() => {
 
     screen(name: string, properties: Record<string, any> = {}) {
       const screenName = `Viewed ${name} Screen`;
-
-      if (!mergingUser) {
-        Braze.logCustomEvent(screenName, properties);
-      }
+      Braze.logCustomEvent(screenName, properties);
     },
 
     track(eventName: string, properties: Record<string, any> = {}) {
-      if (!mergingUser) {
-        Braze.logCustomEvent(eventName, properties);
-      }
+      Braze.logCustomEvent(eventName, properties);
     },
   };
 })();

--- a/src/store/analytics/analytics.effects.ts
+++ b/src/store/analytics/analytics.effects.ts
@@ -32,6 +32,7 @@ const getTrackingAuthorizedByUser =
 export const Analytics = (() => {
   let _preInitQueue: Array<() => void> = [];
   let _isInitialized = false;
+  let _isMergingUser = false;
 
   const guard = (cb: () => void) => {
     if (!APP_ANALYTICS_ENABLED) {
@@ -41,6 +42,11 @@ export const Analytics = (() => {
     if (!_isInitialized) {
       // Queue up any actions that happen before we get a chance to initialize.
       _preInitQueue.push(cb);
+      return;
+    }
+
+    // If we are migrating a user, we don't want to run any analytics events.
+    if (_isMergingUser) {
       return;
     }
 
@@ -199,5 +205,25 @@ export const Analytics = (() => {
           onComplete?.();
         });
       },
+    /**
+     * Start merging user data.
+     * This is used to indicate that the user is in the process of merging accounts.
+     */
+    startMergingUser: () => {
+      _isMergingUser = true;
+    },
+    /**
+     * End merging user data.
+     * This is used to indicate that the user has finished merging accounts.
+     */
+    endMergingUser: () => {
+      _isMergingUser = false;
+    },
+    /**
+     * Check if still merging user data.
+     */
+    isMergingUser: () => {
+      return _isMergingUser;
+    },
   };
 })();

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -471,6 +471,14 @@ export const initializeBrazeContent = (): Effect => (dispatch, getState) => {
     contentCardSubscription = Braze.addListener(
       Braze.Events.CONTENT_CARDS_UPDATED,
       async (update: Braze.ContentCardsUpdatedEvent) => {
+        if (Analytics.isMergingUser()) {
+          dispatch(
+            LogActions.debug(
+              'Skipping Braze content cards update during user merge.',
+            ),
+          );
+          return;
+        }
         const contentCards = update.cards;
         const isInitializing = currentRetry < MAX_RETRIES;
 
@@ -562,6 +570,14 @@ const createBrazeEid = (): Effect<string | undefined> => dispatch => {
  * @returns void
  */
 export const requestBrazeContentRefresh = (): Effect => async dispatch => {
+  if (Analytics.isMergingUser()) {
+    dispatch(
+      LogActions.debug(
+        'Skipping Braze content refresh during user merge.',
+      ),
+    );
+    return;
+  }
   try {
     dispatch(LogActions.info('Refreshing Braze content...'));
 


### PR DESCRIPTION
* Also set "Opted-in" if selected `agreedToMarketingCommunications`
* Remove Old user.