### PR TITLE
Buy/Sell/Swap: Ref - external services prefetch data

### DIFF
--- a/src/navigation/services/components/ExternalServicesLoadingWalletSkeleton.tsx
+++ b/src/navigation/services/components/ExternalServicesLoadingWalletSkeleton.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {useTheme} from 'styled-components/native';
-import {Slate30} from '../../../../styles/colors';
+import {Slate30} from '../../../styles/colors';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import {View} from 'react-native';
 
-const SwapCryptoLoadingWalletSkeleton = () => {
+const ExternalServicesLoadingWalletSkeleton = () => {
   const theme = useTheme();
 
   return (
@@ -35,4 +35,4 @@ const SwapCryptoLoadingWalletSkeleton = () => {
   );
 };
 
-export default SwapCryptoLoadingWalletSkeleton;
+export default ExternalServicesLoadingWalletSkeleton;

--- a/src/navigation/services/components/externalServicesAmountPills.tsx
+++ b/src/navigation/services/components/externalServicesAmountPills.tsx
@@ -2,6 +2,7 @@ import React, {memo} from 'react';
 import styled from 'styled-components/native';
 import {
   Action,
+  DisabledTextDark,
   LightBlack,
   NeutralSlate,
   SlateDark,
@@ -32,13 +33,7 @@ const AmountPill = styled(TouchableOpacity)<{
   hideFiatPills?: boolean;
 }>`
   background-color: ${({theme: {dark}, isSelected, disabled}) =>
-    disabled
-      ? NeutralSlate
-      : isSelected
-      ? Action
-      : dark
-      ? LightBlack
-      : NeutralSlate};
+    isSelected ? Action : dark ? LightBlack : NeutralSlate};
   min-width: ${({showMaxPill, hideFiatPills}) =>
     showMaxPill && !hideFiatPills ? '23%' : '31%'};
   max-width: ${({showMaxPill, hideFiatPills}) =>
@@ -62,7 +57,13 @@ const AmountPillText = styled(BaseText)<{
   line-height: ${({isSmallScreen}) => (isSmallScreen ? 18 : 30)}px;
   letter-spacing: 0px;
   color: ${({theme: {dark}, isSelected, disabled}) =>
-    disabled ? SlateDark : isSelected ? White : dark ? White : SlateDark};
+    disabled
+      ? DisabledTextDark
+      : isSelected
+      ? White
+      : dark
+      ? White
+      : SlateDark};
 `;
 
 const defaultPills = [

--- a/src/navigation/services/components/externalServicesWalletSelector.tsx
+++ b/src/navigation/services/components/externalServicesWalletSelector.tsx
@@ -12,7 +12,6 @@ import {
   White,
   Black,
   Slate,
-  Slate30,
   LightBlack,
   NeutralSlate,
   SlateDark,
@@ -50,7 +49,7 @@ import {useOngoingProcess} from '../../../contexts';
 import {isTSSKey} from '../../../store/wallet/effects/tss-send/tss-send';
 import {BuyCryptoStateOpts} from '../../../store/buy-crypto/buy-crypto.reducer';
 import {HomeCarouselConfig} from '../../../store/app/app.models';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import ExternalServicesLoadingWalletSkeleton from './ExternalServicesLoadingWalletSkeleton';
 
 const GlobalSelectContainer = styled.View`
   flex: 1;
@@ -585,28 +584,7 @@ const ExternalServicesWalletSelector: React.FC<
       {loading ? (
         <WalletSelector disabled>
           <WalletSelectorLeft>
-            <SkeletonPlaceholder
-              backgroundColor={theme.dark ? '#363636' : '#FAFAFB'}
-              highlightColor={theme.dark ? '#575757' : Slate30}>
-              <View>
-                <SkeletonPlaceholder.Item
-                  flexDirection={'row'}
-                  alignItems={'center'}
-                  justifyContent={'flex-start'}>
-                  <SkeletonPlaceholder.Item
-                    width={20}
-                    height={20}
-                    borderRadius={50}
-                    marginRight={5}
-                  />
-                  <SkeletonPlaceholder.Item
-                    width={70}
-                    height={14}
-                    borderRadius={4}
-                  />
-                </SkeletonPlaceholder.Item>
-              </View>
-            </SkeletonPlaceholder>
+            <ExternalServicesLoadingWalletSkeleton />
           </WalletSelectorLeft>
         </WalletSelector>
       ) : (

--- a/src/navigation/services/components/externalServicesWalletSelector.tsx
+++ b/src/navigation/services/components/externalServicesWalletSelector.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
+import {View} from 'react-native';
 import styled, {useTheme} from 'styled-components/native';
 import {orderBy} from 'lodash';
 import {useAppDispatch, useAppSelector, useLogger} from '../../../utils/hooks';
@@ -11,6 +12,7 @@ import {
   White,
   Black,
   Slate,
+  Slate30,
   LightBlack,
   NeutralSlate,
   SlateDark,
@@ -48,6 +50,7 @@ import {useOngoingProcess} from '../../../contexts';
 import {isTSSKey} from '../../../store/wallet/effects/tss-send/tss-send';
 import {BuyCryptoStateOpts} from '../../../store/buy-crypto/buy-crypto.reducer';
 import {HomeCarouselConfig} from '../../../store/app/app.models';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 const GlobalSelectContainer = styled.View`
   flex: 1;
@@ -113,6 +116,7 @@ interface ExternalServicesWalletSelectorScreenProps {
   currencyAbbreviation?: string | undefined; // used from charts and deeplinks.
   chain?: string | undefined; // used from charts and deeplinks.
   partner?: BuyCryptoExchangeKey | undefined; // used from deeplinks.
+  loading?: boolean; // shows skeleton while initializing
 }
 
 const ExternalServicesWalletSelector: React.FC<
@@ -129,6 +133,7 @@ const ExternalServicesWalletSelector: React.FC<
   fromWallet,
   currencyAbbreviation,
   chain,
+  loading,
 }) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
@@ -189,7 +194,7 @@ const ExternalServicesWalletSelector: React.FC<
     );
 
     if (!keysList[0]) {
-      await sleep(500);
+      await sleep(300);
       walletError('emptyKeyList');
       return;
     }
@@ -208,8 +213,7 @@ const ExternalServicesWalletSelector: React.FC<
       fromWalletData = allWallets.find(wallet => wallet.id === walletIdToFind);
       if (fromWalletData) {
         setWallet(fromWalletData);
-        await sleep(500);
-        hideOngoingProcess();
+        return;
       } else {
         if (preSetWallet?.id) {
           walletError(
@@ -303,8 +307,6 @@ const ExternalServicesWalletSelector: React.FC<
 
       if (allowedWallets[0]) {
         _setSelectedWallet(allowedWallets[0]);
-        await sleep(500);
-        hideOngoingProcess();
       } else {
         if (fromCurrencyAbbreviation) {
           walletError(
@@ -580,56 +582,85 @@ const ExternalServicesWalletSelector: React.FC<
 
   return (
     <ExternalServicesWalletSelectorContainer>
-      <WalletSelector
-        style={selectedWallet ? {} : {backgroundColor: Action}}
-        onPress={() => {
-          setWalletSelectorModalVisible(true);
-        }}>
-        <WalletSelectorLeft>
-          {selectedWallet ? (
-            <>
-              <CurrencyImage
-                img={selectedWallet.img}
-                badgeUri={getBadgeImg(
-                  getCurrencyAbbreviation(
-                    selectedWallet.currencyAbbreviation,
+      {loading ? (
+        <WalletSelector disabled>
+          <WalletSelectorLeft>
+            <SkeletonPlaceholder
+              backgroundColor={theme.dark ? '#363636' : '#FAFAFB'}
+              highlightColor={theme.dark ? '#575757' : Slate30}>
+              <View>
+                <SkeletonPlaceholder.Item
+                  flexDirection={'row'}
+                  alignItems={'center'}
+                  justifyContent={'flex-start'}>
+                  <SkeletonPlaceholder.Item
+                    width={20}
+                    height={20}
+                    borderRadius={50}
+                    marginRight={5}
+                  />
+                  <SkeletonPlaceholder.Item
+                    width={70}
+                    height={14}
+                    borderRadius={4}
+                  />
+                </SkeletonPlaceholder.Item>
+              </View>
+            </SkeletonPlaceholder>
+          </WalletSelectorLeft>
+        </WalletSelector>
+      ) : (
+        <WalletSelector
+          style={selectedWallet ? {} : {backgroundColor: Action}}
+          onPress={() => {
+            setWalletSelectorModalVisible(true);
+          }}>
+          <WalletSelectorLeft>
+            {selectedWallet ? (
+              <>
+                <CurrencyImage
+                  img={selectedWallet.img}
+                  badgeUri={getBadgeImg(
+                    getCurrencyAbbreviation(
+                      selectedWallet.currencyAbbreviation,
+                      selectedWallet.chain,
+                    ),
                     selectedWallet.chain,
-                  ),
-                  selectedWallet.chain,
-                )}
-                size={20}
-              />
-              <WalletSelectorName ellipsizeMode="tail" numberOfLines={1}>
-                {selectedWallet.walletName
-                  ? selectedWallet.walletName
-                  : selectedWallet.currencyName}
+                  )}
+                  size={20}
+                />
+                <WalletSelectorName ellipsizeMode="tail" numberOfLines={1}>
+                  {selectedWallet.walletName
+                    ? selectedWallet.walletName
+                    : selectedWallet.currencyName}
+                </WalletSelectorName>
+              </>
+            ) : (
+              <WalletSelectorName
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                style={{fontWeight: '500', color: White}}>
+                {t('Choose Crypto')}
               </WalletSelectorName>
-            </>
-          ) : (
-            <WalletSelectorName
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              style={{fontWeight: '500', color: White}}>
-              {t('Choose Crypto')}
-            </WalletSelectorName>
-          )}
-        </WalletSelectorLeft>
-        <WalletSelectorRight>
-          <ArrowContainer style={{marginRight: 10}}>
-            <SelectorArrowRight
-              {...{
-                width: 5,
-                height: 9,
-                color: selectedWallet
-                  ? theme.dark
-                    ? Slate
-                    : SlateDark
-                  : White,
-              }}
-            />
-          </ArrowContainer>
-        </WalletSelectorRight>
-      </WalletSelector>
+            )}
+          </WalletSelectorLeft>
+          <WalletSelectorRight>
+            <ArrowContainer style={{marginRight: 10}}>
+              <SelectorArrowRight
+                {...{
+                  width: 5,
+                  height: 9,
+                  color: selectedWallet
+                    ? theme.dark
+                      ? Slate
+                      : SlateDark
+                    : White,
+                }}
+              />
+            </ArrowContainer>
+          </WalletSelectorRight>
+        </WalletSelector>
+      )}
 
       <SheetModal
         modalLibrary="bottom-sheet"

--- a/src/navigation/services/screens/BuyAndSellRoot.tsx
+++ b/src/navigation/services/screens/BuyAndSellRoot.tsx
@@ -62,11 +62,7 @@ import ExternalServicesAmountPills from '../components/externalServicesAmountPil
 import {AltCurrenciesRowProps} from '../../../components/list/AltCurrenciesRow';
 import {StackActions} from '@react-navigation/native';
 import ExternalServicesWalletSelector from '../components/externalServicesWalletSelector';
-import {
-  Key,
-  SendMaxInfo,
-  Wallet,
-} from '../../../store/wallet/wallet.models';
+import {Key, SendMaxInfo, Wallet} from '../../../store/wallet/wallet.models';
 import {
   BuyCryptoConfig,
   ExternalServicesConfig,

--- a/src/navigation/services/screens/BuyAndSellRoot.tsx
+++ b/src/navigation/services/screens/BuyAndSellRoot.tsx
@@ -43,7 +43,7 @@ import {
   getRateByCurrencyName,
   sleep,
 } from '../../../utils/helper-methods';
-import {useAppDispatch, useMount} from '../../../utils/hooks';
+import {useAppDispatch} from '../../../utils/hooks';
 import useAppSelector from '../../../utils/hooks/useAppSelector';
 import {useLogger} from '../../../utils/hooks/useLogger';
 import {
@@ -65,13 +65,11 @@ import ExternalServicesWalletSelector from '../components/externalServicesWallet
 import {
   Key,
   SendMaxInfo,
-  Token,
   Wallet,
 } from '../../../store/wallet/wallet.models';
 import {
   BuyCryptoConfig,
   ExternalServicesConfig,
-  ExternalServicesConfigRequestParams,
   SellCryptoConfig,
 } from '../../../store/external-services/external-services.types';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -80,7 +78,11 @@ import {
   ExternalServicesScreens,
 } from '../ExternalServicesGroup';
 import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';
-import {getExternalServicesConfig} from '../../../store/external-services/external-services.effects';
+import {
+  getExternalServicesConfig,
+  getCachedExternalServicesConfig,
+  isExternalServicesConfigCacheFresh,
+} from '../../../store/external-services/external-services.effects';
 import {AppActions} from '../../../store/app';
 import {SupportedCurrencyOptions} from '../../../constants/SupportedCurrencyOptions';
 import {ToWalletSelectorCustomCurrency} from '../../wallet/screens/GlobalSelect';
@@ -215,7 +217,7 @@ import {SellCryptoActions} from '../../../store/sell-crypto';
 import {GetProtocolPrefixAddress} from '../../../store/wallet/utils/wallet';
 import {useTheme} from 'styled-components/native';
 import Modal from 'react-native-modal';
-import {Linking, View} from 'react-native';
+import {ActivityIndicator, Linking, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import WebView, {
   WebViewMessageEvent,
@@ -281,6 +283,18 @@ const VirtualKeyboardContainer = styled.View`
 
 const Row = styled.View`
   flex-direction: row;
+`;
+
+const SpinnerContainer = styled.View<{
+  isSmallScreen?: boolean;
+  addMarginBottom?: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: ${({isSmallScreen}) => (isSmallScreen ? '50px' : '70px')};
+  margin-bottom: ${({addMarginBottom}) => (addMarginBottom ? '40px' : '0')};
 `;
 
 const AmountText = styled(BaseText)<{bigAmount?: boolean}>`
@@ -657,6 +671,7 @@ const BuyAndSellRoot = ({
   const [selectedPillValue, setSelectedPillValue] = useState<
     number | string | null
   >(null);
+  const [isInitializing, setIsInitializing] = useState<boolean>(true);
   const [selectedWallet, setSelectedWallet] = useState<Wallet | undefined>();
   const [externalServicesConfig, setExternalServicesConfig] = useState<
     ExternalServicesConfig | undefined
@@ -960,13 +975,6 @@ const BuyAndSellRoot = ({
   const initAmountRef = useRef(initAmount);
   initAmountRef.current = initAmount;
 
-  const initLimits = (): void => {
-    if (context === 'buyCrypto') {
-      setLimits(dispatch(getBuyCryptoFiatLimits(undefined, fiatCurrency)));
-    }
-    // Sell crypto limits are set when selling coin is selected (from selectedWallet)
-  };
-
   const getLogoUri = (_currencyAbbreviation: string, _chain: string) => {
     const foundToken = (
       Object.values(tokenDataByAddress) as CurrencyOpts[]
@@ -996,15 +1004,13 @@ const BuyAndSellRoot = ({
 
   const initBuyCrypto = async () => {
     try {
-      const requestData: ExternalServicesConfigRequestParams = {
-        currentLocationCountry: locationData?.countryShortCode,
-        currentLocationState: locationData?.stateShortCode,
-        bitpayIdLocationCountry: user?.country,
-        bitpayIdLocationState: user?.state,
-      };
-      const config: ExternalServicesConfig = await dispatch(
-        getExternalServicesConfig(requestData),
-      );
+      let config: ExternalServicesConfig;
+      if (isExternalServicesConfigCacheFresh()) {
+        config = getCachedExternalServicesConfig()!.config;
+        logger.debug('Using cached buyCryptoConfig');
+      } else {
+        config = await dispatch(getExternalServicesConfig());
+      }
       buyCryptoConfig = config?.buyCrypto;
       setExternalServicesConfig(config);
       logger.debug('buyCryptoConfig: ' + JSON.stringify(buyCryptoConfig));
@@ -1014,7 +1020,7 @@ const BuyAndSellRoot = ({
     }
 
     if (buyCryptoConfig?.disabled) {
-      hideOngoingProcess();
+      setIsInitializing(false);
       await sleep(600);
       dispatch(
         AppActions.showBottomNotificationModal({
@@ -1044,31 +1050,30 @@ const BuyAndSellRoot = ({
       return;
     }
 
-    if (preSetPartner) {
-      logger.debug(
-        `preSetPartner: ${preSetPartner} - fromAmount: ${fromAmount} - fromCurrencyAbbreviation: ${fromCurrencyAbbreviation} - fromChain: ${fromChain}`,
-      );
-    }
-
-    const limits = dispatch(
-      getBuyCryptoFiatLimits(preSetPartner, fiatCurrency),
+    logger.debug(
+      `[initBuyCrypto] preSetPartner: ${preSetPartner} - fromAmount: ${fromAmount} - fromCurrencyAbbreviation: ${fromCurrencyAbbreviation} - fromChain: ${fromChain}`,
     );
 
+    const _limits = dispatch(
+      getBuyCryptoFiatLimits(preSetPartner, fiatCurrency),
+    );
+    setLimits(_limits);
+
     if (
-      limits.min !== undefined &&
+      _limits.min !== undefined &&
       fromAmount !== undefined &&
-      fromAmount < limits.min
+      fromAmount < _limits.min
     ) {
-      curValRef.current = limits.min.toString();
-      updateAmountRef.current(limits.min.toString());
+      curValRef.current = _limits.min.toString();
+      updateAmountRef.current(_limits.min.toString());
     }
     if (
-      limits.max !== undefined &&
+      _limits.max !== undefined &&
       fromAmount !== undefined &&
-      fromAmount > limits.max
+      fromAmount > _limits.max
     ) {
-      curValRef.current = limits.max.toString();
-      updateAmountRef.current(limits.max.toString());
+      curValRef.current = _limits.max.toString();
+      updateAmountRef.current(_limits.max.toString());
     }
 
     if (!buyCryptoSupportedCoins) {
@@ -1143,13 +1148,14 @@ const BuyAndSellRoot = ({
           .filter(currency => !!currency.name);
 
       setBuyCryptoSupportedCoinsFullObj(initialBuyCryptoSupportedCoinsFullObj);
+      setIsInitializing(false);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
       logger.error(
         'Buy crypto Error when trying to build the list of supported coins from: ' +
           JSON.stringify(supportedCoins),
       );
-      hideOngoingProcess();
+      setIsInitializing(false);
       await sleep(600);
       dispatch(
         AppActions.showBottomNotificationModal({
@@ -1176,8 +1182,7 @@ const BuyAndSellRoot = ({
       );
       return;
     }
-    await sleep(600);
-    hideOngoingProcess();
+    setIsInitializing(false);
   };
 
   const filterMoonpayCurrenciesConditions = (
@@ -1494,17 +1499,19 @@ const BuyAndSellRoot = ({
   };
 
   const initSellCrypto = async () => {
+    if (fromDeeplink) {
+      await sleep(300);
+    }
     try {
-      const requestData: ExternalServicesConfigRequestParams = {
-        currentLocationCountry: locationData?.countryShortCode,
-        currentLocationState: locationData?.stateShortCode,
-        bitpayIdLocationCountry: user?.country,
-        bitpayIdLocationState: user?.state,
-      };
-      const config: ExternalServicesConfig = await dispatch(
-        getExternalServicesConfig(requestData),
-      );
+      let config: ExternalServicesConfig;
+      if (isExternalServicesConfigCacheFresh()) {
+        config = getCachedExternalServicesConfig()!.config;
+        logger.debug('Using cached sellCryptoConfig');
+      } else {
+        config = await dispatch(getExternalServicesConfig());
+      }
       sellCryptoConfig = config?.sellCrypto;
+      setExternalServicesConfig(config);
       logger.debug('sellCryptoConfig: ' + JSON.stringify(sellCryptoConfig));
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
@@ -1512,7 +1519,7 @@ const BuyAndSellRoot = ({
     }
 
     if (sellCryptoConfig?.disabled) {
-      hideOngoingProcess();
+      setIsInitializing(false);
       await sleep(600);
       dispatch(
         AppActions.showBottomNotificationModal({
@@ -1597,7 +1604,7 @@ const BuyAndSellRoot = ({
       }
       const reason =
         'initSellCrypto Error. Could not get enabledExchanges for the user parameters';
-      hideOngoingProcess();
+      setIsInitializing(false);
       await sleep(100);
       showError(undefined, msg, reason);
       return;
@@ -1745,8 +1752,9 @@ const BuyAndSellRoot = ({
             ({symbol}) => symbol,
           );
           setSellCryptoSupportedCoins(_sellCryptoSupportedCoins);
-          await sleep(100);
-          hideOngoingProcess();
+          if (!fromWallet) {
+            setIsInitializing(false);
+          }
         } else {
           logger.error(
             'Sell crypto getCurrencies Error: allSupportedCoins array is empty',
@@ -1754,7 +1762,7 @@ const BuyAndSellRoot = ({
           const msg = t(
             'Sell Crypto feature is not available at this moment. Please try again later.',
           );
-          hideOngoingProcess();
+          setIsInitializing(false);
           await sleep(500);
           showError(undefined, msg, undefined, undefined, true);
         }
@@ -1765,20 +1773,11 @@ const BuyAndSellRoot = ({
       const msg = t(
         'Sell Crypto feature is not available at this moment. Please try again later.',
       );
-      hideOngoingProcess();
+      setIsInitializing(false);
       await sleep(500);
       showError(undefined, msg, undefined, undefined, true);
     }
   };
-
-  const init = async () => {
-    if (fromDeeplink) {
-      await sleep(200);
-    }
-    await sleep(100);
-    showOngoingProcess('GENERAL_AWAITING');
-  };
-
   const updateWalletStatus = async (
     wallet: Wallet,
     skipStatusUpdate?: boolean,
@@ -1940,10 +1939,12 @@ const BuyAndSellRoot = ({
         }
       }
       setLoadingEnterAmountBtn(false);
+      setIsInitializing(false);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
       logger.error('Sell crypto getLimits Error: ' + errMsg);
       setLoadingEnterAmountBtn(false);
+      setIsInitializing(false);
       const msg = t(
         'Sell Crypto feature is not available at this moment. Please try again later.',
       );
@@ -2046,34 +2047,40 @@ const BuyAndSellRoot = ({
     return Promise.resolve(simplexLimits);
   };
 
-  useMount(() => {
-    init();
-    if (context === 'buyCrypto') {
-      try {
-        initBuyCrypto();
-      } catch (err: any) {
-        const errStr = err instanceof Error ? err.message : JSON.stringify(err);
-        logger.error(`[Buy] could not initialize view: ${errStr}`);
-        hideOngoingProcess();
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', async () => {
+      console.log('BuyAndSellRoot focused, initializing...');
+      if (context === 'buyCrypto') {
+        try {
+          await initBuyCrypto();
+        } catch (err: any) {
+          const errStr =
+            err instanceof Error ? err.message : JSON.stringify(err);
+          logger.error(`[Buy] could not initialize view: ${errStr}`);
+          setIsInitializing(false);
+        }
+      } else if (context === 'sellCrypto') {
+        try {
+          await initSellCrypto();
+        } catch (err: any) {
+          const errStr =
+            err instanceof Error ? err.message : JSON.stringify(err);
+          logger.error(`[Sell] could not initialize view: ${errStr}`);
+          setIsInitializing(false);
+        }
       }
-    } else if (context === 'sellCrypto') {
-      try {
-        initSellCrypto();
-      } catch (err: any) {
-        const errStr = err instanceof Error ? err.message : JSON.stringify(err);
-        logger.error(`[Sell] could not initialize view: ${errStr}`);
-        hideOngoingProcess();
-      }
-    }
 
-    try {
-      initAmountRef.current();
-    } catch (err: any) {
-      const errStr = err instanceof Error ? err.message : JSON.stringify(err);
-      logger.error(`[Buy/Sell Amount] could not initialize view: ${errStr}`);
-    }
-    initLimits();
-  });
+      try {
+        initAmountRef.current();
+      } catch (err: any) {
+        const errStr = err instanceof Error ? err.message : JSON.stringify(err);
+        logger.error(`[Buy/Sell Amount] could not initialize view: ${errStr}`);
+      }
+    });
+
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     KeyEvent.onKeyUpListener((keyEvent: any) => {
@@ -3800,26 +3807,38 @@ const BuyAndSellRoot = ({
         }}>
         <AmountHeroContainer isSmallScreen={_isSmallScreen}>
           <Row>
-            <AmountText
-              numberOfLines={1}
-              ellipsizeMode={'tail'}
-              bigAmount={
-                _isSmallScreen ? true : amountConfig.displayAmount?.length > 8
-              }>
-              {amountConfig.displayAmount || 0}
-            </AmountText>
-            {context !== 'sellCrypto' || selectedWallet ? (
-              <CurrencySuperScript>
-                <CurrencyText
+            {isInitializing ? (
+              <SpinnerContainer
+                isSmallScreen={_isSmallScreen}
+                addMarginBottom={!!(context === 'sellCrypto' && fromWallet)}>
+                <ActivityIndicator color={SlateDark} />
+              </SpinnerContainer>
+            ) : (
+              <>
+                <AmountText
+                  numberOfLines={1}
+                  ellipsizeMode={'tail'}
                   bigAmount={
                     _isSmallScreen
                       ? true
                       : amountConfig.displayAmount?.length > 8
                   }>
-                  {formatCurrencyAbbreviation(usingCurrency) || 'USD'}
-                </CurrencyText>
-              </CurrencySuperScript>
-            ) : null}
+                  {amountConfig.displayAmount || 0}
+                </AmountText>
+                {context !== 'sellCrypto' || selectedWallet ? (
+                  <CurrencySuperScript>
+                    <CurrencyText
+                      bigAmount={
+                        _isSmallScreen
+                          ? true
+                          : amountConfig.displayAmount?.length > 8
+                      }>
+                      {formatCurrencyAbbreviation(usingCurrency) || 'USD'}
+                    </CurrencyText>
+                  </CurrencySuperScript>
+                ) : null}
+              </>
+            )}
           </Row>
           {/* This section shows the equivalent amount (in crypto if usingCurrency is fiat / in fiat if usingCurrency is crypto)
               Do not remove commented section*/}
@@ -3901,6 +3920,7 @@ const BuyAndSellRoot = ({
             chain={fromChain}
             partner={preSetPartner}
             onWalletSelected={setSelectedWallet}
+            loading={isInitializing}
           />
         </AmountHeroContainer>
         <ActionContainer>

--- a/src/navigation/services/screens/BuyAndSellRoot.tsx
+++ b/src/navigation/services/screens/BuyAndSellRoot.tsx
@@ -2048,8 +2048,8 @@ const BuyAndSellRoot = ({
   };
 
   useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', async () => {
-      console.log('BuyAndSellRoot focused, initializing...');
+    const unsubscribe = navigation.addListener('transitionEnd', async () => {
+      logger.debug('BuyAndSellRoot transitionEnd, initializing...');
       if (context === 'buyCrypto') {
         try {
           await initBuyCrypto();

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -132,7 +132,7 @@ import {
   WrongPasswordError,
 } from '../../../wallet/components/ErrorMessages';
 import {startUpdateWalletStatus} from '../../../../store/wallet/effects/status/status';
-import SwapCryptoLoadingWalletSkeleton from './SwapCryptoLoadingWalletSkeleton';
+import ExternalServicesLoadingWalletSkeleton from '../../components/ExternalServicesLoadingWalletSkeleton';
 import SwapCryptoBalanceSkeleton from './SwapCryptoBalanceSkeleton';
 import BalanceDetailsModal from '../../../wallet/components/BalanceDetailsModal';
 import SelectorArrowRight from '../../../../../assets/img/selector-arrow-right.svg';
@@ -2827,7 +2827,7 @@ const SwapCryptoRoot: React.FC = () => {
                 <SwapCardAccountChainsContainer>
                   {loadingWalletFromStatus ? (
                     <SelectedOptionCol>
-                      <SwapCryptoLoadingWalletSkeleton />
+                      <ExternalServicesLoadingWalletSkeleton />
                     </SelectedOptionCol>
                   ) : (
                     <>
@@ -2878,7 +2878,7 @@ const SwapCryptoRoot: React.FC = () => {
                   style={fromWalletSelected ? {maxWidth: '85%'} : {}}>
                   {loadingWalletFromStatus ? (
                     <SelectedOptionCol>
-                      <SwapCryptoLoadingWalletSkeleton />
+                      <ExternalServicesLoadingWalletSkeleton />
                     </SelectedOptionCol>
                   ) : (
                     <>

--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -138,10 +138,13 @@ import BalanceDetailsModal from '../../../wallet/components/BalanceDetailsModal'
 import SelectorArrowRight from '../../../../../assets/img/selector-arrow-right.svg';
 import {
   ExternalServicesConfig,
-  ExternalServicesConfigRequestParams,
   SwapCryptoConfig,
 } from '../../../../store/external-services/external-services.types';
-import {getExternalServicesConfig} from '../../../../store/external-services/external-services.effects';
+import {
+  getExternalServicesConfig,
+  getCachedExternalServicesConfig,
+  isExternalServicesConfigCacheFresh,
+} from '../../../../store/external-services/external-services.effects';
 import {StackActions} from '@react-navigation/native';
 import {Analytics} from '../../../../store/analytics/analytics.effects';
 import styled from 'styled-components/native';
@@ -229,7 +232,11 @@ import SwapCryptoTxDataSkeleton from './SwapCryptoTxDataSkeleton';
 import TSSProgressTracker from '../../../wallet/components/TSSProgressTracker';
 import SwapCryptoFiatSwitcherIcon from '../../../../components/icons/external-services/swap/SwapCryptoFiatSwitcherIcon';
 import BottomAmountModal from '../components/BottomAmountModal';
-import {SWAP_CRYPTO_CACHE_TTL} from '../../../../store/swap-crypto/swap-crypto.effects';
+import {
+  SWAP_CRYPTO_CACHE_TTL,
+  getSwapCryptoPrefetchedData,
+  setSwapCryptoPrefetchedData,
+} from '../../../../store/swap-crypto/swap-crypto.effects';
 
 export type SwapCryptoRootScreenParams =
   | {
@@ -346,7 +353,7 @@ const SwapCryptoRoot: React.FC = () => {
   );
   const rates = useAppSelector(({RATE}) => RATE.rates);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const prefetchedOpts = useAppSelector(({SWAP_CRYPTO}) => SWAP_CRYPTO.opts);
+  const prefetchedOpts = getSwapCryptoPrefetchedData();
   const route =
     useRoute<
       RouteProp<SwapCryptoGroupParamList, SwapCryptoScreens.SWAP_CRYPTO_ROOT>
@@ -1518,19 +1525,17 @@ const SwapCryptoRoot: React.FC = () => {
       setLoadingWalletFromStatus(true);
     }
 
+    // Try caches first, then fall back to a network call
     if (isCacheFresh && prefetchedOpts?.swapCryptoConfig !== undefined) {
       swapCryptoConfig = prefetchedOpts.swapCryptoConfig;
-      logger.debug('Using cached swapCryptoConfig');
+      logger.debug('Using cached swapCryptoConfig (prefetch)');
+    } else if (isExternalServicesConfigCacheFresh()) {
+      swapCryptoConfig = getCachedExternalServicesConfig()?.config?.swapCrypto;
+      logger.debug('Using cached swapCryptoConfig (external-services)');
     } else {
       try {
-        const requestData: ExternalServicesConfigRequestParams = {
-          currentLocationCountry: locationData?.countryShortCode,
-          currentLocationState: locationData?.stateShortCode,
-          bitpayIdLocationCountry: user?.country,
-          bitpayIdLocationState: user?.state,
-        };
         const config: ExternalServicesConfig = await dispatch(
-          getExternalServicesConfig(requestData),
+          getExternalServicesConfig(),
         );
         swapCryptoConfig = config?.swapCrypto;
         logger.debug('swapCryptoConfig: ' + JSON.stringify(swapCryptoConfig));
@@ -1726,14 +1731,12 @@ const SwapCryptoRoot: React.FC = () => {
 
           // Write back to cache so subsequent opens skip network calls
           if (!isCacheFresh) {
-            dispatch(
-              SwapCryptoActions.setPrefetchedData({
-                swapCryptoConfig,
-                changellyRawCurrencies: changellyRawRef.current,
-                thorswapRawCurrencies: thorswapRawRef.current,
-                fetchedAt: Date.now(),
-              }),
-            );
+            setSwapCryptoPrefetchedData({
+              swapCryptoConfig,
+              changellyRawCurrencies: changellyRawRef.current,
+              thorswapRawCurrencies: thorswapRawRef.current,
+              fetchedAt: Date.now(),
+            });
           }
         } else {
           const reason =

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -126,7 +126,7 @@ import {ShortcutList} from '../../constants/shortcuts';
 import {goToBuyCrypto} from '../buy-crypto/buy-crypto.effects';
 import {goToSellCrypto} from '../sell-crypto/sell-crypto.effects';
 import {goToSwapCrypto} from '../swap-crypto/swap-crypto.effects';
-import {prefetchSwapCryptoData} from '../swap-crypto/swap-crypto.effects';
+import {prefetchExternalServicesData} from '../external-services/external-services.effects';
 import {receiveCrypto, sendCrypto} from '../wallet/effects/send/send';
 import moment from 'moment';
 import {FeedbackRateType} from '../../navigation/tabs/settings/about/screens/SendFeedback';
@@ -376,8 +376,8 @@ export const startAppInit = (): Effect => async (dispatch, getState) => {
     dispatch(AppActions.appInitCompleted());
     DeviceEventEmitter.emit(DeviceEmitterEvents.APP_INIT_COMPLETED);
 
-    // Pre-fetch swap crypto config and currencies in background
-    dispatch(prefetchSwapCryptoData());
+    // Pre-fetch external services config and swap crypto currencies in background
+    dispatch(prefetchExternalServicesData());
   } catch (err: unknown) {
     let errorStr;
     if (err instanceof Error) {

--- a/src/store/external-services/external-services.effects.ts
+++ b/src/store/external-services/external-services.effects.ts
@@ -1,27 +1,74 @@
 import axios from 'axios';
 import {Platform} from 'react-native';
 import {Effect} from '..';
-import {LogActions} from '../log';
 import {APP_VERSION, BASE_BWS_URL} from '../../constants/config';
-import {ExternalServicesConfigRequestParams} from './external-services.types';
+import {
+  ExternalServicesConfig,
+  SwapCryptoConfig,
+} from './external-services.types';
 import {logManager} from '../../managers/LogManager';
+import {
+  getSwapCryptoPrefetchedData,
+  setSwapCryptoPrefetchedData,
+  SWAP_CRYPTO_CACHE_TTL,
+} from '../swap-crypto/swap-crypto.effects';
+import {changellyGetCurrencies} from '../swap-crypto/effects/changelly/changelly';
+import {thorswapGetCurrencies} from '../swap-crypto/effects/thorswap/thorswap';
+import {thorswapEnv} from '../../navigation/services/swap-crypto/utils/thorswap-utils';
 
 const bwsUri = BASE_BWS_URL;
 
+// ---------------------------------------------------------------------------
+// Module-level cache for ExternalServicesConfig.
+// Fetched once during app init (prefetchExternalServicesData) and reused by
+// SwapCryptoRoot, BuyAndSellRoot, etc. to avoid redundant network calls.
+// The cache lives in memory only — same lifecycle as the app process.
+// ---------------------------------------------------------------------------
+export const EXTERNAL_SERVICES_CONFIG_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+
+interface CachedExternalServicesConfig {
+  config: ExternalServicesConfig;
+  fetchedAt: number;
+}
+
+let _cachedConfig: CachedExternalServicesConfig | undefined;
+
+/** Read the cached external services config (may be undefined). */
+export const getCachedExternalServicesConfig = ():
+  | CachedExternalServicesConfig
+  | undefined => _cachedConfig;
+
+/** Write a new cached config. */
+export const setCachedExternalServicesConfig = (
+  config: ExternalServicesConfig,
+  fetchedAt: number = Date.now(),
+): void => {
+  _cachedConfig = {config, fetchedAt};
+};
+
+/** Check whether the cached config is still fresh. */
+export const isExternalServicesConfigCacheFresh = (): boolean =>
+  !!_cachedConfig?.fetchedAt &&
+  Date.now() - _cachedConfig.fetchedAt < EXTERNAL_SERVICES_CONFIG_CACHE_TTL;
+
 export const getExternalServicesConfig =
-  (params: ExternalServicesConfigRequestParams): Effect<Promise<any>> =>
-  async (dispatch): Promise<any> => {
+  (): Effect<Promise<any>> =>
+  async (dispatch, getState): Promise<any> => {
     try {
+      const {APP, LOCATION, BITPAY_ID} = getState();
+      const locationData = LOCATION.locationData;
+      const user = BITPAY_ID.user[APP.network];
+
       const config = {
         headers: {
           'Content-Type': 'application/json',
         },
         params: {
-          currentAppVersion: params.currentAppVersion ?? APP_VERSION,
-          currentLocationCountry: params.currentLocationCountry,
-          currentLocationState: params.currentLocationState,
-          bitpayIdLocationCountry: params.bitpayIdLocationCountry,
-          bitpayIdLocationState: params.bitpayIdLocationState,
+          currentAppVersion: APP_VERSION,
+          currentLocationCountry: locationData?.countryShortCode,
+          currentLocationState: locationData?.stateShortCode,
+          bitpayIdLocationCountry: user?.country,
+          bitpayIdLocationState: user?.state,
           platform: {
             os: Platform.OS,
             version: Platform.Version,
@@ -35,9 +82,110 @@ export const getExternalServicesConfig =
         )}`,
       );
       const {data} = await axios.get(bwsUri + '/v1/services', config);
+
+      // Update module-level cache on every successful fetch
+      if (data) {
+        setCachedExternalServicesConfig(data);
+      }
+
       return Promise.resolve(data);
     } catch (err) {
       return Promise.reject(err);
+    }
+  };
+
+/**
+ * Pre-fetches external services config and swap crypto exchange currencies
+ * in the background. The config is cached at the module level here
+ * (shared with BuyAndSellRoot) and the swap currency data is cached in
+ * swap-crypto.effects.ts (_prefetchedSwapData).
+ *
+ * This effect is fire-and-forget — failures are silently ignored since
+ * consumers can always fall back to fetching on their own.
+ */
+export const prefetchExternalServicesData =
+  (): Effect<Promise<void>> => async dispatch => {
+    try {
+      let swapCryptoConfig: SwapCryptoConfig | undefined;
+      if (isExternalServicesConfigCacheFresh()) {
+        swapCryptoConfig =
+          getCachedExternalServicesConfig()?.config?.swapCrypto;
+        logManager.debug('[prefetchExternalServices] Using cached config');
+      } else {
+        try {
+          const config = await dispatch(getExternalServicesConfig());
+          swapCryptoConfig = config?.swapCrypto;
+        } catch (err) {
+          logManager.debug(
+            '[prefetchExternalServices] Config fetch failed, continuing with currencies only',
+          );
+        }
+      }
+
+      // Skip if swap cache is still fresh
+      const prefetchedSwapData = getSwapCryptoPrefetchedData();
+      if (
+        prefetchedSwapData?.fetchedAt &&
+        Date.now() - prefetchedSwapData.fetchedAt < SWAP_CRYPTO_CACHE_TTL
+      ) {
+        logManager.debug('[prefetchSwapCrypto] Cache is still fresh, skipping');
+        return;
+      }
+
+      // If swap is disabled, save config and stop
+      if (swapCryptoConfig?.disabled) {
+        setSwapCryptoPrefetchedData({
+          swapCryptoConfig,
+          fetchedAt: Date.now(),
+        });
+        return;
+      }
+
+      // 2. Determine which exchanges to fetch
+      const fetchChangelly = !(
+        swapCryptoConfig?.changelly?.removed ||
+        swapCryptoConfig?.changelly?.disabled
+      );
+      const fetchThorswap = !(
+        swapCryptoConfig?.thorswap?.removed ||
+        swapCryptoConfig?.thorswap?.disabled
+      );
+
+      // 3. Fetch raw currencies in parallel
+      const [changellyResult, thorswapResult] = await Promise.allSettled([
+        fetchChangelly
+          ? changellyGetCurrencies(true).then(data => data?.result)
+          : Promise.resolve(undefined),
+        fetchThorswap
+          ? thorswapGetCurrencies({
+              env: thorswapEnv,
+              categories: 'all',
+              includeDetails: true,
+            })
+          : Promise.resolve(undefined),
+      ]);
+
+      setSwapCryptoPrefetchedData({
+        swapCryptoConfig,
+        changellyRawCurrencies:
+          changellyResult.status === 'fulfilled'
+            ? changellyResult.value
+            : undefined,
+        thorswapRawCurrencies:
+          thorswapResult.status === 'fulfilled'
+            ? thorswapResult.value
+            : undefined,
+        fetchedAt: Date.now(),
+      });
+
+      logManager.debug(
+        '[prefetchExternalServices] Prefetch completed successfully',
+      );
+    } catch (err) {
+      // Silent fail — consumers will fetch on their own
+      logManager.debug(
+        '[prefetchExternalServices] Prefetch failed: ' + JSON.stringify(err),
+      );
     }
   };
 

--- a/src/store/swap-crypto/swap-crypto.actions.ts
+++ b/src/store/swap-crypto/swap-crypto.actions.ts
@@ -1,9 +1,5 @@
 import {SwapCryptoActionType, SwapCryptoActionTypes} from './swap-crypto.types';
-import {
-  changellyTxData,
-  thorswapTxData,
-  SwapCryptoPrefetchedData,
-} from './swap-crypto.models';
+import {changellyTxData, thorswapTxData} from './swap-crypto.models';
 
 export const successTxChangelly = (payload: {
   changellyTxData: changellyTxData;
@@ -30,12 +26,5 @@ export const removeTxThorswap = (payload: {
   orderId: string;
 }): SwapCryptoActionType => ({
   type: SwapCryptoActionTypes.REMOVE_TX_THORSWAP,
-  payload,
-});
-
-export const setPrefetchedData = (
-  payload: SwapCryptoPrefetchedData,
-): SwapCryptoActionType => ({
-  type: SwapCryptoActionTypes.SET_PREFETCHED_DATA,
   payload,
 });

--- a/src/store/swap-crypto/swap-crypto.effects.ts
+++ b/src/store/swap-crypto/swap-crypto.effects.ts
@@ -1,18 +1,21 @@
 import {Effect} from '..';
 import {navigationRef} from '../../Root';
 import {Analytics} from '../analytics/analytics.effects';
-import {getExternalServicesConfig} from '../external-services/external-services.effects';
-import {
-  ExternalServicesConfigRequestParams,
-  SwapCryptoConfig,
-} from '../external-services/external-services.types';
-import {changellyGetCurrencies} from './effects/changelly/changelly';
-import {thorswapGetCurrencies} from './effects/thorswap/thorswap';
-import {thorswapEnv} from '../../navigation/services/swap-crypto/utils/thorswap-utils';
-import {setPrefetchedData} from './swap-crypto.actions';
-import {logManager} from '../../managers/LogManager';
+import {SwapCryptoPrefetchedData} from './swap-crypto.models';
 
-export const SWAP_CRYPTO_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+let _prefetchedSwapData: SwapCryptoPrefetchedData | undefined;
+
+export const getSwapCryptoPrefetchedData = ():
+  | SwapCryptoPrefetchedData
+  | undefined => _prefetchedSwapData;
+
+export const setSwapCryptoPrefetchedData = (
+  data: SwapCryptoPrefetchedData,
+): void => {
+  _prefetchedSwapData = data;
+};
+
+export const SWAP_CRYPTO_CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours
 
 export const goToSwapCrypto = (): Effect<void> => dispatch => {
   dispatch(
@@ -22,106 +25,3 @@ export const goToSwapCrypto = (): Effect<void> => dispatch => {
   );
   navigationRef.navigate('SwapCryptoRoot');
 };
-
-/**
- * Pre-fetches swap crypto config and exchange currencies in the background.
- * Results are stored in SWAP_CRYPTO.opts and used by SwapCryptoRoot to skip
- * network calls when the cache is fresh (< 24 hours).
- *
- * This effect is fire-and-forget — failures are silently ignored since
- * SwapCryptoRoot can always fall back to fetching on its own.
- */
-export const prefetchSwapCryptoData =
-  (): Effect<Promise<void>> => async (dispatch, getState) => {
-    try {
-      const {APP, LOCATION, BITPAY_ID, SWAP_CRYPTO} = getState();
-
-      // Skip if cache is still fresh
-      if (
-        SWAP_CRYPTO.opts?.fetchedAt &&
-        Date.now() - SWAP_CRYPTO.opts.fetchedAt < SWAP_CRYPTO_CACHE_TTL
-      ) {
-        logManager.debug('[prefetchSwapCrypto] Cache is still fresh, skipping');
-        return;
-      }
-
-      const {network} = APP;
-      const locationData = LOCATION.locationData;
-      const user = BITPAY_ID.user[network];
-
-      // 1. Fetch external services config
-      const requestData: ExternalServicesConfigRequestParams = {
-        currentLocationCountry: locationData?.countryShortCode,
-        currentLocationState: locationData?.stateShortCode,
-        bitpayIdLocationCountry: user?.country,
-        bitpayIdLocationState: user?.state,
-      };
-
-      let swapCryptoConfig: SwapCryptoConfig | undefined;
-      try {
-        const config = await dispatch(getExternalServicesConfig(requestData));
-        swapCryptoConfig = config?.swapCrypto;
-      } catch (err) {
-        logManager.debug(
-          '[prefetchSwapCrypto] Config fetch failed, continuing with currencies only',
-        );
-      }
-
-      // If swap is disabled, store config and stop
-      if (swapCryptoConfig?.disabled) {
-        dispatch(
-          setPrefetchedData({
-            swapCryptoConfig,
-            fetchedAt: Date.now(),
-          }),
-        );
-        return;
-      }
-
-      // 2. Determine which exchanges to fetch
-      const fetchChangelly = !(
-        swapCryptoConfig?.changelly?.removed ||
-        swapCryptoConfig?.changelly?.disabled
-      );
-      const fetchThorswap = !(
-        swapCryptoConfig?.thorswap?.removed ||
-        swapCryptoConfig?.thorswap?.disabled
-      );
-
-      // 3. Fetch raw currencies in parallel
-      const [changellyResult, thorswapResult] = await Promise.allSettled([
-        fetchChangelly
-          ? changellyGetCurrencies(true).then(data => data?.result)
-          : Promise.resolve(undefined),
-        fetchThorswap
-          ? thorswapGetCurrencies({
-              env: thorswapEnv,
-              categories: 'all',
-              includeDetails: true,
-            })
-          : Promise.resolve(undefined),
-      ]);
-
-      dispatch(
-        setPrefetchedData({
-          swapCryptoConfig,
-          changellyRawCurrencies:
-            changellyResult.status === 'fulfilled'
-              ? changellyResult.value
-              : undefined,
-          thorswapRawCurrencies:
-            thorswapResult.status === 'fulfilled'
-              ? thorswapResult.value
-              : undefined,
-          fetchedAt: Date.now(),
-        }),
-      );
-
-      logManager.debug('[prefetchSwapCrypto] Prefetch completed successfully');
-    } catch (err) {
-      // Silent fail — SwapCryptoRoot will fetch on its own
-      logManager.debug(
-        '[prefetchSwapCrypto] Prefetch failed: ' + JSON.stringify(err),
-      );
-    }
-  };

--- a/src/store/swap-crypto/swap-crypto.reducer.ts
+++ b/src/store/swap-crypto/swap-crypto.reducer.ts
@@ -1,24 +1,18 @@
 import {SwapCryptoActionType, SwapCryptoActionTypes} from './swap-crypto.types';
-import {
-  changellyTxData,
-  thorswapTxData,
-  SwapCryptoPrefetchedData,
-} from './swap-crypto.models';
+import {changellyTxData, thorswapTxData} from './swap-crypto.models';
 
 type SwapCryptoReduxPersistBlackList = string[];
 export const swapCryptoReduxPersistBlackList: SwapCryptoReduxPersistBlackList =
-  ['opts'];
+  [];
 
 export interface SwapCryptoState {
   changelly: {[key in string]: changellyTxData};
   thorswap: {[key in string]: thorswapTxData};
-  opts?: SwapCryptoPrefetchedData;
 }
 
 const initialState: SwapCryptoState = {
   changelly: {},
   thorswap: {},
-  opts: undefined,
 };
 
 export const swapCryptoReducer = (
@@ -62,12 +56,6 @@ export const swapCryptoReducer = (
       return {
         ...state,
         thorswap: {...thorswapTxList},
-      };
-
-    case SwapCryptoActionTypes.SET_PREFETCHED_DATA:
-      return {
-        ...state,
-        opts: action.payload,
       };
 
     default:

--- a/src/store/swap-crypto/swap-crypto.types.ts
+++ b/src/store/swap-crypto/swap-crypto.types.ts
@@ -1,15 +1,10 @@
-import {
-  changellyTxData,
-  thorswapTxData,
-  SwapCryptoPrefetchedData,
-} from './swap-crypto.models';
+import {changellyTxData, thorswapTxData} from './swap-crypto.models';
 
 export enum SwapCryptoActionTypes {
   SUCCESS_TX_CHANGELLY = 'SWAP_CRYPTO/SUCCESS_TX_CHANGELLY',
   REMOVE_TX_CHANGELLY = 'SWAP_CRYPTO/REMOVE_TX_CHANGELLY',
   SUCCESS_TX_THORSWAP = 'SWAP_CRYPTO/SUCCESS_TX_THORSWAP',
   REMOVE_TX_THORSWAP = 'SWAP_CRYPTO/REMOVE_TX_THORSWAP',
-  SET_PREFETCHED_DATA = 'SWAP_CRYPTO/SET_PREFETCHED_DATA',
 }
 
 interface successTxChangelly {
@@ -40,14 +35,8 @@ interface removeTxThorswap {
   };
 }
 
-interface setPrefetchedData {
-  type: typeof SwapCryptoActionTypes.SET_PREFETCHED_DATA;
-  payload: SwapCryptoPrefetchedData;
-}
-
 export type SwapCryptoActionType =
   | successTxChangelly
   | removeTxChangelly
   | successTxThorswap
-  | removeTxThorswap
-  | setPrefetchedData;
+  | removeTxThorswap;


### PR DESCRIPTION
In this PR:

- I refactored the prefetch of externalServices (config and swap supported currencies) to avoid using Redux during app initialization, thus reducing potential UI freezes during data saving.

- The cache is now modular-level and remains in memory while the session is active.

- I refactored the getExternalServicesConfig to run only once and then reuse it in buy/sell/swap.

- I removed the ongoing process from Buy/Sell (it had already been removed from Swap) and replaced it with spinners/skeletons from the view, in an attempt to reduce the time it takes for the user to interact with these features.

- Fix: Accessing Buy/Sell from wallet details now correctly selects the wallet from which the user is accessing the feature.