### PR TITLE
Fix: use custom header in CustomizeHome.tsx when navigating from the home tab

### DIFF
--- a/src/navigation/tabs/home/components/Crypto.tsx
+++ b/src/navigation/tabs/home/components/Crypto.tsx
@@ -378,7 +378,10 @@ const Crypto = () => {
               activeOpacity={ActiveOpacity}
               onPress={() => {
                 haptic('soft');
-                navigation.navigate('CustomizeHomeSettings');
+                // Apply SettingsDetails config so that the custom header is used
+                navigation.navigate('SettingsDetails', {
+                  initialRoute: 'Customize Home',
+                } as any);
               }}>
               <CustomizeSvg width={37} height={37} />
             </TouchableOpacity>


### PR DESCRIPTION
Prevents the custom back button from being wrapped in a native back button on iOS 26