### PR TITLE
Braze: Fix - Prevent remove oldEid before merge data to newEid

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -145,7 +145,6 @@ import {
   successAddWallet,
   successGetReceiveAddress,
 } from './store/wallet/wallet.actions';
-import {BrazeWrapper} from './lib/Braze';
 import {selectSettingsNotificationState} from './store/app/app.selectors';
 import {HeaderShownContext} from '@react-navigation/elements';
 import PaymentSent from './navigation/wallet/components/PaymentSent';
@@ -654,30 +653,6 @@ export default () => {
 
     return () => subscriptionAppStateChange.remove();
   }, [pinLockActive, biometricLockActive, onboardingCompleted]);
-
-  useEffect(() => {
-    const eventBrazeListener = DeviceEventEmitter.addListener(
-      DeviceEmitterEvents.SHOULD_DELETE_BRAZE_USER,
-      async ({oldEid, newEid}) => {
-        await sleep(20000);
-        logManager.info('Deleting old user EID: ', oldEid);
-        try {
-          await BrazeWrapper.delete(oldEid);
-        } catch (error) {
-          const errMsg =
-            error instanceof Error ? error.message : JSON.stringify(error);
-          logManager.error(`Deleting old user EID failed: ${errMsg}`);
-        }
-        // Wait for a few seconds to ensure the user is deleted
-        await sleep(5000);
-        Analytics.endMergingUser();
-      },
-    );
-
-    return () => {
-      eventBrazeListener.remove();
-    };
-  }, []);
 
   // Patch BWC logger to forward logs to the debug screen.
   // Note: BWC logs full request bodies — we filter long messages to avoid clutter.

--- a/src/lib/Braze/index.ts
+++ b/src/lib/Braze/index.ts
@@ -221,6 +221,10 @@ class BrazeClientWrapper {
     }
 
     if (userId) {
+      // Flush buffered events for the current user before switching, so they
+      // land on Braze servers under the old EID and can be captured by a
+      // subsequent server-side merge call.
+      Braze.requestImmediateDataFlush();
       Braze.changeUser(userId);
       const {status} = await checkNotifications().catch(() => ({
         status: null,

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -25,8 +25,6 @@ import {getCoinAndChainFromCurrencyCode} from '../../navigation/bitpay-id/utils/
 import axios from 'axios';
 import {BASE_BITPAY_URLS, NO_CACHE_HEADERS} from '../../constants/config';
 import {setBrazeEid, setEmailNotificationsAccepted} from '../app/app.actions';
-import {DeviceEmitterEvents} from '../../constants/device-emitter-events';
-import {DeviceEventEmitter} from 'react-native';
 import {
   getPasskeyCredentials,
   getPasskeyStatus,
@@ -39,6 +37,7 @@ import {
 import {logManager} from '../../managers/LogManager';
 import {ongoingProcessManager} from '../../managers/OngoingProcessManager';
 import {clearAllCookiesEverywhere} from '../../utils/cookieAuth';
+import {sleep} from '../../utils/helper-methods';
 
 interface StartLoginParams {
   email?: string;
@@ -74,39 +73,7 @@ export const startBitPayIdAnalyticsInit =
         }
       }
 
-      // Check if Braze EID exists and not the same
-      // Merge ONLY anonymous EIDs
-      // If login with any other BitPayID, we shouldn't delete/merge previous user
-      // Only switch to a new EID with setBrazeEid
-      if (
-        APP.brazeEid &&
-        APP.brazeEid !== eid &&
-        isAnonymousBrazeEid(APP.brazeEid)
-      ) {
-        Analytics.startMergingUser();
-        // Should migrate the user to the new EID
-        logManager.info(
-          '[startBitPayIdAnalyticsInit] Merging current user to new EID: ',
-          eid,
-        );
-        try {
-          await BrazeWrapper.merge(APP.brazeEid, eid);
-          // Emit event to delete old user
-          DeviceEventEmitter.emit(
-            DeviceEmitterEvents.SHOULD_DELETE_BRAZE_USER,
-            {
-              oldEid: APP.brazeEid,
-              newEid: eid,
-            },
-          );
-        } catch (error) {
-          const errMsg =
-            error instanceof Error ? error.message : JSON.stringify(error);
-          logManager.error(
-            `[startBitPayIdAnalyticsInit] Merging current user failed: ${errMsg}`,
-          );
-        }
-      }
+      const previousBrazeEid = APP.brazeEid;
       dispatch(setBrazeEid(eid));
       await dispatch(
         Analytics.identify(eid, {
@@ -115,6 +82,29 @@ export const startBitPayIdAnalyticsInit =
           lastName: familyName,
         }),
       );
+
+      if (
+        previousBrazeEid &&
+        previousBrazeEid !== eid &&
+        isAnonymousBrazeEid(previousBrazeEid)
+      ) {
+        Analytics.startMergingUser();
+        try {
+          logManager.info(
+            '[Braze] Merge oldEid/newEid: ',
+            previousBrazeEid,
+            eid,
+          );
+          await BrazeWrapper.merge(previousBrazeEid, eid);
+        } catch (error) {
+          const errMsg =
+            error instanceof Error ? error.message : JSON.stringify(error);
+          logManager.error(`[Braze] Merge EID failed: ${errMsg}`);
+        }
+        await sleep(5000);
+        Analytics.endMergingUser();
+      }
+
       // Set email notifications and push notifications after Braze EID is set
       dispatch(
         setEmailNotifications(


### PR DESCRIPTION
### Problem
Anonymous Braze tracking data was not migrating to the authenticated user profile on login.

### Root cause
`Braze.changeUser(newEid)` and the server-side merge were called in the wrong order, and buffered SDK events were never flushed before switching users.

### Fix
* Added `Braze.requestImmediateDataFlush()` before `Braze.changeUser()` in `BrazeWrapper.identify` to flush buffered anonymous events to Braze servers first.
* Reordered the login flow so `identify` (→ `changeUser`) runs before the server-side merge API call.
* Removed programmatic delete of the anonymous profile — it races against Braze's async merge and can cancel it. The empty shell is harmless and handled by Braze's User Archival policy.

---
[RN-2699](https://bitpayprod.atlassian.net/browse/RN-2699)