### PR TITLE
Braze: Chore - Upgrade to latest plugin version

### DIFF
--- a/android/app/src/main/java/com/bitpay/wallet/MainActivity.kt
+++ b/android/app/src/main/java/com/bitpay/wallet/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import com.braze.reactbridge.BrazeReactUtils
 import com.braze.ui.inappmessage.BrazeInAppMessageManager
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
@@ -40,6 +41,7 @@ class MainActivity : ReactActivity() {
             return
         }
 
+        BrazeReactUtils.populateInitialPushPayloadFromIntent(intent)
         RNBootSplash.init(this, R.style.BootTheme)
         supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="com_braze_api_key">BRAZE_API_KEY_REPLACE_ME</string>
-  <string translatable="false" name="com_braze_custom_endpoint">sdk.iad-05.braze.com</string>
+  <bool name="com_braze_enable_delayed_initialization">true</bool>
   <bool translatable="false" name="com_braze_firebase_cloud_messaging_registration_enabled">true</bool>
   <string translatable="false" name="com_braze_firebase_cloud_messaging_sender_id">BRAZE_SENDER_ID_REPLACE_ME</string>
   <bool name="com_braze_handle_push_deep_links_automatically">false</bool>

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -7,6 +7,9 @@ declare module '*.svg' {
 declare module '@env' {
   export const PAYPRO_TRUSTED_KEYS: string;
   export const BASE_FIATRATES_MARKETSTATS_URL_DEVELOPMENT: string;
+  export const BRAZE_API_ENDPOINT: string;
+  export const BRAZE_API_KEY_ANDROID: string;
+  export const BRAZE_API_KEY_IOS: string;
   export const BRAZE_EXPORT_API_KEY: string;
   export const BRAZE_MERGE_AND_DELETE_API_KEY: string;
   export const BRAZE_REST_API_ENDPOINT: string;

--- a/ios/BitPayApp/AppDelegate.swift
+++ b/ios/BitPayApp/AppDelegate.swift
@@ -6,6 +6,7 @@ import AppsFlyerLib
 import RNBootSplash
 import BrazeKit
 import BrazeUI
+import braze_react_native_sdk
 import UserNotifications
 import CryptoKit
 
@@ -172,17 +173,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BrazeInAppMessageUIDelega
         window?.makeKeyAndVisible()
 
         // MARK: Braze SDK setup
-        let config = Braze.Configuration(apiKey: "BRAZE_API_KEY_REPLACE_ME", endpoint: "sdk.iad-05.braze.com")
-        config.logger.level = .info
-        config.triggerMinimumTimeInterval = 1
-
-        // `BrazeReactBridge.initBraze(_:)` is an Objective-C selector; we call it dynamically
-        if let brazeObj = BrazeReactBridge.perform(#selector(BrazeReactBridge.initBraze(_:)), with: config)?.takeUnretainedValue() as? Braze {
-            self.braze = brazeObj
+        BrazeReactInitializer.configure({ config in
+            config.logger.level = .info
+            config.triggerMinimumTimeInterval = 1
+        }, postInitialization: { [weak self] braze in
+            self?.braze = braze
             let inAppUI = BrazeInAppMessageUI()
             inAppUI.delegate = self
-            brazeObj.inAppMessagePresenter = inAppUI
-        }
+            braze.inAppMessagePresenter = inAppUI
+        })
 
         // Disable URL caching globally to prevent sensitive data disclosure
         URLCache.shared.removeAllCachedResponses()

--- a/ios/BitPayApp/PrivacyInfo.xcprivacy
+++ b/ios/BitPayApp/PrivacyInfo.xcprivacy
@@ -10,6 +10,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+				<string>1C8F.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,11 +3,11 @@ PODS:
     - AppsFlyerFramework/Main (= 6.17.9)
   - AppsFlyerFramework/Main (6.17.9)
   - boost (1.84.0)
-  - braze-react-native-sdk (16.1.0):
+  - braze-react-native-sdk (20.1.0):
     - boost
-    - BrazeKit (~> 13.2.0)
-    - BrazeLocation (~> 13.2.0)
-    - BrazeUI (~> 13.2.0)
+    - BrazeKit (~> 14.0.4)
+    - BrazeLocation (~> 14.0.4)
+    - BrazeUI (~> 14.0.4)
     - DoubleConversion
     - fast_float
     - fmt
@@ -34,11 +34,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - BrazeKit (13.2.1)
-  - BrazeLocation (13.2.1):
-    - BrazeKit (= 13.2.1)
-  - BrazeUI (13.2.1):
-    - BrazeKit (= 13.2.1)
+  - BrazeKit (14.0.4)
+  - BrazeLocation (14.0.4):
+    - BrazeKit (= 14.0.4)
+  - BrazeUI (14.0.4):
+    - BrazeKit (= 14.0.4)
   - BVLinearGradient (2.6.2):
     - React-Core
   - CookieManager (6.3.0):
@@ -3955,10 +3955,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppsFlyerFramework: 4f9a8237d40e9093941aef760cd77d606238aedd
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  braze-react-native-sdk: b3bd4594310a390c12beb06b02bf0fbbfcbca7e0
-  BrazeKit: dc74d3969d42e3f890461fe842e9422480269774
-  BrazeLocation: 1919682502f70d3f215215b9ef2b56836dde4a9e
-  BrazeUI: b49f51ff3eb88657d6a97e6b3688e03a7255cbe1
+  braze-react-native-sdk: 12e813e4a989839c912c87acc4a2ab72c5652df5
+  BrazeKit: ba951d2299c1d16b541cf35cdd7250d03e28a0fb
+  BrazeLocation: d6938a737f123bb9e6632246d1abea40eeb12768
+  BrazeUI: 1d733e1dea4d81f95f261b52cc6e4b91a0eccca8
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   CookieManager: ae06e97a79ea66832add0c8aa501a7986bdbb72d
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
@@ -4101,4 +4101,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 91e915b372fe50cffa909299965ad28bb54bc3f7
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@bitpay-labs/bitcore-wallet-client": "11.10.0",
-    "@braze/react-native-sdk": "16.1.0",
+    "@braze/react-native-sdk": "20.1.0",
     "@ethersproject/shims": "5.7.0",
     "@freakycoder/react-native-bounceable": "0.2.5",
     "@gorhom/bottom-sheet": "5.2.6",

--- a/scripts/braze-config.js
+++ b/scripts/braze-config.js
@@ -15,27 +15,9 @@ const dotenv = require('dotenv');
     throw result.error;
   }
 
-  // Configure Braze for iOS
-  if (process.env.BRAZE_API_KEY_IOS) {
-    const brazeConfigFileIOS = `${__dirname}/../ios/BitPayApp/AppDelegate.swift`;
-    let contentiOS = fs.readFileSync(brazeConfigFileIOS, 'utf8');
-    contentiOS = contentiOS.replace(
-      'BRAZE_API_KEY_REPLACE_ME',
-      process.env.BRAZE_API_KEY_IOS,
-    );
-    fs.writeFileSync(brazeConfigFileIOS, contentiOS);
-  }
-
   // Configure Braze for Android
   const brazeConfigFileAndroid = `${__dirname}/../android/app/src/main/res/values/braze.xml`;
   let contentAndroid = fs.readFileSync(brazeConfigFileAndroid, 'utf8');
-
-  if (process.env.BRAZE_API_KEY_ANDROID) {
-    contentAndroid = contentAndroid.replace(
-      'BRAZE_API_KEY_REPLACE_ME',
-      process.env.BRAZE_API_KEY_ANDROID,
-    );
-  }
 
   if (process.env.BRAZE_SENDER_ID) {
     contentAndroid = contentAndroid.replace(

--- a/src/lib/Braze/index.ts
+++ b/src/lib/Braze/index.ts
@@ -1,6 +1,12 @@
 import Braze from '@braze/react-native-sdk';
 import axios from 'axios';
-import {BRAZE_MERGE_AND_DELETE_API_KEY, BRAZE_REST_API_ENDPOINT} from '@env';
+import {
+  BRAZE_API_ENDPOINT,
+  BRAZE_API_KEY_ANDROID,
+  BRAZE_API_KEY_IOS,
+  BRAZE_MERGE_AND_DELETE_API_KEY,
+  BRAZE_REST_API_ENDPOINT,
+} from '@env';
 import {checkNotifications, RESULTS} from 'react-native-permissions';
 import {NativeModules, Platform} from 'react-native';
 import {logManager} from '../../managers/LogManager';
@@ -296,7 +302,9 @@ class BrazeClientWrapper {
   }
 
   private async initializeSdk(): Promise<void> {
-    return Promise.resolve();
+    const apiKey =
+      Platform.OS === 'ios' ? BRAZE_API_KEY_IOS : BRAZE_API_KEY_ANDROID;
+    Braze.initialize(apiKey, BRAZE_API_ENDPOINT);
   }
 }
 

--- a/src/utils/braze.ts
+++ b/src/utils/braze.ts
@@ -1,5 +1,4 @@
 import {
-  BannerNewsFeedCard,
   CaptionedContentCard,
   ClassicContentCard,
   ContentCard,
@@ -25,12 +24,6 @@ export const DEFAULT_CLASSIC_CONTENT_CARD: ClassicContentCard = {
   type: 'Classic',
   title: 'Lorem Ipsum',
   cardDescription: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-};
-
-export const isBannerContentCard = (
-  contentCard: BannerNewsFeedCard,
-): contentCard is BannerNewsFeedCard => {
-  return contentCard.type === 'Banner';
 };
 
 export const isCaptionedContentCard = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,10 +1490,10 @@
     web3 "4.16.0"
     xrpl "2.13.0"
 
-"@braze/react-native-sdk@16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@braze/react-native-sdk/-/react-native-sdk-16.1.0.tgz#d66c838a4eb38d2c5390d3dc4168767d7808a55a"
-  integrity sha512-IUoL+36KELKk4w6tlNdYjJ2fi0QBs2HT+yhYsupwfntvbbKPdSqlKrXU0e/xAyDv34qACcIxl2AYxeeD7Vhptg==
+"@braze/react-native-sdk@20.1.0":
+  version "20.1.0"
+  resolved "https://registry.yarnpkg.com/@braze/react-native-sdk/-/react-native-sdk-20.1.0.tgz#3ef34c045e561affa7756ad8b88c231f8390192f"
+  integrity sha512-OM4Nwj2Eld6ICTFFpQQ/EgzG+f+DyW+sN9Y2HyavWIkreBbYXkEtuRPbAmplG4jw8RI4Gqr7S6RPhs0gKQDgfw==
 
 "@cbor-extract/cbor-extract-darwin-arm64@2.2.0":
   version "2.2.0"


### PR DESCRIPTION
Upgrades the Braze React Native SDK to v20.1.0 and migrates to its new delayed-initialization pattern, where the API key and endpoint are no longer hardcoded in native config files but instead passed from the JS layer at runtime.

https://github.com/braze-inc/braze-react-native-sdk/blob/master/CHANGELOG.md#2010
