### PR TITLE
[REF] improve export tx history performance

### DIFF
--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -396,12 +396,6 @@ const ProcessNewTxs =
         if (!txHistoryUnique[`${tx.txid}-${tx.coin}`]) {
           ret.push(tx);
           txHistoryUnique[`${tx.txid}-${tx.coin}`] = true;
-        } else {
-          dispatch(
-            LogActions.info(
-              `Ignoring duplicate TX in history: ${tx.txid}-${tx.coin}`,
-            ),
-          );
         }
       } catch (e) {
         const error = e instanceof Error ? e.message : JSON.stringify(e);


### PR DESCRIPTION
- replace ongoingProcess with button state handling
- ensure that the full history is fetched for the CSV export.
- remove the destination address from the CSV, since most transactions have multiple outputs and it makes no sense to show only the first one. I keep the Tag: `Destination`. But now I show: Sent / Received 
- I removed a log that provided little information and slowed down performance.
- skip the TXProcess since it's not needed for the CSV in particular, and it slowed down performance.