### PR TITLE
Transaction List: Fix - Month name localization for regional locales (e.g. zh-cn)

### DIFF
--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -563,17 +563,24 @@ const IsFirstInCoinbaseGroup = (index: number, history: any[]) => {
   return !WithinSameMonthTimestamp(curTx.created_at, prevTx.created_at);
 };
 
-const getMonthName = (time: MomentInput): String => {
-  let month = '';
+const getMomentLocale = (language?: string): string => {
+  const lang = (language || '').toLowerCase();
+
+  if (lang.startsWith('zh')) return 'zh-cn';
+
+  const base = lang.split('-')[0];
+
+  return base || 'en';
+};
+
+const getMonthName = (time: MomentInput): string => {
   try {
-    month = moment(time).locale(i18n.language).format('MMMM');
+    return moment(time).locale(getMomentLocale(i18n.language)).format('MMMM');
   } catch (e) {
-    // Fallback to default locale if the language is not supported
     const error = e instanceof Error ? e.message : JSON.stringify(e);
     logManager.warn('Error formatting date:', error);
-    month = moment(time).format('MMMM');
+    return moment(time).locale('en').format('MMMM');
   }
-  return month;
 };
 
 export const GroupCoinbaseTransactions = (txs: any[]) => {


### PR DESCRIPTION
Fix issue reported on Android:
```
Requiring unknown module "./locale/zh"
```

This was not related to our i18n translations, but to Moment.js locale loading behavior.

---

### Month Name in English (should be zh)

![IMG_1208](https://github.com/user-attachments/assets/2c703c84-6b0e-4688-96f4-1227d60577ca)


### Fixed

![IMG_1207](https://github.com/user-attachments/assets/718765c6-146b-4fc1-a42c-2726b3ece2c2)


---
[RN-2652](https://bitpayprod.atlassian.net/browse/RN-2652)