### PR TITLE
Buy: Fix - Unhide EVM account when a new wallet is created via Buy Crypto

### DIFF
--- a/src/navigation/services/components/externalServicesWalletSelector.tsx
+++ b/src/navigation/services/components/externalServicesWalletSelector.tsx
@@ -34,6 +34,7 @@ import {
   WrongPasswordError,
 } from '../../wallet/components/ErrorMessages';
 import {showWalletError} from '../../../store/wallet/effects/errors/errors';
+import {toggleHideAccount} from '../../../store/wallet/wallet.actions';
 import {Analytics} from '../../../store/analytics/analytics.effects';
 import SheetModal from '../../../components/modal/base/sheet/SheetModal';
 import GlobalSelect, {
@@ -542,6 +543,21 @@ const ExternalServicesWalletSelector: React.FC<
         logger.debug(
           `Added ${createdToWallet?.currencyAbbreviation} wallet from Buy Crypto`,
         );
+        if (
+          context === 'buyCrypto' &&
+          createdToWallet?.receiveAddress &&
+          createNewWalletData.key.evmAccountsInfo?.[
+            createdToWallet.receiveAddress
+          ]?.hideAccount
+        ) {
+          dispatch(
+            toggleHideAccount({
+              keyId: createNewWalletData.key.id,
+              accountAddress: createdToWallet.receiveAddress,
+              accountToggleSelected: false,
+            }),
+          );
+        }
         dispatch(
           Analytics.track('Created Basic Wallet', {
             coin: createNewWalletData.currency.currencyAbbreviation,


### PR DESCRIPTION
When buying a token (e.g. USDC on Ethereum) whose parent EVM account was previously hidden, the newly created wallet would appear visible while the rest of the account (ETH, Polygon, Arbitrum, etc.) remained hidden, causing an inconsistent state on the home screen.

Fix: after addWallet() succeeds in the Buy Crypto flow, check if the created wallet's receive address belongs to a hidden EVM account and if so, unhide the entire account automatically.