### PR TITLE
Portfolio: Fix - Hide balance chart and asset list loaders on fresh install

### DIFF
--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -75,7 +75,7 @@ import type {Rates} from '../../../store/rate/rate.models';
 import {
   getQuoteCurrency,
   getVisibleWalletsFromKeys,
-  walletHasNonZeroLiveBalance,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../utils/portfolio/assets';
 import {sortNewestFirst} from '../../../utils/braze';
 import buildHomeExchangeRateItems from './homeExchangeRates';
@@ -123,7 +123,7 @@ const HomeRoot: React.FC<HomeScreenProps> = ({route, navigation}) => {
   );
 
   const hasAnyVisibleWalletBalance = useMemo(() => {
-    return visibleWallets.some(walletHasNonZeroLiveBalance);
+    return walletsHaveNonZeroLiveBalance(visibleWallets);
   }, [visibleWallets]);
 
   const showPortfolioAllocationSection =

--- a/src/navigation/tabs/home/components/AllocationSection.tsx
+++ b/src/navigation/tabs/home/components/AllocationSection.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../../utils/portfolio/allocation';
 import {
   getVisibleWalletsFromKeys,
-  walletHasNonZeroLiveBalance,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../../utils/portfolio/assets';
 import {
   Black,
@@ -451,7 +451,7 @@ const AllocationSection: React.FC = () => {
   );
 
   const hasAnyVisibleWalletBalance = useMemo(() => {
-    return visibleWallets.some(walletHasNonZeroLiveBalance);
+    return walletsHaveNonZeroLiveBalance(visibleWallets);
   }, [visibleWallets]);
 
   const walletRows: AllocationWallet[] = useMemo(() => {

--- a/src/navigation/tabs/home/components/AssetsSection.tsx
+++ b/src/navigation/tabs/home/components/AssetsSection.tsx
@@ -13,6 +13,7 @@ import {
   GainLossMode,
   buildAssetPreviewRowItemsFromWallets,
   getVisibleWalletsFromKeys,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../../utils/portfolio/assets';
 import AssetsGainLossDropdown from './AssetsGainLossDropdown';
 import {useAppSelector} from '../../../../utils/hooks';
@@ -89,6 +90,9 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
   const visibleWallets = useMemo(() => {
     return getVisibleWalletsFromKeys(keys, homeCarouselConfig);
   }, [homeCarouselConfig, keys]);
+  const hasAnyVisibleWalletBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(visibleWallets);
+  }, [visibleWallets]);
   const topAssetKeys = useMemo(() => {
     const allocationData = buildAllocationDataFromWalletRows(
       visibleWallets.map(toAllocationWallet),
@@ -177,6 +181,7 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
     return nextItems.slice(0, 4);
   }, [enabled, isFiatLoading, previewItems, topAssetKeys, visibleItems]);
   const shouldShowActivationPlaceholder =
+    hasAnyVisibleWalletBalance &&
     !items.length &&
     (!!visibleWallets.length || !!portfolio.populateStatus?.inProgress);
 

--- a/src/navigation/tabs/home/components/PortfolioBalance.tsx
+++ b/src/navigation/tabs/home/components/PortfolioBalance.tsx
@@ -50,6 +50,7 @@ import {maskIfHidden} from '../../../../utils/hideBalances';
 import {
   getVisibleKeysFromKeys,
   getVisibleWalletsFromKeys,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../../utils/portfolio/assets';
 import {resolveActivePortfolioDisplayQuoteCurrency} from '../../../../portfolio/ui/common';
 import usePortfolioBalanceChartSurface from '../../../../portfolio/ui/hooks/usePortfolioBalanceChartSurface';
@@ -240,9 +241,14 @@ const PortfolioBalanceContent = () => {
     return Array.from(byId.values());
   }, [homeCarouselConfig, keys]);
 
+  const hasAnyChartWalletBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(walletsAcrossKeys);
+  }, [walletsAcrossKeys]);
+  const balanceChartsEnabled =
+    canRenderPortfolioBalanceCharts && hasAnyChartWalletBalance;
   const hasChartData = useMemo(() => {
-    return canRenderPortfolioBalanceCharts && walletsAcrossKeys.length > 0;
-  }, [canRenderPortfolioBalanceCharts, walletsAcrossKeys.length]);
+    return balanceChartsEnabled && walletsAcrossKeys.length > 0;
+  }, [balanceChartsEnabled, walletsAcrossKeys.length]);
   const shouldLeftAlignTopSection = hasChartData && !hideAllBalances;
   const canCollapseChart =
     shouldLeftAlignTopSection && chartHasRenderableSeries;
@@ -419,7 +425,7 @@ const PortfolioBalanceContent = () => {
     quoteCurrency,
     fallbackBalance: totalBalanceIncludingCoinbase,
     fallbackCurrency: defaultAltCurrency.isoCode,
-    enabled: canRenderPortfolioBalanceCharts,
+    enabled: balanceChartsEnabled,
     resetKey: chartLifecycleKey,
   });
   const commonBalanceHistoryChartProps: BalanceHistoryChartProps = {
@@ -452,12 +458,12 @@ const PortfolioBalanceContent = () => {
   }, [chartLifecycleKey]);
 
   useEffect(() => {
-    if (canRenderPortfolioBalanceCharts) {
+    if (balanceChartsEnabled) {
       return;
     }
 
     setChartHasRenderableSeries(false);
-  }, [canRenderPortfolioBalanceCharts]);
+  }, [balanceChartsEnabled]);
 
   const displayedPortfolioBalance =
     typeof balanceChartSurface.selectedBalance === 'number'
@@ -503,7 +509,7 @@ const PortfolioBalanceContent = () => {
     visibleLastDayBalance,
   ]);
   const displayedChangeRowData =
-    canRenderPortfolioBalanceCharts && balanceChartSurface.changeRowData
+    balanceChartsEnabled && balanceChartSurface.changeRowData
       ? balanceChartSurface.changeRowData
       : lastDayChangeRowData;
   const shouldRenderPortfolioBalance = showPortfolioValue === true;
@@ -616,7 +622,7 @@ const PortfolioBalanceContent = () => {
         />
       ) : null}
 
-      {!hideAllBalances && canRenderPortfolioBalanceCharts ? (
+      {!hideAllBalances && balanceChartsEnabled ? (
         hasChartData ? (
           <ChartStage
             onLayout={e => {

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -177,7 +177,10 @@ import {ExternalServicesScreens} from '../../services/ExternalServicesGroup';
 import {AllocationDonutLegendCard} from '../../tabs/home/components/AllocationSection';
 import {AllocationRowsList} from '../../tabs/home/screens/Allocation';
 import {buildAllocationDataFromWalletRows} from '../../../utils/portfolio/allocation';
-import {getQuoteCurrency} from '../../../utils/portfolio/assets';
+import {
+  getQuoteCurrency,
+  walletsHaveNonZeroLiveBalance,
+} from '../../../utils/portfolio/assets';
 
 export type AccountDetailsScreenParamList = {
   selectedAccountAddress: string;
@@ -459,6 +462,11 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
       ),
     [key, selectedAccountAddress],
   );
+  const hasAnyAccountWalletBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(keyFullWalletObjs);
+  }, [keyFullWalletObjs]);
+  const canRenderAccountBalanceChart =
+    canRenderPortfolioBalanceCharts && hasAnyAccountWalletBalance;
   const accountWalletIds = useMemo(
     () => keyFullWalletObjs.map(wallet => wallet.id).filter(Boolean),
     [keyFullWalletObjs],
@@ -503,7 +511,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     wallets: keyFullWalletObjs,
     quoteCurrency: displayQuoteCurrency,
     fallbackCurrency: defaultAltCurrency.isoCode,
-    enabled: canRenderPortfolioBalanceCharts,
+    enabled: canRenderAccountBalanceChart,
     resetKey: `${keyId}:${selectedAccountAddress || ''}`,
   });
   const totalBalance =
@@ -1474,7 +1482,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
               </Row>
             </TouchableOpacity>
 
-            {canRenderPortfolioBalanceCharts && !hideAllBalances ? (
+            {canRenderAccountBalanceChart && !hideAllBalances ? (
               <BalanceHistoryChart
                 wallets={keyFullWalletObjs}
                 quoteCurrency={displayQuoteCurrency}
@@ -1646,7 +1654,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     accountChartPreContent,
     accountItem?.fiatLockedBalanceFormat,
     accountItem?.receiveAddress,
-    canRenderPortfolioBalanceCharts,
+    canRenderAccountBalanceChart,
     debouncedLoadHistory,
     displayQuoteCurrency,
     defaultAltCurrency.isoCode,

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -147,6 +147,7 @@ import {
   getVisibleWalletsForKey,
   getQuoteCurrency,
   isPopulateLoadingForWallets,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../utils/portfolio/assets';
 import usePortfolioGainLossSummary from '../../../portfolio/ui/hooks/usePortfolioGainLossSummary';
 
@@ -695,6 +696,11 @@ const KeyOverview = () => {
   const visibleKeyWallets = useMemo(() => {
     return getVisibleWalletsForKey(key);
   }, [key]);
+  const hasAnyVisibleKeyWalletBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(visibleKeyWallets);
+  }, [visibleKeyWallets]);
+  const canRenderKeyBalanceChart =
+    canRenderPortfolioBalanceCharts && hasAnyVisibleKeyWalletBalance;
   const visibleKeyWalletIds = useMemo(
     () => visibleKeyWallets.map(wallet => wallet.id).filter(Boolean),
     [visibleKeyWallets],
@@ -704,7 +710,7 @@ const KeyOverview = () => {
     quoteCurrency,
     fallbackBalance: totalBalance,
     fallbackCurrency: defaultAltCurrency.isoCode,
-    enabled: canRenderPortfolioBalanceCharts,
+    enabled: canRenderKeyBalanceChart,
     resetKey: id,
   });
 
@@ -734,7 +740,7 @@ const KeyOverview = () => {
     });
   }, [portfolio.populateStatus, visibleKeyWallets]);
 
-  const showAllocationGainLossFooter = canRenderPortfolioBalanceCharts;
+  const showAllocationGainLossFooter = canRenderKeyBalanceChart;
 
   const maybeActivateAllocationGainLoss = useCallback(() => {
     if (shouldLoadAllocationGainLoss || !showAllocationGainLossFooter) {
@@ -1171,7 +1177,7 @@ const KeyOverview = () => {
             )}
           </TouchableOpacity>
 
-          {canRenderPortfolioBalanceCharts && !hideAllBalances ? (
+          {canRenderKeyBalanceChart && !hideAllBalances ? (
             <BalanceHistoryChart
               wallets={visibleKeyWallets}
               quoteCurrency={quoteCurrency}
@@ -1212,7 +1218,7 @@ const KeyOverview = () => {
       </>
     );
   }, [
-    canRenderPortfolioBalanceCharts,
+    canRenderKeyBalanceChart,
     defaultAltCurrency.isoCode,
     dispatch,
     balanceChartSurface,

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -153,7 +153,10 @@ import {ExternalServicesScreens} from '../../services/ExternalServicesGroup';
 import {isTSSKey} from '../../../store/wallet/effects/tss-send/tss-send';
 import {logManager} from '../../../managers/LogManager';
 import type {RootState} from '../../../store';
-import {getQuoteCurrency} from '../../../utils/portfolio/assets';
+import {
+  getQuoteCurrency,
+  walletsHaveNonZeroLiveBalance,
+} from '../../../utils/portfolio/assets';
 
 export type WalletDetailsScreenParamList = {
   walletId: string;
@@ -601,11 +604,16 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
     });
   }, [committedPortfolioQuoteCurrency, defaultAltCurrency.isoCode]);
   const chartWallets = useMemo(() => [fullWalletObj], [fullWalletObj]);
+  const walletHasLiveBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(chartWallets);
+  }, [chartWallets]);
+  const canRenderWalletBalanceChart =
+    canRenderPortfolioBalanceCharts && walletHasLiveBalance;
   const balanceChartSurface = usePortfolioBalanceChartSurface({
     wallets: chartWallets,
     quoteCurrency: chartQuoteCurrency,
     fallbackCurrency: defaultAltCurrency.isoCode,
-    enabled: canRenderPortfolioBalanceCharts,
+    enabled: canRenderWalletBalanceChart,
     resetKey: `${walletId}:${copayerId || ''}`,
   });
 
@@ -663,15 +671,13 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
   const [needActionPendingTxps, setNeedActionPendingTxps] = useState<any[]>([]);
   const [needActionUnsentTxps, setNeedActionUnsentTxps] = useState<any[]>([]);
   const [isScrolling, setIsScrolling] = useState<boolean>(false);
-  const walletBalanceSat = Number(fullWalletObj.balance?.sat || 0);
   const {hasAnySnapshots: walletHasSnapshots, checked: walletSnapshotsChecked} =
     usePortfolioWalletSnapshotPresence({
       wallets: chartWallets,
-      enabled: canRenderPortfolioBalanceCharts,
+      enabled: canRenderWalletBalanceChart,
     });
   const showWalletBalanceChart =
-    canRenderPortfolioBalanceCharts &&
-    walletBalanceSat > 0 &&
+    canRenderWalletBalanceChart &&
     (!walletSnapshotsChecked || walletHasSnapshots);
   const walletChartChangeRowStyle = useMemo(() => ({marginTop: 2}), []);
 

--- a/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.spec.tsx
+++ b/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.spec.tsx
@@ -54,6 +54,7 @@ jest.mock('../../../../utils/portfolio/assets', () => ({
   hasCompletedPopulateForWallets: jest.fn(() => false),
   isPopulateLoadingForWallets: jest.fn(() => false),
   walletHasNonZeroLiveBalance: jest.fn(() => false),
+  walletsHaveNonZeroLiveBalance: jest.fn(() => true),
 }));
 
 jest.mock('../../../../utils/fiatAmountText', () => ({
@@ -114,6 +115,11 @@ const {hasCompletedPopulateForWallets} = jest.requireMock(
 ) as {
   hasCompletedPopulateForWallets: jest.Mock;
 };
+const {walletsHaveNonZeroLiveBalance} = jest.requireMock(
+  '../../../../utils/portfolio/assets',
+) as {
+  walletsHaveNonZeroLiveBalance: jest.Mock;
+};
 
 const sharedFactory = () =>
   ({
@@ -151,6 +157,8 @@ describe('AssetBalanceHistoryScreen', () => {
     usePortfolioAnalysis.mockClear();
     hasCompletedPopulateForWallets.mockClear();
     hasCompletedPopulateForWallets.mockReturnValue(false);
+    walletsHaveNonZeroLiveBalance.mockClear();
+    walletsHaveNonZeroLiveBalance.mockReturnValue(true);
   });
 
   it('updates parent analysis when the chart timeframe changes', async () => {

--- a/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.tsx
+++ b/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.tsx
@@ -16,6 +16,7 @@ import {
   hasCompletedPopulateForWallets,
   isPopulateLoadingForWallets,
   walletHasNonZeroLiveBalance,
+  walletsHaveNonZeroLiveBalance,
 } from '../../../../utils/portfolio/assets';
 import {shouldUseCompactFiatAmountText} from '../../../../utils/fiatAmountText';
 import ExchangeRateScreenLayout from './ExchangeRateScreenLayout';
@@ -182,6 +183,9 @@ const AssetBalanceHistoryScreen = ({
   const hasCompletedFullPortfolioPopulate = useAppSelector(
     selectHasCompletedFullPortfolioPopulate,
   );
+  const hasAnyAssetWalletBalance = useMemo(() => {
+    return walletsHaveNonZeroLiveBalance(shared.assetWallets);
+  }, [shared.assetWallets]);
   const hasCompletedAssetPopulate = useMemo(() => {
     const liveBalanceWallets = shared.assetWallets.filter(
       walletHasNonZeroLiveBalance,
@@ -200,6 +204,7 @@ const AssetBalanceHistoryScreen = ({
   }, [hasCompletedFullPortfolioPopulate, populateStatus, shared.assetWallets]);
   const balanceHistoryEnabled =
     shared.showPortfolioValue &&
+    hasAnyAssetWalletBalance &&
     hasCompletedAssetPopulate &&
     shared.hasWalletsForAsset;
   const analysis = usePortfolioAnalysis({
@@ -313,11 +318,13 @@ const AssetBalanceHistoryScreen = ({
   const shouldRenderBalanceChart = useMemo(() => {
     return (
       shared.showPortfolioValue &&
+      hasAnyAssetWalletBalance &&
       hasCompletedAssetPopulate &&
       !shared.hideAllBalances &&
       shared.hasWalletsForAsset
     );
   }, [
+    hasAnyAssetWalletBalance,
     hasCompletedAssetPopulate,
     shared.showPortfolioValue,
     shared.hideAllBalances,

--- a/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
+++ b/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
@@ -347,6 +347,7 @@ jest.mock('../components/WalletIcons', () => {
     default: {
       Cog: Icon,
       Encrypt: Icon,
+      Network: Icon,
       RequestAmount: Icon,
       Settings: Icon,
       ShareAddress: Icon,
@@ -401,6 +402,7 @@ jest.mock('../../../utils/portfolio/assets', () => ({
   getVisibleWalletsForKey: jest.fn((key: any) => key?.wallets || []),
   isPopulateLoadingForWallets: jest.fn(() => false),
   walletHasNonZeroLiveBalance: jest.fn(() => true),
+  walletsHaveNonZeroLiveBalance: jest.fn(() => true),
 }));
 
 jest.mock('../../../utils/portfolio/allocation', () => ({
@@ -490,6 +492,9 @@ jest.mock('@react-native-clipboard/clipboard', () => ({
 const mockBalanceHistoryChart = jest.requireMock(
   '../../../components/charts/BalanceHistoryChart',
 ) as jest.Mock;
+const mockWalletsHaveNonZeroLiveBalance = jest.requireMock(
+  '../../../utils/portfolio/assets',
+).walletsHaveNonZeroLiveBalance as jest.Mock;
 const mockUsePortfolioWalletSnapshotPresence =
   usePortfolioWalletSnapshotPresence as jest.Mock;
 
@@ -677,6 +682,7 @@ const chartSurfaceCases: Array<[string, () => React.ReactElement, string]> = [
 describe('portfolio chart visibility guards', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWalletsHaveNonZeroLiveBalance.mockReturnValue(true);
     resetState(false);
   });
 
@@ -793,6 +799,17 @@ describe('portfolio chart visibility guards', () => {
     expect(mockBalanceHistoryChart).toHaveBeenCalled();
   });
 
+  it('does not mount the Home portfolio balance chart when all visible wallets have zero balance', async () => {
+    resetState(true, {completedFullPopulate: true});
+    mockWalletsHaveNonZeroLiveBalance.mockReturnValue(false);
+
+    await act(async () => {
+      renderWithTheme(<PortfolioBalance />);
+    });
+
+    expect(mockBalanceHistoryChart).not.toHaveBeenCalled();
+  });
+
   it('honors the persisted Home chart collapsed state before chart diagnostics arrive', async () => {
     resetState(true, {
       completedFullPopulate: true,
@@ -878,6 +895,20 @@ describe('portfolio chart visibility guards', () => {
       });
 
       expect(mockBalanceHistoryChart).toHaveBeenCalled();
+    },
+  );
+
+  it.each(chartSurfaceCases)(
+    'does not mount the %s balance chart when its wallet scope has zero balance',
+    async (_screen, makeScreen) => {
+      resetState(true);
+      mockWalletsHaveNonZeroLiveBalance.mockReturnValue(false);
+
+      await act(async () => {
+        renderWithTheme(makeScreen());
+      });
+
+      expect(mockBalanceHistoryChart).not.toHaveBeenCalled();
     },
   );
 

--- a/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
@@ -1,7 +1,18 @@
 import {
+  PORTFOLIO_BWS_CLIENT_VERSION_HEADER,
   appendPortfolioTxHistoryCacheBustParam,
   buildPortfolioTxHistoryRequestPath,
 } from './txHistoryRequest';
+import {version as bitcoreWalletClientVersion} from '@bitpay-labs/bitcore-wallet-client/package.json';
+
+describe('PORTFOLIO_BWS_CLIENT_VERSION_HEADER', () => {
+  it('matches the installed BWC package version in BWS-compatible format', () => {
+    expect(PORTFOLIO_BWS_CLIENT_VERSION_HEADER).toBe(
+      `bwc-${bitcoreWalletClientVersion}`,
+    );
+    expect(PORTFOLIO_BWS_CLIENT_VERSION_HEADER).toMatch(/^bwc-\d+\.\d+\.\d+$/);
+  });
+});
 
 describe('buildPortfolioTxHistoryRequestPath', () => {
   it('adds tokenAddress, reverse=1, and multisig params for oldest-first paging', () => {

--- a/src/portfolio/adapters/rn/txHistoryRequest.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.ts
@@ -2,6 +2,7 @@ import type {BwsConfig} from '../../core/shared/bws';
 import type {Tx} from '../../core/types';
 import type {PortfolioRuntimeWalletCredentials} from '../../core/runtimeWalletCredentials';
 import type {NitroResponse as NitroFetchResponse} from 'react-native-nitro-fetch';
+import {version as bitcoreWalletClientVersion} from '@bitpay-labs/bitcore-wallet-client/package.json';
 import {
   buildTokenWalletTxHistoryContextFromCredentials,
   normalizeTokenWalletTxHistoryPage,
@@ -13,7 +14,7 @@ import {
   takeNextPortfolioTransferredSignHandleOnRuntime,
 } from './txHistorySigning';
 
-export const PORTFOLIO_BWS_CLIENT_VERSION_HEADER = 'bwc-11.7.0';
+export const PORTFOLIO_BWS_CLIENT_VERSION_HEADER = `bwc-${bitcoreWalletClientVersion}`;
 const TXHISTORY_BASE_PATH = '/v1/txhistory/';
 const TXHISTORY_CACHE_BUST_PARAM = 'r';
 

--- a/src/portfolio/adapters/rn/txHistorySigning.spec.ts
+++ b/src/portfolio/adapters/rn/txHistorySigning.spec.ts
@@ -59,7 +59,10 @@ import {
   setPortfolioTxHistorySigningDispatchContextOnRuntime,
   takeNextPortfolioTransferredSignHandleOnRuntime,
 } from './txHistorySigning';
-import {fetchPortfolioTxHistoryPageByRequest} from './txHistoryRequest';
+import {
+  PORTFOLIO_BWS_CLIENT_VERSION_HEADER,
+  fetchPortfolioTxHistoryPageByRequest,
+} from './txHistoryRequest';
 
 describe('txHistorySigning runtime context', () => {
   beforeEach(() => {
@@ -146,6 +149,10 @@ describe('txHistorySigning runtime context', () => {
     );
     expect(request.headers).toEqual(
       expect.arrayContaining([
+        {
+          key: 'x-client-version',
+          value: PORTFOLIO_BWS_CLIENT_VERSION_HEADER,
+        },
         {key: 'x-identity', value: 'copayer-1'},
         {key: 'x-signature', value: '3006020101020101'},
       ]),

--- a/src/utils/portfolio/assets.pure.spec.ts
+++ b/src/utils/portfolio/assets.pure.spec.ts
@@ -118,6 +118,7 @@ import {
   getVisibleWalletsFromKeys,
   getWalletLiveAtomicBalance,
   walletHasNonZeroLiveBalance,
+  walletsHaveNonZeroLiveBalance,
   canNavigateToExchangeRateForAssetRowItem,
   getPopulateLoadingByAssetKey,
   hasCompletedPopulateForWallets,
@@ -840,6 +841,31 @@ describe('walletHasNonZeroLiveBalance', () => {
   it('returns true for an ETH wallet with crypto balance', () => {
     const wallet = {chain: 'eth', balance: {sat: 0, crypto: '0.5'}} as any;
     expect(walletHasNonZeroLiveBalance(wallet)).toBe(true);
+  });
+});
+
+describe('walletsHaveNonZeroLiveBalance', () => {
+  it('returns false for empty or undefined wallet lists', () => {
+    expect(walletsHaveNonZeroLiveBalance(undefined)).toBe(false);
+    expect(walletsHaveNonZeroLiveBalance([])).toBe(false);
+  });
+
+  it('returns false when every wallet has zero balance', () => {
+    const wallets = [
+      {chain: 'btc', balance: {sat: 0, crypto: '0'}},
+      {chain: 'eth', balance: {sat: 0, crypto: '0'}},
+    ] as any;
+
+    expect(walletsHaveNonZeroLiveBalance(wallets)).toBe(false);
+  });
+
+  it('returns true when at least one wallet has a non-zero live balance', () => {
+    const wallets = [
+      {chain: 'btc', balance: {sat: 0, crypto: '0'}},
+      {chain: 'eth', balance: {sat: 0, crypto: '0.5'}},
+    ] as any;
+
+    expect(walletsHaveNonZeroLiveBalance(wallets)).toBe(true);
   });
 });
 

--- a/src/utils/portfolio/assets.ts
+++ b/src/utils/portfolio/assets.ts
@@ -953,6 +953,12 @@ export const walletHasNonZeroLiveBalance = (wallet: Wallet): boolean => {
   return liveAtomicBalance > 0n;
 };
 
+export const walletsHaveNonZeroLiveBalance = (
+  wallets: Wallet[] | undefined,
+): boolean => {
+  return (wallets || []).some(walletHasNonZeroLiveBalance);
+};
+
 export const getWalletsMatchingExchangeRateAsset = (args: {
   wallets: Wallet[] | undefined;
   currencyAbbreviation?: string;


### PR DESCRIPTION
Balance charts and asset lists now only appear when at least one wallet has a non-zero balance. Also ensures portfolio populate tx history requests pass the currently installed BWC version.