### PR TITLE
Location: Fix - return normalized location data and ensure dispatch completes

### DIFF
--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -274,7 +274,7 @@ export const startAppInit = (): Effect => async (dispatch, getState) => {
 
     dispatch(initializeApi(network, identity));
 
-    dispatch(LocationEffects.getLocationData());
+    const locationDataPromise = dispatch(LocationEffects.getLocationData());
 
     dispatch(fetchInitialUserData());
 
@@ -377,6 +377,7 @@ export const startAppInit = (): Effect => async (dispatch, getState) => {
     DeviceEventEmitter.emit(DeviceEmitterEvents.APP_INIT_COMPLETED);
 
     // Pre-fetch external services config and swap crypto currencies in background
+    await locationDataPromise;
     dispatch(prefetchExternalServicesData());
   } catch (err: unknown) {
     let errorStr;

--- a/src/store/location/location.effects.ts
+++ b/src/store/location/location.effects.ts
@@ -5,6 +5,7 @@ import {EUCountries} from './location.constants';
 import cloneDeep from 'lodash.clonedeep';
 import {logManager} from '../../managers/LogManager';
 import {NO_CACHE_HEADERS} from '../../constants/config';
+import {LocationData} from './location.models';
 
 export const isEuCountry = (countryShortCode: string | undefined): boolean => {
   if (!countryShortCode) {
@@ -13,7 +14,8 @@ export const isEuCountry = (countryShortCode: string | undefined): boolean => {
   return EUCountries.includes(cloneDeep(countryShortCode).toUpperCase());
 };
 
-export const getLocationData = (): Effect => async dispatch => {
+export const getLocationData =
+  (): Effect<Promise<LocationData | undefined>> => async dispatch => {
   try {
     const {data: locationData} = await axios.get(
       'https://bitpay.com/location/ipAddress',
@@ -25,20 +27,24 @@ export const getLocationData = (): Effect => async dispatch => {
       },
     );
 
+    const normalizedLocationData: LocationData = {
+      countryShortCode: locationData.country,
+      isEuCountry: isEuCountry(locationData.country),
+      stateShortCode: locationData.state ?? undefined,
+      cityFullName: locationData.city ?? undefined,
+      locationFullName: locationData.locationString ?? undefined,
+    };
+
     logManager.info('getLocationData', locationData.country);
     await dispatch(
       LocationActions.successGetLocation({
-        locationData: {
-          countryShortCode: locationData.country,
-          isEuCountry: isEuCountry(locationData.country),
-          stateShortCode: locationData.state ?? undefined,
-          cityFullName: locationData.city ?? undefined,
-          locationFullName: locationData.locationString ?? undefined,
-        },
+        locationData: normalizedLocationData,
       }),
     );
+    return normalizedLocationData;
   } catch (err) {
     const errStr = err instanceof Error ? err.message : JSON.stringify(err);
     logManager.error('getLocationData', errStr);
+    return undefined;
   }
 };


### PR DESCRIPTION
This fixes a startup race between location initialization and external services prefetch.

### Changes

* Update `getLocationData` to return the normalized **LocationData** payload it stores.
* Capture the startup location fetch promise in `startAppInit`.
* Await that promise before dispatching `prefetchExternalServicesData`.

<img width="801" height="788" alt="Screenshot 2026-04-20 at 2 07 18 PM" src="https://github.com/user-attachments/assets/53d62c20-4e64-4a52-ad42-ece4d3bf78f5" />
