### PR TITLE
Fix: pre-select wallet from assets details correctly

### DIFF
--- a/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
+++ b/src/navigation/services/swap-crypto/screens/SwapCryptoRoot.tsx
@@ -730,8 +730,11 @@ const SwapCryptoRoot: React.FC = () => {
             chain: `${cloneDeep(selectedWallet.chain).toUpperCase()}`,
           },
         );
+        logger.warn('It was not possible to set the selected wallet');
         showError({msg});
         selectedWallet = undefined;
+        await sleep(600);
+        setLoadingWalletFromStatus(false);
         return;
       }
 

--- a/src/navigation/wallet/screens/ExchangeRate.tsx
+++ b/src/navigation/wallet/screens/ExchangeRate.tsx
@@ -128,6 +128,7 @@ import useExchangeRateChartData, {
   defaultDisplayData,
   HISTORIC_TIMEFRAME_WINDOW_MS,
 } from '../hooks/useExchangeRateChartData';
+import {SwapCryptoScreens} from '../../services/swap-crypto/SwapCryptoGroup';
 
 const AxisLabel = ({
   value,
@@ -1750,9 +1751,8 @@ const ExchangeRate = () => {
                     chain: assetContext.chain || '',
                   }),
                 );
-                navigation.navigate('GlobalSelect', {
-                  context: 'swapFrom',
-                  assetContext,
+                navigation.navigate(SwapCryptoScreens.SWAP_CRYPTO_ROOT, {
+                  selectedWallet: walletsForAsset[0]?.wallet || undefined,
                 });
               },
             }}


### PR DESCRIPTION
Ticket reference: https://bitpayprod.atlassian.net/browse/RN-2695

This fix should resolve the issue where clicking on swap displays an "Insufficient Funds" message in the Global Selector.

---
[RN-2695](https://bitpayprod.atlassian.net/browse/RN-2695)