### PR TITLE
Fix: misc invoice payment bugs

### DIFF
--- a/src/store/scan/scan.effects.ts
+++ b/src/store/scan/scan.effects.ts
@@ -379,13 +379,19 @@ const handleUnlock =
         if (context === 'u') {
           const {
             invoice: {
+              buyerEmailAddress,
               buyerProvidedInfo: {emailAddress},
               buyerProvidedEmail,
               status,
             },
           } = invoice;
 
-          if (emailAddress || buyerProvidedEmail || status !== 'new') {
+          if (
+            emailAddress ||
+            buyerProvidedEmail ||
+            buyerEmailAddress ||
+            status !== 'new'
+          ) {
             dispatch(goToPayPro(data, undefined, undefined, wallet));
           } else {
             navigationRef.navigate('EnterBuyerProvidedEmail', {data});

--- a/src/store/wallet/utils/validations.ts
+++ b/src/store/wallet/utils/validations.ts
@@ -528,22 +528,23 @@ export const ValidateCoinAddress = (
 ) => {
   const extractAddress = (data: string) => {
     const prefix = /^[a-z]+:/i;
-    const params = /([\?\&](value|gas|gasPrice|gasLimit)=(\d+([\,\.]\d+)?))+/i;
+    const params =
+      /([\?\&](amount|gas|gasLimit|gasPrice|value)=(\d+([\,\.]\d+)?))+/i;
     return data.replace(prefix, '').replace(params, '');
   };
   switch (coin) {
     case 'btc':
       const address = BWC.getBitcore().Address;
-      return !!address.isValid(str, network);
+      return !!address.isValid(extractAddress(str), network);
     case 'bch':
       const addressCash = BWC.getBitcoreCash().Address;
-      return !!addressCash.isValid(str, network);
+      return !!addressCash.isValid(extractAddress(str), network);
     case 'doge':
       const addressDoge = BWC.getBitcoreDoge().Address;
-      return !!addressDoge.isValid(str, network);
+      return !!addressDoge.isValid(extractAddress(str), network);
     case 'ltc':
       const addressLtc = BWC.getBitcoreLtc().Address;
-      return !!addressLtc.isValid(str, network);
+      return !!addressLtc.isValid(extractAddress(str), network);
     case 'eth':
     case 'xrp':
     case 'matic':


### PR DESCRIPTION
This PR fixes the following issues:

1. When scanning an invoice that has a `buyerEmailAddress` set, the user will now skip the "Enter Email" screen and go directly to the confirm screen.
2. Scanning or pasting a BIP21 URI from within a wallet will no longer result in a currency/network mismatch error.