### PR TITLE
AppsFlyer: Fix - Prevent unhandled exceptions and SDK calls when not initialized

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -30,6 +30,12 @@ export const STATIC_CONTENT_CARDS_ENABLED = parseEnvBoolean(
 );
 export const APP_ANALYTICS_ENABLED = !__DEV__;
 
+// AppsFlyer hosts to resolve deep links for.
+export const RESOLVED_DEEP_LINK_HOSTS = [
+  'clicks.bitpay.com',
+  'email.bitpay.com',
+];
+
 // GENERAL
 export const APP_NAME = 'bitpay';
 export const APP_NAME_UPPERCASE = 'BitPay';

--- a/src/store/analytics/analytics.effects.ts
+++ b/src/store/analytics/analytics.effects.ts
@@ -103,32 +103,8 @@ export const Analytics = (() => {
             logManager.debug('Failed to initialize Mixpanel SDK.', errMsg);
           });
 
-        await AppsFlyerWrapper.init()
-          .then(() => {
-            logManager.debug('Successfully initialized AppsFlyer SDK');
-            // Configure AppsFlyer to handle wrapped deeplinks
-            AppsFlyerWrapper.configureResolvedDeepLinks(
-              ['clicks.bitpay.com', 'email.bitpay.com'],
-              () => {
-                logManager.debug(
-                  'AppsFlyer SDK configured to handle wrapped deeplinks',
-                );
-              },
-              (err: any) => {
-                const errMsg =
-                  err instanceof Error ? err.message : JSON.stringify(err);
-                logManager.error(
-                  'AppsFlyer SDK failed to configure wrapped deeplinks: ' +
-                    errMsg,
-                );
-              },
-            );
-          })
-          .catch(err => {
-            const errMsg =
-              err instanceof Error ? err.message : JSON.stringify(err);
-            logManager.error('AppsFlyer SDK failed to initialize: ' + errMsg);
-          });
+        // AppsFlyer
+        await AppsFlyerWrapper.init();
       }
 
       _isInitialized = true;

--- a/src/utils/appsFlyer.ts
+++ b/src/utils/appsFlyer.ts
@@ -1,54 +1,166 @@
 import AppsFlyer from 'react-native-appsflyer';
 import {APPSFLYER_API_KEY, APPSFLYER_APP_ID} from '@env';
+import {logManager} from '../managers/LogManager';
+import {RESOLVED_DEEP_LINK_HOSTS} from '../constants/config';
+
+type AppsFlyerStatus = 'idle' | 'initializing' | 'ready' | 'failed';
+
+type EventValues = Record<string, string | number | boolean>;
 
 export const AppsFlyerWrapper = (() => {
   const devKey = APPSFLYER_API_KEY;
   const appId = APPSFLYER_APP_ID;
 
+  let status: AppsFlyerStatus = 'idle';
+  let initPromise: Promise<void> | null = null;
+  let loggedNotReadyWarning = false;
+
+  const isReady = () => status === 'ready';
+
+  const logNotReadyOnce = (methodName: string) => {
+    if (loggedNotReadyWarning) {
+      return;
+    }
+
+    loggedNotReadyWarning = true;
+    logManager.warn(
+      `[AppsFlyer] ${methodName} skipped because SDK is not ready (status=${status})`,
+    );
+  };
+
+  const resetNotReadyWarning = () => {
+    loggedNotReadyWarning = false;
+  };
+
+  const configureResolvedDeepLinks = (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      try {
+        AppsFlyer.setResolveDeepLinkURLs(
+          RESOLVED_DEEP_LINK_HOSTS,
+          () => {
+            logManager.debug('[AppsFlyer] configured wrapped deeplinks');
+            resolve();
+          },
+          (err: unknown) => {
+            const errMsg =
+              err instanceof Error ? err.message : JSON.stringify(err);
+
+            logManager.error(
+              `[AppsFlyer] failed to configure wrapped deeplinks: ${errMsg}`,
+            );
+            reject(err);
+          },
+        );
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+
+        logManager.error(`[AppsFlyer] setResolveDeepLinkURLs threw: ${errMsg}`);
+        reject(err);
+      }
+    });
+  };
+
   return {
-    /**
-     * Initialize the AppsFlyer SDK.
-     */
-    init() {
-      return AppsFlyer.initSdk({
-        devKey: devKey,
-        isDebug: !!__DEV__,
-        appId: appId,
-        onInstallConversionDataListener: true,
-        onDeepLinkListener: true, // -->  you must set the onDeepLinkListener to true to get onDeepLink callbacks
+    getStatus(): AppsFlyerStatus {
+      return status;
+    },
+
+    async init(): Promise<void> {
+      if (status === 'ready') {
+        return;
+      }
+
+      if (initPromise) {
+        return initPromise;
+      }
+
+      status = 'initializing';
+      resetNotReadyWarning();
+
+      initPromise = (async () => {
+        try {
+          await AppsFlyer.initSdk({
+            devKey,
+            isDebug: !!__DEV__,
+            appId,
+            onInstallConversionDataListener: true,
+            onDeepLinkListener: true,
+          });
+
+          try {
+            await configureResolvedDeepLinks();
+          } catch (err) {
+            const errMsg =
+              err instanceof Error ? err.message : JSON.stringify(err);
+
+            logManager.error(
+              `[AppsFlyer] configureResolvedDeepLinks failed: ${errMsg}`,
+            );
+          }
+
+          status = 'ready';
+          resetNotReadyWarning();
+          logManager.debug('[AppsFlyer] init completed successfully');
+        } catch (err) {
+          status = 'failed';
+
+          const errMsg =
+            err instanceof Error ? err.message : JSON.stringify(err);
+
+          logManager.error(`[AppsFlyer] init failed: ${errMsg}`);
+        } finally {
+          initPromise = null;
+        }
+      })();
+
+      return initPromise;
+    },
+
+    async getId(): Promise<string | undefined> {
+      if (!isReady()) {
+        logNotReadyOnce('getId');
+        return undefined;
+      }
+
+      return new Promise<string | undefined>(resolve => {
+        try {
+          AppsFlyer.getAppsFlyerUID((err, id) => {
+            if (err) {
+              const errMsg =
+                err instanceof Error ? err.message : JSON.stringify(err);
+
+              logManager.error(`[AppsFlyer] getAppsFlyerUID failed: ${errMsg}`);
+              resolve(undefined);
+              return;
+            }
+
+            resolve(id);
+          });
+        } catch (err) {
+          const errMsg =
+            err instanceof Error ? err.message : JSON.stringify(err);
+
+          logManager.error(`[AppsFlyer] getAppsFlyerUID threw: ${errMsg}`);
+          resolve(undefined);
+        }
       });
     },
 
-    /**
-     * Get AppsFlyer ID.
-     */
-    getId() {
-      return new Promise<string | undefined>(resolve =>
-        AppsFlyer.getAppsFlyerUID((err, id) => {
-          resolve(err ? undefined : id);
-        }),
-      );
-    },
+    async track(eventName: string, eventValues?: EventValues): Promise<void> {
+      if (!isReady()) {
+        logNotReadyOnce(`track(${eventName})`);
+        return;
+      }
 
-    /**
-     * Track an event.
-     */
-    track(eventName: string, eventValues?: any) {
-      return AppsFlyer.logEvent(eventName, eventValues);
-    },
+      try {
+        AppsFlyer.logEvent(eventName, eventValues ?? {});
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
 
-    /**
-     * Configure AppsFlyer to handle wrapped deeplinks
-     * @param allowedHosts - List of allowed hosts for wrapped deeplinks
-     * @param success - Callback for successful configuration
-     * @param failed - Callback for failed configuration
-     */
-    configureResolvedDeepLinks(
-      allowedHosts: string[],
-      success: () => void,
-      failed: (error: any) => void,
-    ) {
-      AppsFlyer.setResolveDeepLinkURLs(allowedHosts, success, failed);
+        logManager.error(
+          `[AppsFlyer] logEvent failed for "${eventName}": ${errMsg}`,
+        );
+      }
     },
   };
 })();


### PR DESCRIPTION
RN-2412
RN-2416

## Changes
- Remove public configureResolvedDeepLinks() from the wrapper API
- Configure wrapped deep link hosts internally during init()
- Keep AppsFlyer state handling in the wrapper to **avoid SDK calls before successful initialization**

## Notes

Wrapped deep link configuration is startup-time SDK setup, not a general runtime action. Keeping it inside init() simplifies call sites and avoids calling deep link configuration separately or when the SDK is not ready.

---
[RN-2412](https://bitpayprod.atlassian.net/browse/RN-2412)