### PR TITLE
Release: Bump - 14.41.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,8 +104,8 @@ android {
         applicationId "com.bitpay.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 91212414
-        versionName "14.41.0"
+        versionCode 91212416
+        versionName "14.41.1"
         missingDimensionStrategy 'react-native-camera', 'mlkit'
         ndk {
             abiFilters "armeabi-v7a", "x86", "x86_64", "arm64-v8a"

--- a/ios/BitPayApp/Info.plist
+++ b/ios/BitPayApp/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>14.41.0</string>
+	<string>14.41.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitpay",
-  "version": "14.41.0",
+  "version": "14.41.1",
   "private": true,
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
[RN-2660](https://bitpayprod.atlassian.net/browse/RN-2660)

Version bump to 14.41.1 for the release/14.41.0 release.

**Tickets (14)**
- [RN-2416](https://bitpayprod.atlassian.net/browse/RN-2416) — Error: Unable to resolve host "yeqtpl-inapps.appsflyersdk.com": No address associated with hostname
- [RN-2593](https://bitpayprod.atlassian.net/browse/RN-2593) — TSS: Enhancement - Bump bwc v11.5.2 / rename patches / import and backup navigation
- [RN-2610](https://bitpayprod.atlassian.net/browse/RN-2610) — AppsFlyer: Chore - Upgrade react-native-appsflyer
- [RN-2642](https://bitpayprod.atlassian.net/browse/RN-2642) — Fix email validation regex causing stack overflow in SendTo
- [RN-2643](https://bitpayprod.atlassian.net/browse/RN-2643) — Fix unhandled rejected promise in OTP toggle during two-factor setup
- [RN-2644](https://bitpayprod.atlassian.net/browse/RN-2644) — Release bump to version 14.41.0
- [RN-2645](https://bitpayprod.atlassian.net/browse/RN-2645) — KeySettings: Fix - Remove old LogAction by logManager
- [RN-2646](https://bitpayprod.atlassian.net/browse/RN-2646) — Sentry: Fix - iOS Sourcemaps
- [RN-2647](https://bitpayprod.atlassian.net/browse/RN-2647) — Create/Import: Enhancement - remove duplicate work and introducing controlled concurrency
- [RN-2649](https://bitpayprod.atlassian.net/browse/RN-2649) — Add nonce assignment on signing for EVM and XRP transactions
- [RN-2651](https://bitpayprod.atlassian.net/browse/RN-2651) — Update testIDs and accessibility labels for E2E tests
- [RN-2656](https://bitpayprod.atlassian.net/browse/RN-2656) — Enhance TSS feature with wording, readonly support, and backup handling
- [RN-2657](https://bitpayprod.atlassian.net/browse/RN-2657) — Fix misplaced accessibilityLabel from JSX children to props in E2E tests
- [RN-2658](https://bitpayprod.atlassian.net/browse/RN-2658) — Fix Banxa CreateOrder to send payment_method prop

**Linked PRs (13)**
- [#2089](https://github.com/bitpay/bitpay-app/pull/2089) (merged) — Create/Import: Enhancement - remove duplicate work and introducing controlled concurrency
- [#2098](https://github.com/bitpay/bitpay-app/pull/2098) (merged) — TSS: Enhancement - Bump bwc v11.7.0 / rename patches / import and backup navigation / add CopayerReady event / Improve signing recovery
- [#2104](https://github.com/bitpay/bitpay-app/pull/2104) (merged) — Sentry: Fix - iOS Sourcemaps
- [#2109](https://github.com/bitpay/bitpay-app/pull/2109) (merged) — AppsFlyer: Chore - Upgrade react-native-appsflyer
- [#2113](https://github.com/bitpay/bitpay-app/pull/2113) (merged) — KeySettings: Fix - Remove old LogAction by logManager
- [#2114](https://github.com/bitpay/bitpay-app/pull/2114) (merged) — TSS: Enhancement - wording / readonly support / clear encrypt support / how to find SessionID text / needsBackup handling
- [#2118](https://github.com/bitpay/bitpay-app/pull/2118) (merged) — SendTo: Fix - Email validation regex causing stack overflow
- [#2119](https://github.com/bitpay/bitpay-app/pull/2119) (merged) — EnableTwoFactor: Fix - prevent unhandled rejected dangling otp toggle promise
- [#2120](https://github.com/bitpay/bitpay-app/pull/2120) (merged) — Release: Bump - 14.41.0
- [#2124](https://github.com/bitpay/bitpay-app/pull/2124) (merged) — Send: Feature - Nonce assignment on signing for EVM and XRP
- [#2125](https://github.com/bitpay/bitpay-app/pull/2125) (merged) — E2E: Enhancement - Updated testIDs and accessibility labels 
- [#2127](https://github.com/bitpay/bitpay-app/pull/2127) (merged) — E2E: Fix - move misplaced accessibilityLabel from JSX children to props
- [#2128](https://github.com/bitpay/bitpay-app/pull/2128) (merged) — Buy: Fix - send payment_method prop for Banxa's CreateOrder