### PR TITLE
[FIX] remove SOL from custom fee options

### DIFF
--- a/src/navigation/tabs/settings/NetworkFeePolicy/screens/NewtorkFeePolicy.tsx
+++ b/src/navigation/tabs/settings/NetworkFeePolicy/screens/NewtorkFeePolicy.tsx
@@ -81,7 +81,7 @@ const FeeOptions = ({
   chainName,
 }: {
   feeOptions: any[];
-  chain: 'btc' | 'eth' | 'matic' | 'arb' | 'base' | 'op' | 'sol';
+  chain: 'btc' | 'eth' | 'matic' | 'arb' | 'base' | 'op';
   chainName: string;
 }) => {
   const dispatch = useAppDispatch();
@@ -202,7 +202,6 @@ const NetworkFeePolicy = () => {
   const [arbFeeOptions, setArbFeeOptions] = useState<any[]>();
   const [baseFeeOptions, setBaseFeeOptions] = useState<any[]>();
   const [opFeeOptions, setOpFeeOptions] = useState<any[]>();
-  const [solFeeOptions, setSolFeeOptions] = useState<any[]>();
   const [btcFeeOptions, setBtcFeeOptions] = useState<any[]>();
   const [isLoading, setIsLoading] = useState(true);
 
@@ -263,15 +262,13 @@ const NetworkFeePolicy = () => {
         setBaseFeeOptions(feeOptions);
       } else if (currencyAbbreviation === 'op') {
         setOpFeeOptions(feeOptions);
-      } else if (currencyAbbreviation === 'sol') {
-        setSolFeeOptions(feeOptions);
       }
     } catch (e) {
       return;
     }
   };
   const init = async () => {
-    ['btc', 'eth', 'matic', 'arb', 'base', 'op', 'sol'].forEach((ca: string) =>
+    ['btc', 'eth', 'matic', 'arb', 'base', 'op'].forEach((ca: string) =>
       initFeeLevel(ca, ca),
     );
     await sleep(500);
@@ -351,16 +348,6 @@ const NetworkFeePolicy = () => {
                   feeOptions={opFeeOptions}
                   chain={'op'}
                   chainName={'Optimism'}
-                />
-              ) : null}
-            </View>
-
-            <View>
-              {solFeeOptions && solFeeOptions.length > 0 ? (
-                <FeeOptions
-                  feeOptions={solFeeOptions}
-                  chain={'sol'}
-                  chainName={'Solana'}
                 />
               ) : null}
             </View>

--- a/src/navigation/wallet/screens/send/confirm/Confirm.tsx
+++ b/src/navigation/wallet/screens/send/confirm/Confirm.tsx
@@ -294,7 +294,7 @@ const Confirm = () => {
   }, []);
 
   const isTxLevelAvailable = () => {
-    const includedChains = ['btc', 'eth', 'matic', 'arb', 'base', 'op', 'sol'];
+    const includedChains = ['btc', 'eth', 'matic', 'arb', 'base', 'op'];
     // TODO: exclude paypro, coinbase, usingMerchantFee txs,
     // const {payProUrl} = txDetails;
     return includedChains.includes(chain.toLowerCase());


### PR DESCRIPTION
Solana only supports "low" level fee.
`https://api-sol.bitcore.io/api/SOL/mainnet/fee/1 == https://api-sol.bitcore.io/api/SOL/mainnet/fee/4. `