### PR TITLE
XCode: Fix - Patch fmt consteval for Xcode 26/Clang compatibility

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -79,6 +79,12 @@ target 'BitPayApp' do
           config.build_settings['OTHER_SWIFT_FLAGS'] << '-no-verify-emitted-module-interface'
         end
       end
+      if target.name == 'fmt' || target.name == 'RCT-Folly'
+        target.build_configurations.each do |config|
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
+          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = '$(inherited) -DFMT_USE_NONTYPE_TEMPLATE_ARGS=0 -DFMT_CONSTEXPR=constexpr'
+        end
+      end
     end
     react_native_post_install(
       installer,
@@ -95,6 +101,9 @@ target 'BitPayApp' do
     # This call modifies BitPayApp.xcodeproj — the change should be committed to git.
     # Subsequent `pod install` runs detect the existing phase and skip the modification.
     add_bundle_hash_build_phase(project)
+
+    # Patch fmt FMT_CONSTEVAL to constexpr for Xcode 26 / Clang compatibility
+    system("sed -i '' 's/#  define FMT_CONSTEVAL consteval/#  define FMT_CONSTEVAL constexpr/' #{installer.sandbox.root}/fmt/include/fmt/base.h")
   end
 end
 


### PR DESCRIPTION
<img width="779" height="236" alt="Screenshot 2026-04-17 at 5 35 47 PM" src="https://github.com/user-attachments/assets/e3c0a5e6-29c5-43bc-81c3-b3799a0524c9" />

### Summary

Xcode 26 ships with a stricter version of Clang that rejects `consteval` in certain contexts inside the fmt library (v11.0.2). Specifically, `fmt` defines a macro called `FMT_CONSTEVAL` that resolves to the C++ `consteval` keyword when the compiler supports it — but Clang 26 raises an error when that keyword is used inside a lambda that returns a local struct, which is exactly what `fmt's FMT_STRING` macro does internally.

### Fix

Added a `post_install` patch in the `Podfile` that rewrites `#define FMT_CONSTEVAL consteval` to `#define FMT_CONSTEVAL constexpr` in `fmt/base.h` after every pod install

---
[RN-2691](https://bitpayprod.atlassian.net/browse/RN-2691)