### PR TITLE
Send: Feature - Nonce assignment on signing for EVM and XRP

### DIFF
--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -91,6 +91,7 @@ import {
   IsSVMChain,
   IsUtxoChain,
   IsEVMChain,
+  IsNonceChain,
 } from '../../utils/currency';
 import {CommonActions, NavigationProp} from '@react-navigation/native';
 import {BwcProvider} from '../../../../lib/bwc';
@@ -1400,10 +1401,10 @@ export const publishAndSign =
 
         let txpToSign = publishedTx || txp;
 
-        // EVM txps without a nonce need one assigned before signing.
-        // TODO: remove deferNonce check once BWS always defers nonce for EVM chains
-        if ((txpToSign.deferNonce || txpToSign.nonce == null) && IsEVMChain(txpToSign.chain)) {
-          txpToSign = await wallet.prepareTx({ txp: txpToSign });
+        // Nonce-based chains (EVM, XRP) without a nonce need one assigned before signing.
+        // TODO: remove deferNonce check once BWS always defers nonce for nonce chains
+        if ((txpToSign.deferNonce || txpToSign.nonce == null) && IsNonceChain(txpToSign.chain)) {
+          txpToSign = (await wallet.prepareTx({ txp: txpToSign })) as TransactionProposal;
           logManager.info(`prepareTx: BWS assigned nonce ${txpToSign.nonce} to txp ${txpToSign.id}`);
         }
 
@@ -1603,9 +1604,9 @@ export const publishAndSignMultipleProposals =
           | void
           | Error
         )[] = [];
-        const evmTxsWithNonce = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce || (txp.nonce == null && IsEVMChain(txp.chain)));
-        evmTxsWithNonce.sort((a, b) => (a.nonce || 0) - (b.nonce || 0));
-        for (const txp of evmTxsWithNonce) {
+        const nonceTxs = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce || (txp.nonce == null && IsNonceChain(txp.chain)));
+        nonceTxs.sort((a, b) => (a.nonce || 0) - (b.nonce || 0));
+        for (const txp of nonceTxs) {
           try {
             const result = await dispatch(
               publishAndSign({
@@ -1627,7 +1628,7 @@ export const publishAndSignMultipleProposals =
         }
 
         // Process transactions without a nonce concurrently
-        const withoutNonce = txps.filter(txp => txp.nonce === undefined && !txp.deferNonce && !IsEVMChain(txp.chain));
+        const withoutNonce = txps.filter(txp => txp.nonce === undefined && !txp.deferNonce && !IsNonceChain(txp.chain));
         const promisesWithoutNonce: Promise<
           Partial<TransactionProposal> | void | Error
         >[] = withoutNonce.map(txp =>

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -1400,10 +1400,11 @@ export const publishAndSign =
 
         let txpToSign = publishedTx || txp;
 
-        // For deferred-nonce EVM txps, assign fresh nonce from BWS before signing
-        if (txpToSign.deferNonce && IsEVMChain(txpToSign.chain)) {
-          txpToSign = await wallet.assignNonce({ txp: txpToSign });
-          logManager.info(`Deferred nonce: BWS assigned nonce ${txpToSign.nonce} to txp ${txpToSign.id}`);
+        // EVM txps without a nonce need one assigned before signing.
+        // TODO: remove deferNonce check once BWS always defers nonce for EVM chains
+        if ((txpToSign.deferNonce || txpToSign.nonce == null) && IsEVMChain(txpToSign.chain)) {
+          txpToSign = await wallet.prepareTx({ txp: txpToSign });
+          logManager.info(`prepareTx: BWS assigned nonce ${txpToSign.nonce} to txp ${txpToSign.id}`);
         }
 
         if (key.isReadOnly && !key.hardwareSource) {
@@ -1602,7 +1603,7 @@ export const publishAndSignMultipleProposals =
           | void
           | Error
         )[] = [];
-        const evmTxsWithNonce = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce);
+        const evmTxsWithNonce = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce || (txp.nonce == null && IsEVMChain(txp.chain)));
         evmTxsWithNonce.sort((a, b) => (a.nonce || 0) - (b.nonce || 0));
         for (const txp of evmTxsWithNonce) {
           try {
@@ -1626,7 +1627,7 @@ export const publishAndSignMultipleProposals =
         }
 
         // Process transactions without a nonce concurrently
-        const withoutNonce = txps.filter(txp => txp.nonce === undefined && !txp.deferNonce);
+        const withoutNonce = txps.filter(txp => txp.nonce === undefined && !txp.deferNonce && !IsEVMChain(txp.chain));
         const promisesWithoutNonce: Promise<
           Partial<TransactionProposal> | void | Error
         >[] = withoutNonce.map(txp =>

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -1604,7 +1604,12 @@ export const publishAndSignMultipleProposals =
           | void
           | Error
         )[] = [];
-        const nonceTxs = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce || (txp.nonce == null && IsNonceChain(txp.chain)));
+        const nonceTxs = txps.filter(txp => {
+          const hasAssignedNonce = txp.nonce !== undefined; // BWS already set a nonce (normal flow)
+          const hasDeferredNonce = txp.deferNonce; // flagged txp — app assigns nonce via prepareTx
+          const isMissingNonceOnNonceChain = txp.nonce == null && IsNonceChain(txp.chain); // handles when BWS always defers nonce by default (deferNonce flag won't be needed)
+          return hasAssignedNonce || hasDeferredNonce || isMissingNonceOnNonceChain;
+        });
         nonceTxs.sort((a, b) => (a.nonce || 0) - (b.nonce || 0));
         for (const txp of nonceTxs) {
           try {

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -1398,7 +1398,13 @@ export const publishAndSign =
           logManager.debug('success publish [publishAndSign]');
         }
 
-        const txpToSign = publishedTx || txp;
+        let txpToSign = publishedTx || txp;
+
+        // For deferred-nonce EVM txps, assign fresh nonce from BWS before signing
+        if (txpToSign.deferNonce && IsEVMChain(txpToSign.chain)) {
+          txpToSign = await wallet.assignNonce({ txp: txpToSign });
+          logManager.info(`Deferred nonce: BWS assigned nonce ${txpToSign.nonce} to txp ${txpToSign.id}`);
+        }
 
         if (key.isReadOnly && !key.hardwareSource) {
           // read only wallet
@@ -1596,7 +1602,7 @@ export const publishAndSignMultipleProposals =
           | void
           | Error
         )[] = [];
-        const evmTxsWithNonce = txps.filter(txp => txp.nonce !== undefined);
+        const evmTxsWithNonce = txps.filter(txp => txp.nonce !== undefined || txp.deferNonce);
         evmTxsWithNonce.sort((a, b) => (a.nonce || 0) - (b.nonce || 0));
         for (const txp of evmTxsWithNonce) {
           try {
@@ -1620,7 +1626,7 @@ export const publishAndSignMultipleProposals =
         }
 
         // Process transactions without a nonce concurrently
-        const withoutNonce = txps.filter(txp => txp.nonce === undefined);
+        const withoutNonce = txps.filter(txp => txp.nonce === undefined && !txp.deferNonce);
         const promisesWithoutNonce: Promise<
           Partial<TransactionProposal> | void | Error
         >[] = withoutNonce.map(txp =>

--- a/src/store/wallet/utils/currency.ts
+++ b/src/store/wallet/utils/currency.ts
@@ -93,6 +93,10 @@ export const IsEVMChain = (chain: string): boolean => {
   return Object.keys(BitpaySupportedEvmCoins).includes(_chain);
 };
 
+export const IsNonceChain = (chain: string): boolean => {
+  return IsEVMChain(chain) || chain.toLowerCase() === 'xrp';
+};
+
 export const IsSVMChain = (chain: string): boolean => {
   const _chain = cloneDeep(chain).toLowerCase();
 

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -399,6 +399,7 @@ export interface TransactionProposal {
   multisigGnosisContractAddress?: string;
   network: Network;
   nonce?: number;
+  deferNonce?: boolean;
   note?: {
     body?: string;
   };


### PR DESCRIPTION
### Description
[RN-2649](https://bitpayprod.atlassian.net/browse/RN-2649)
replaces https://github.com/bitpay/bitpay-app/pull/2123

EVM and XRP transaction proposals can now have their nonce deferred to signing time. When the app sees a txp with `deferNonce` set or a null nonce on a nonce-based chain, it calls `prepareTx` to get a fresh nonce from BWS right before signing. This prevents stale nonces on proposals that sit pending.

Also widens the multi-proposal signing filters so XRP txps go through the sequential path alongside EVM, since they both depend on ordered nonce assignment.

**Depends on:**
- BWS/BWC: https://github.com/bitpay/bitcore/pull/4124 (prepareTx endpoint + deferNonce support)
- Server: internal MR 11390 (deferNonce runtime setting)

### Changelog

* Added `IsNonceChain` helper covering EVM + XRP chains
* `publishAndSign` calls `prepareTx` before signing when nonce is missing on a nonce chain
* Multi-proposal filters use `IsNonceChain` instead of just `IsEVMChain` so XRP txps are signed sequentially
* `deferNonce` field added to `TransactionProposal` model

### Testing Notes
With `deferNonce` **disabled** in runtime settings, behavior should be identical to before — nonces are assigned at creation time.

With `deferNonce` **enabled**:
1. Create an EVM or XRP txp — should have null nonce and `deferNonce: true`
2. Sign the txp — app should log `prepareTx: BWS assigned nonce X to txp Y` before signing
3. Bulk sign multiple EVM/XRP txps — they should be processed sequentially with incrementing nonces

UTXO chains (BTC, BCH, etc.) are unaffected.
