### PR TITLE
[FIX] force token creation when push notification enabled

### DIFF
--- a/src/navigation/tabs/settings/components/Notifications.tsx
+++ b/src/navigation/tabs/settings/components/Notifications.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useCallback} from 'react';
-import {Alert, Linking, LogBox, DeviceEventEmitter} from 'react-native';
+import {Alert, Linking, DeviceEventEmitter} from 'react-native';
 import {AppEffects} from '../../../../store/app';
 import {
   ActiveOpacity,
@@ -11,14 +11,12 @@ import AngleRight from '../../../../../assets/img/angle-right.svg';
 import {SettingsComponent} from '../SettingsRoot';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from '@react-navigation/native';
-import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
-import {selectSettingsNotificationState} from '../../../../store/app/app.selectors';
+import {useAppDispatch} from '../../../../utils/hooks';
 import {DeviceEmitterEvents} from '../../../../constants/device-emitter-events';
 
 const Notifications = () => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
-  const notificationsState = useAppSelector(selectSettingsNotificationState);
   const navigation = useNavigation();
 
   const openSettings = useCallback(() => {
@@ -73,18 +71,6 @@ const Notifications = () => {
     );
     return () => subscription.remove();
   }, [setNotificationValue]);
-
-  // Ignore warning: Setting a timer for long period of time...
-  LogBox.ignoreLogs(['Setting a timer']);
-  useEffect(() => {
-    if (notificationsState && notificationsState.pushNotifications) {
-      // Subscribe for silent push notifications
-      const silentPushInterval = setInterval(() => {
-        dispatch(AppEffects.renewSubscription());
-      }, 3 * 60 * 1000); // 3 min
-      return () => clearInterval(silentPushInterval);
-    }
-  }, [dispatch, notificationsState]);
 
   return (
     <SettingsComponent>

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -860,7 +860,14 @@ export const unSubscribeEmailNotifications =
 
 export const checkNotificationsPermissions = async (): Promise<boolean> => {
   const {status} = await checkNotifications().catch(() => ({status: null}));
-  return status?.toLowerCase() === RESULTS.GRANTED;
+
+  const normalized = status?.toLowerCase?.();
+  const granted =
+    normalized === RESULTS.GRANTED || normalized === RESULTS.LIMITED;
+  if (granted) {
+    Braze.requestPushPermission();
+  }
+  return granted;
 };
 
 export const renewSubscription = (): Effect => (dispatch, getState) => {


### PR DESCRIPTION
- Moved `AppEffects.renewSubscription` to `Root.tsx`, since it never ran from `Notifications.tsx`.
- Trigger subscription renewal on the app’s first run to ensure BWS can fetch subscriptions and broadcast silent push notifications to active users. ( check: https://github.com/bitpay/bitcore/blob/master/packages/bitcore-wallet-service/src/lib/pushnotificationsservice.ts#L627 )
- Added a call to `Braze.requestPushPermission` so the device’s Braze token is refreshed. Previously, new tokens were not being saved.