### PR TITLE
Braze: Fix - No remove OldEid and subscribe new users to email notifications

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -145,7 +145,6 @@ import {
   successAddWallet,
   successGetReceiveAddress,
 } from './store/wallet/wallet.actions';
-import {BrazeWrapper} from './lib/Braze';
 import {selectSettingsNotificationState} from './store/app/app.selectors';
 import {HeaderShownContext} from '@react-navigation/elements';
 import PaymentSent from './navigation/wallet/components/PaymentSent';
@@ -654,30 +653,6 @@ export default () => {
 
     return () => subscriptionAppStateChange.remove();
   }, [pinLockActive, biometricLockActive, onboardingCompleted]);
-
-  useEffect(() => {
-    const eventBrazeListener = DeviceEventEmitter.addListener(
-      DeviceEmitterEvents.SHOULD_DELETE_BRAZE_USER,
-      async ({oldEid, newEid}) => {
-        await sleep(20000);
-        logManager.info('Deleting old user EID: ', oldEid);
-        try {
-          await BrazeWrapper.delete(oldEid);
-        } catch (error) {
-          const errMsg =
-            error instanceof Error ? error.message : JSON.stringify(error);
-          logManager.error(`Deleting old user EID failed: ${errMsg}`);
-        }
-        // Wait for a few seconds to ensure the user is deleted
-        await sleep(5000);
-        Analytics.endMergingUser();
-      },
-    );
-
-    return () => {
-      eventBrazeListener.remove();
-    };
-  }, []);
 
   // Patch BWC logger to forward logs to the debug screen.
   // Note: BWC logs full request bodies — we filter long messages to avoid clutter.

--- a/src/lib/Braze/index.ts
+++ b/src/lib/Braze/index.ts
@@ -221,6 +221,10 @@ class BrazeClientWrapper {
     }
 
     if (userId) {
+      // Flush buffered events for the current user before switching, so they
+      // land on Braze servers under the old EID and can be captured by a
+      // subsequent server-side merge call.
+      Braze.requestImmediateDataFlush();
       Braze.changeUser(userId);
       const {status} = await checkNotifications().catch(() => ({
         status: null,

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -945,11 +945,7 @@ export const setAnnouncementsNotifications =
   };
 
 export const setEmailNotifications =
-  (
-    accepted: boolean,
-    email: string | null,
-    agreedToMarketingCommunications?: boolean,
-  ): Effect =>
+  (accepted: boolean, email: string | null): Effect =>
   (dispatch, getState) => {
     const {
       WALLET: {keys},
@@ -966,10 +962,7 @@ export const setEmailNotifications =
         Braze.setEmail(email);
       }
       Braze.setEmailNotificationSubscriptionType(
-        (bitpayUser &&
-          bitpayUser?.verified &&
-          bitpayUser?.optInEmailMarketing) ||
-          agreedToMarketingCommunications
+        bitpayUser && bitpayUser?.verified && bitpayUser?.optInEmailMarketing
           ? Braze.NotificationSubscriptionTypes.OPTED_IN
           : Braze.NotificationSubscriptionTypes.SUBSCRIBED,
       );

--- a/src/store/bitpay-id/bitpay-id.effects.spec.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.spec.ts
@@ -74,6 +74,7 @@ jest.mock('../analytics/analytics.effects', () => ({
     track: jest.fn(() => ({type: 'ANALYTICS/TRACK'})),
     identify: jest.fn(() => () => Promise.resolve()),
     startMergingUser: jest.fn(),
+    endMergingUser: jest.fn(),
   },
 }));
 
@@ -150,6 +151,7 @@ jest.mock('../../api/bitpay', () => ({
 import AuthApi from '../../api/auth';
 import UserApi from '../../api/user';
 import {getPasskeyStatus, signInWithPasskey} from '../../utils/passkey';
+import * as helperMethods from '../../utils/helper-methods';
 import {isAnonymousBrazeEid} from '../app/app.effects';
 import {BrazeWrapper} from '../../lib/Braze';
 
@@ -159,6 +161,9 @@ const MockGetPasskeyStatus = getPasskeyStatus as jest.Mock;
 const MockSignInWithPasskey = signInWithPasskey as jest.Mock;
 const MockIsAnonymousBrazeEid = isAnonymousBrazeEid as jest.Mock;
 const MockBrazeWrapperMerge = BrazeWrapper.merge as jest.Mock;
+const MockSleep = jest
+  .spyOn(helperMethods, 'sleep')
+  .mockResolvedValue(undefined);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -265,7 +270,7 @@ describe('startBitPayIdStoreInit', () => {
     const store = baseStore();
     const initialData = makeInitialData();
 
-    await store.dispatch(startBitPayIdStoreInit(initialData, true));
+    await store.dispatch(startBitPayIdStoreInit(initialData));
 
     // Even with marketing flag set, user should still be initialized
     const state = store.getState().BITPAY_ID;
@@ -309,6 +314,7 @@ describe('startBitPayIdAnalyticsInit', () => {
       'old-anon-eid',
       'new-eid-xyz',
     );
+    expect(MockSleep).toHaveBeenCalledWith(5000);
   });
 
   it('does NOT call BrazeWrapper.merge when brazeEid is not anonymous', async () => {

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -46,14 +46,10 @@ interface StartLoginParams {
 }
 
 export const startBitPayIdAnalyticsInit =
-  (
-    user: BasicUserInfo,
-    agreedToMarketingCommunications?: boolean,
-  ): Effect<void> =>
+  (user: BasicUserInfo): Effect<void> =>
   async (dispatch, getState) => {
     const {APP} = getState();
     const acceptedEmailNotifications = !!APP.emailNotifications?.accepted;
-    const notificationsAccepted = APP.notificationsAccepted;
 
     if (user) {
       const {eid, name} = user;
@@ -106,31 +102,18 @@ export const startBitPayIdAnalyticsInit =
       }
 
       // Set email notifications and push notifications after Braze EID is set
-      dispatch(
-        setEmailNotifications(
-          acceptedEmailNotifications &&
-            user.optInEmailMarketing &&
-            user.verified,
-          email,
-          agreedToMarketingCommunications,
-        ),
-      );
+      dispatch(setEmailNotifications(acceptedEmailNotifications, email));
     }
   };
 
 export const startBitPayIdStoreInit =
-  (
-    initialData: InitialUserData,
-    agreedToMarketingCommunications?: boolean,
-  ): Effect<void> =>
+  (initialData: InitialUserData): Effect<void> =>
   async (dispatch, getState) => {
     const {APP} = getState();
     const {basicInfo: user} = initialData;
     dispatch(BitPayIdActions.successInitializeStore(APP.network, initialData));
     try {
-      dispatch(
-        startBitPayIdAnalyticsInit(user, agreedToMarketingCommunications),
-      );
+      dispatch(startBitPayIdAnalyticsInit(user));
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
       logManager.error(
@@ -183,12 +166,13 @@ export const startCreateAccount =
         hashedPassword: hashedPassword,
         salt: salt,
         agreedToTOSandPP: params.agreedToTOSandPP,
-        optInEmailMarketing: params.agreedToMarketingCommunications,
-        attribute: params.agreedToMarketingCommunications
-          ? 'App Signup'
-          : undefined,
+        optInEmailMarketing: agreedToMarketingCommunications,
+        attribute: agreedToMarketingCommunications ? 'App Signup' : undefined,
         gCaptchaResponse: params.gCaptchaResponse,
       });
+
+      // New users accept email notifications by default
+      dispatch(setEmailNotificationsAccepted(true, params.email));
 
       // refresh session
       const session = await AuthApi.fetchSession(APP.network);
@@ -198,14 +182,7 @@ export const startCreateAccount =
         APP.network,
         session.csrfToken,
       );
-      await dispatch(
-        startPairAndLoadUser(
-          APP.network,
-          secret,
-          undefined,
-          agreedToMarketingCommunications,
-        ),
-      );
+      await dispatch(startPairAndLoadUser(APP.network, secret, undefined));
 
       dispatch(BitPayIdActions.successCreateAccount());
     } catch (err) {
@@ -536,12 +513,7 @@ export const startDeeplinkPairing =
   };
 
 export const startPairAndLoadUser =
-  (
-    network: Network,
-    secret: string,
-    code?: string,
-    agreedToMarketingCommunications?: boolean,
-  ): Effect<Promise<void>> =>
+  (network: Network, secret: string, code?: string): Effect<Promise<void>> =>
   async (dispatch, getState) => {
     try {
       const token = await AuthApi.pair(secret, code);
@@ -575,9 +547,7 @@ export const startPairAndLoadUser =
         );
       }
 
-      dispatch(
-        startBitPayIdStoreInit(data.user, agreedToMarketingCommunications),
-      );
+      dispatch(startBitPayIdStoreInit(data.user));
       dispatch(CardEffects.startCardStoreInit(data.user));
       dispatch(ShopEffects.startFetchCatalog());
       dispatch(ShopEffects.startSyncGiftCards()).then(() =>

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -25,8 +25,6 @@ import {getCoinAndChainFromCurrencyCode} from '../../navigation/bitpay-id/utils/
 import axios from 'axios';
 import {BASE_BITPAY_URLS, NO_CACHE_HEADERS} from '../../constants/config';
 import {setBrazeEid, setEmailNotificationsAccepted} from '../app/app.actions';
-import {DeviceEmitterEvents} from '../../constants/device-emitter-events';
-import {DeviceEventEmitter} from 'react-native';
 import {
   getPasskeyCredentials,
   getPasskeyStatus,
@@ -39,6 +37,7 @@ import {
 import {logManager} from '../../managers/LogManager';
 import {ongoingProcessManager} from '../../managers/OngoingProcessManager';
 import {clearAllCookiesEverywhere} from '../../utils/cookieAuth';
+import {sleep} from '../../utils/helper-methods';
 
 interface StartLoginParams {
   email?: string;
@@ -74,39 +73,7 @@ export const startBitPayIdAnalyticsInit =
         }
       }
 
-      // Check if Braze EID exists and not the same
-      // Merge ONLY anonymous EIDs
-      // If login with any other BitPayID, we shouldn't delete/merge previous user
-      // Only switch to a new EID with setBrazeEid
-      if (
-        APP.brazeEid &&
-        APP.brazeEid !== eid &&
-        isAnonymousBrazeEid(APP.brazeEid)
-      ) {
-        Analytics.startMergingUser();
-        // Should migrate the user to the new EID
-        logManager.info(
-          '[startBitPayIdAnalyticsInit] Merging current user to new EID: ',
-          eid,
-        );
-        try {
-          await BrazeWrapper.merge(APP.brazeEid, eid);
-          // Emit event to delete old user
-          DeviceEventEmitter.emit(
-            DeviceEmitterEvents.SHOULD_DELETE_BRAZE_USER,
-            {
-              oldEid: APP.brazeEid,
-              newEid: eid,
-            },
-          );
-        } catch (error) {
-          const errMsg =
-            error instanceof Error ? error.message : JSON.stringify(error);
-          logManager.error(
-            `[startBitPayIdAnalyticsInit] Merging current user failed: ${errMsg}`,
-          );
-        }
-      }
+      const previousBrazeEid = APP.brazeEid;
       dispatch(setBrazeEid(eid));
       await dispatch(
         Analytics.identify(eid, {
@@ -115,6 +82,29 @@ export const startBitPayIdAnalyticsInit =
           lastName: familyName,
         }),
       );
+
+      if (
+        previousBrazeEid &&
+        previousBrazeEid !== eid &&
+        isAnonymousBrazeEid(previousBrazeEid)
+      ) {
+        Analytics.startMergingUser();
+        try {
+          logManager.info(
+            '[Braze] Merge oldEid/newEid: ',
+            previousBrazeEid,
+            eid,
+          );
+          await BrazeWrapper.merge(previousBrazeEid, eid);
+        } catch (error) {
+          const errMsg =
+            error instanceof Error ? error.message : JSON.stringify(error);
+          logManager.error(`[Braze] Merge EID failed: ${errMsg}`);
+        }
+        await sleep(5000);
+        Analytics.endMergingUser();
+      }
+
       // Set email notifications and push notifications after Braze EID is set
       dispatch(
         setEmailNotifications(


### PR DESCRIPTION
### Commit f305ce4347e7aa99009934c602a6945c1744cba6

New users could end up with `UNSUBSCRIBED` email status in Braze because `agreedToMarketingCommunications` was propagated through the pairing chain and used to gate the setEmailNotifications call. 
Now **setEmailNotificationsAccepted(true)** is dispatched immediately after account creation, and the `agreedToMarketingCommunications` parameter is removed from the chain. 

The OPTED_IN vs SUBSCRIBED distinction is determined solely by the BitPay user's optInEmailMarketing + verified flags.

[RN-2700](https://bitpayprod.atlassian.net/browse/RN-2700)

---

### Commit a8235395bb8d9b09a8d8a5b3fe35243e574d9fc2

Anonymous Braze tracking data was not migrating to the authenticated user profile on login.

#### Root cause

Braze.changeUser(newEid) and the server-side merge were called in the wrong order, and buffered SDK events were never flushed before switching users.

#### Fix

Added Braze.requestImmediateDataFlush() before Braze.changeUser() in BrazeWrapper.identify to flush buffered anonymous events to Braze servers first.
Reordered the login flow so identify (→ changeUser) runs before the server-side merge API call.
Removed programmatic delete of the anonymous profile — it races against Braze's async merge and can cancel it. The empty shell is harmless and handled by Braze's User Archival policy.

[RN-2699](https://bitpayprod.atlassian.net/browse/RN-2699)