### PR TITLE
TSS: Fix - Cancel ceremony when unmounting mid-join (new-join path)

### DIFF
--- a/src/navigation/wallet/screens/JoinTSSWallet.tsx
+++ b/src/navigation/wallet/screens/JoinTSSWallet.tsx
@@ -189,11 +189,15 @@ const JoinTSSWallet: React.FC<Props> = ({navigation, route}) => {
 
   const resumeKeyId = route.params?.keyId;
   const activeKeyIdRef = useRef<string | null>(resumeKeyId || null);
+  // new-join only
+  const cancelOnCreateRef = useRef(false);
 
   useEffect(() => {
     return () => {
       if (activeKeyIdRef.current) {
         dispatch(cancelTSSCeremony(activeKeyIdRef.current));
+      } else {
+        cancelOnCreateRef.current = true;
       }
     };
   }, []);
@@ -325,6 +329,9 @@ const JoinTSSWallet: React.FC<Props> = ({navigation, route}) => {
           onRoundReady: () => setIsCeremonyInRounds(true),
           onKeyCreated: (keyId: string) => {
             activeKeyIdRef.current = keyId;
+            if (cancelOnCreateRef.current) {
+              dispatch(cancelTSSCeremony(keyId));
+            }
           },
         }),
       );


### PR DESCRIPTION
Added `cancelOnCreateRef` to signal deferred cancellation: if the component unmounts before the keyId is known, the flag is set, and the first thing `onKeyCreated` does when it eventually fires is dispatch `cancelTSSCeremony` — closing the orphan immediately