### PR TITLE
Portfolio: Fix - Don't clear snapshots on network failures

### DIFF
--- a/src/components/charts/BalanceHistoryChart.spec.tsx
+++ b/src/components/charts/BalanceHistoryChart.spec.tsx
@@ -519,10 +519,14 @@ describe('BalanceHistoryChart', () => {
 
   it('preserves an already visible series while chart data is not ready when requested', async () => {
     let renderer!: TestRenderer.ReactTestRenderer;
+    const onSelectedBalanceChange = jest.fn();
 
     await act(async () => {
       renderer = TestRenderer.create(
-        balanceHistoryChart({showLoaderWhenNoSnapshots: true}),
+        balanceHistoryChart({
+          showLoaderWhenNoSnapshots: true,
+          onSelectedBalanceChange,
+        }),
       );
     });
 
@@ -537,6 +541,7 @@ describe('BalanceHistoryChart', () => {
           showLoaderWhenNoSnapshots: false,
           isBalanceChartDataReadyToQuery: false,
           preserveVisibleSeriesWhileNotReady: true,
+          onSelectedBalanceChange,
         }),
       );
     });
@@ -547,7 +552,89 @@ describe('BalanceHistoryChart', () => {
       mockOneDaySeries.graphPoints,
     );
     expect(latestInteractiveLineChartProps.hideLineWhileLoading).toBe(false);
+    expect(latestInteractiveLineChartProps.enablePanGesture).toBe(true);
+
+    await act(async () => {
+      latestInteractiveLineChartProps.onGestureStart();
+      latestInteractiveLineChartProps.onPointSelected(mockOneDayPoint);
+    });
+
+    expect(onSelectedBalanceChange).toHaveBeenLastCalledWith(100);
+  });
+
+  it('defers a stale-preserved timeframe switch until chart data is ready', async () => {
+    jest.useFakeTimers();
+    mockRunPortfolioBalanceChartViewModelQuery
+      .mockResolvedValueOnce({__series: mockOneDaySeries})
+      .mockResolvedValueOnce({__series: mockOneWeekSeries});
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        balanceHistoryChart({showLoaderWhenNoSnapshots: true}),
+      );
+    });
+
+    expect(mockRunPortfolioBalanceChartViewModelQuery).toHaveBeenCalledTimes(1);
+    expect(latestInteractiveLineChartProps.points).toBe(
+      mockOneDaySeries.graphPoints,
+    );
+
+    await act(async () => {
+      renderer.update(
+        balanceHistoryChart({
+          showLoaderWhenNoSnapshots: false,
+          isBalanceChartDataReadyToQuery: false,
+          preserveVisibleSeriesWhileNotReady: true,
+        }),
+      );
+    });
+
+    expect(latestInteractiveLineChartProps.enablePanGesture).toBe(true);
+
+    await act(async () => {
+      latestTimeframeSelectorProps.onSelect('1W');
+    });
+
+    expect(mockRunPortfolioBalanceChartViewModelQuery).toHaveBeenCalledTimes(1);
+    expect(latestTimeframeSelectorProps.selected).toBe('1W');
+    expect(latestInteractiveLineChartProps.points).toBe(
+      mockOneDaySeries.graphPoints,
+    );
     expect(latestInteractiveLineChartProps.enablePanGesture).toBe(false);
+    expect(latestInteractiveLineChartProps.isLoading).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(119);
+    });
+
+    expect(latestInteractiveLineChartProps.isLoading).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(latestInteractiveLineChartProps.isLoading).toBe(true);
+
+    await act(async () => {
+      renderer.update(
+        balanceHistoryChart({
+          showLoaderWhenNoSnapshots: true,
+          isBalanceChartDataReadyToQuery: true,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(mockRunPortfolioBalanceChartViewModelQuery).toHaveBeenCalledTimes(2);
+    expect(
+      mockRunPortfolioBalanceChartViewModelQuery.mock.calls[1][0].timeframe,
+    ).toBe('1W');
+    expect(latestInteractiveLineChartProps.points).toBe(
+      mockOneWeekSeries.graphPoints,
+    );
+    expect(latestInteractiveLineChartProps.isLoading).toBe(false);
+    expect(latestInteractiveLineChartProps.enablePanGesture).toBe(true);
   });
 
   it('fades out the axis labels for a zero balance interval', async () => {

--- a/src/components/charts/BalanceHistoryChart.spec.tsx
+++ b/src/components/charts/BalanceHistoryChart.spec.tsx
@@ -517,6 +517,39 @@ describe('BalanceHistoryChart', () => {
     expect(latestInteractiveLineChartProps.hideLineWhileLoading).toBe(true);
   });
 
+  it('preserves an already visible series while chart data is not ready when requested', async () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        balanceHistoryChart({showLoaderWhenNoSnapshots: true}),
+      );
+    });
+
+    expect(latestInteractiveLineChartProps.points).toBe(
+      mockOneDaySeries.graphPoints,
+    );
+    expect(mockRunPortfolioBalanceChartViewModelQuery).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.update(
+        balanceHistoryChart({
+          showLoaderWhenNoSnapshots: false,
+          isBalanceChartDataReadyToQuery: false,
+          preserveVisibleSeriesWhileNotReady: true,
+        }),
+      );
+    });
+
+    expect(mockRunPortfolioBalanceChartViewModelQuery).toHaveBeenCalledTimes(1);
+    expect(latestInteractiveLineChartProps.isLoading).toBe(false);
+    expect(latestInteractiveLineChartProps.points).toBe(
+      mockOneDaySeries.graphPoints,
+    );
+    expect(latestInteractiveLineChartProps.hideLineWhileLoading).toBe(false);
+    expect(latestInteractiveLineChartProps.enablePanGesture).toBe(false);
+  });
+
   it('fades out the axis labels for a zero balance interval', async () => {
     mockRunPortfolioBalanceChartViewModelQuery.mockResolvedValue({
       __series: mockZeroBalanceSeries,

--- a/src/components/charts/BalanceHistoryChart.tsx
+++ b/src/components/charts/BalanceHistoryChart.tsx
@@ -47,6 +47,7 @@ export type BalanceHistoryChartProps = {
   showLoaderWhenNoSnapshots?: boolean;
   renderZeroBalanceWhenNoSnapshots?: boolean;
   isBalanceChartDataReadyToQuery?: boolean;
+  preserveVisibleSeriesWhileNotReady?: boolean;
   balanceOffset?: number;
   onSelectedBalanceChange?: (balance?: number) => void;
   preChartContent?: React.ReactNode;
@@ -89,6 +90,7 @@ const BalanceHistoryChart = ({
   showLoaderWhenNoSnapshots = false,
   renderZeroBalanceWhenNoSnapshots = false,
   isBalanceChartDataReadyToQuery = true,
+  preserveVisibleSeriesWhileNotReady = false,
   balanceOffset = 0,
   onSelectedBalanceChange,
   preChartContent,
@@ -124,6 +126,7 @@ const BalanceHistoryChart = ({
     showLoaderWhenNoSnapshots,
     renderZeroBalanceWhenNoSnapshots,
     isBalanceChartDataReadyToQuery,
+    preserveVisibleSeriesWhileNotReady,
     t,
     onSelectedBalanceChange,
     onChangeRowData,

--- a/src/components/charts/useBalanceChartDisplayModel.ts
+++ b/src/components/charts/useBalanceChartDisplayModel.ts
@@ -51,6 +51,7 @@ export type UseBalanceChartDisplayModelArgs = {
   showLoaderWhenNoSnapshots: boolean;
   renderZeroBalanceWhenNoSnapshots: boolean;
   isBalanceChartDataReadyToQuery?: boolean;
+  preserveVisibleSeriesWhileNotReady?: boolean;
   t: (key: string) => string;
   onSelectedBalanceChange?: (balance?: number) => void;
   onChangeRowData?: (data?: BalanceChartCallbackChangeRowData) => void;
@@ -210,6 +211,7 @@ export function useBalanceChartDisplayModel({
   showLoaderWhenNoSnapshots,
   renderZeroBalanceWhenNoSnapshots,
   isBalanceChartDataReadyToQuery = true,
+  preserveVisibleSeriesWhileNotReady = false,
   t,
   onSelectedBalanceChange,
   onChangeRowData,
@@ -382,13 +384,21 @@ export function useBalanceChartDisplayModel({
 
   useEffect(() => {
     if (!isBalanceChartDataReadyToQuery) {
+      const visibleOwner = visibleStateRef.current;
+      const canPreserveVisibleSeries =
+        preserveVisibleSeriesWhileNotReady &&
+        visibleOwner?.scopeId === scopeId &&
+        visibleOwner?.quoteCurrency === committedQueryQuoteCurrency;
+
       activeRequestIdRef.current += 1;
       pendingSelectedTimestampRef.current = undefined;
       gestureStartedRef.current = false;
       lastHapticPointTsRef.current = undefined;
       setSelectedPoint(undefined);
-      setVisibleState(undefined);
-      setLoading(true);
+      if (!canPreserveVisibleSeries) {
+        setVisibleState(undefined);
+      }
+      setLoading(!canPreserveVisibleSeries);
       setError(undefined);
       onSelectedBalanceChangeRef.current?.(undefined);
       return;
@@ -502,6 +512,7 @@ export function useBalanceChartDisplayModel({
     chartDataRevisionSig,
     committedQueryQuoteCurrency,
     isBalanceChartDataReadyToQuery,
+    preserveVisibleSeriesWhileNotReady,
     queryRevisionKey,
     renderZeroBalanceWhenNoSnapshots,
     shouldWaitForHistoricalRates,
@@ -540,8 +551,10 @@ export function useBalanceChartDisplayModel({
     onSelectedBalanceChangeRef.current?.(undefined);
   }, [committedQueryQuoteCurrency, queryRevisionKey, scopeId]);
 
+  const canDisplayVisibleState =
+    isBalanceChartDataReadyToQuery || preserveVisibleSeriesWhileNotReady;
   const activeVisibleState =
-    isBalanceChartDataReadyToQuery &&
+    canDisplayVisibleState &&
     visibleState?.scopeId === scopeId &&
     visibleState?.quoteCurrency === committedQueryQuoteCurrency
       ? visibleState
@@ -658,9 +671,7 @@ export function useBalanceChartDisplayModel({
     );
   }, [displayedAnalysisPoint, onDisplayedAnalysisPointChange]);
 
-  const hasRenderableSeries =
-    isBalanceChartDataReadyToQuery &&
-    (visibleSeries?.graphPoints?.length || 0) >= 2;
+  const hasRenderableSeries = (visibleSeries?.graphPoints?.length || 0) >= 2;
   const shouldDelayPendingOverlay =
     isBalanceChartDataReadyToQuery && loading && hasRenderableSeries;
 
@@ -680,7 +691,7 @@ export function useBalanceChartDisplayModel({
   }, [shouldDelayPendingOverlay]);
 
   const shouldShowLoader =
-    !isBalanceChartDataReadyToQuery ||
+    (!isBalanceChartDataReadyToQuery && !hasRenderableSeries) ||
     pendingOverlayVisible ||
     (!hasRenderableSeries &&
       (loading || (showLoaderWhenNoSnapshots && hasAnyWallets)));

--- a/src/components/charts/useBalanceChartDisplayModel.ts
+++ b/src/components/charts/useBalanceChartDisplayModel.ts
@@ -389,6 +389,9 @@ export function useBalanceChartDisplayModel({
         preserveVisibleSeriesWhileNotReady &&
         visibleOwner?.scopeId === scopeId &&
         visibleOwner?.quoteCurrency === committedQueryQuoteCurrency;
+      const selectedTimeframeIsVisible =
+        canPreserveVisibleSeries &&
+        visibleOwner?.timeframe === selectedTimeframe;
 
       activeRequestIdRef.current += 1;
       pendingSelectedTimestampRef.current = undefined;
@@ -398,7 +401,7 @@ export function useBalanceChartDisplayModel({
       if (!canPreserveVisibleSeries) {
         setVisibleState(undefined);
       }
-      setLoading(!canPreserveVisibleSeries);
+      setLoading(!selectedTimeframeIsVisible);
       setError(undefined);
       onSelectedBalanceChangeRef.current?.(undefined);
       return;
@@ -563,7 +566,12 @@ export function useBalanceChartDisplayModel({
   const visibleTimeframe = activeVisibleState?.timeframe ?? selectedTimeframe;
   const visibleQuoteCurrency =
     activeVisibleState?.quoteCurrency ?? committedQueryQuoteCurrency;
-  const displayedSelectedPoint = isBalanceChartDataReadyToQuery
+  const canInteractWithVisibleSeries =
+    isBalanceChartDataReadyToQuery ||
+    (!!activeVisibleState &&
+      preserveVisibleSeriesWhileNotReady &&
+      activeVisibleState.timeframe === selectedTimeframe);
+  const displayedSelectedPoint = canInteractWithVisibleSeries
     ? selectedPoint
     : undefined;
 
@@ -672,8 +680,7 @@ export function useBalanceChartDisplayModel({
   }, [displayedAnalysisPoint, onDisplayedAnalysisPointChange]);
 
   const hasRenderableSeries = (visibleSeries?.graphPoints?.length || 0) >= 2;
-  const shouldDelayPendingOverlay =
-    isBalanceChartDataReadyToQuery && loading && hasRenderableSeries;
+  const shouldDelayPendingOverlay = loading && hasRenderableSeries;
 
   useEffect(() => {
     if (!shouldDelayPendingOverlay) {
@@ -721,7 +728,7 @@ export function useBalanceChartDisplayModel({
   const onPointSelected = useCallback(
     (point: GraphPoint) => {
       if (
-        !isBalanceChartDataReadyToQuery ||
+        !canInteractWithVisibleSeries ||
         !visibleSeries ||
         !gestureStartedRef.current
       ) {
@@ -744,7 +751,7 @@ export function useBalanceChartDisplayModel({
         lastHapticPointTsRef.current = pointTs;
       }
     },
-    [balanceOffset, isBalanceChartDataReadyToQuery, visibleSeries],
+    [balanceOffset, canInteractWithVisibleSeries, visibleSeries],
   );
 
   const onTimeframeSelect = useCallback(
@@ -769,10 +776,10 @@ export function useBalanceChartDisplayModel({
     visibleSeries,
     visibleTimeframe,
     visibleQuoteCurrency,
-    isLoading: loading || !isBalanceChartDataReadyToQuery,
-    pendingOverlayVisible: isBalanceChartDataReadyToQuery
-      ? pendingOverlayVisible
-      : false,
+    isLoading:
+      loading ||
+      (!isBalanceChartDataReadyToQuery && !canInteractWithVisibleSeries),
+    pendingOverlayVisible,
     shouldShowLoader,
     error: isBalanceChartDataReadyToQuery ? error : undefined,
     selectedPoint: displayedSelectedPoint,

--- a/src/navigation/tabs/home/components/PortfolioBalance.tsx
+++ b/src/navigation/tabs/home/components/PortfolioBalance.tsx
@@ -232,7 +232,9 @@ const PortfolioBalanceContent = () => {
     shouldLeftAlignTopSection && persistedHomeChartCollapsed;
   const showChartLoaderWhenNoSnapshots =
     balanceChartReadiness.shouldShowChartLoader ||
-    (balanceChartsEnabled && !chartHasRenderableSeries);
+    (balanceChartsEnabled &&
+      !balanceChartReadiness.shouldPreserveStaleBalanceChart &&
+      !chartHasRenderableSeries);
   const collapsedScale = 0.26;
   const fullChartHeight =
     chartBlockHeight || HOME_BALANCE_EXPANDED_CHART_HEIGHT;
@@ -399,6 +401,8 @@ const PortfolioBalanceContent = () => {
     enabled: balanceChartsEnabled,
     isBalanceChartDataReadyToQuery:
       balanceChartReadiness.isBalanceChartDataReadyToQuery,
+    preserveChartDrivenStateWhileNotReady:
+      balanceChartReadiness.shouldPreserveStaleBalanceChart,
     resetKey: chartLifecycleKey,
   });
   const commonBalanceHistoryChartProps: BalanceHistoryChartProps = {
@@ -412,6 +416,8 @@ const PortfolioBalanceContent = () => {
     showLoaderWhenNoSnapshots: showChartLoaderWhenNoSnapshots,
     isBalanceChartDataReadyToQuery:
       balanceChartReadiness.isBalanceChartDataReadyToQuery,
+    preserveVisibleSeriesWhileNotReady:
+      balanceChartReadiness.shouldPreserveStaleBalanceChart,
     // NOTE: Coinbase balance is intentionally excluded from the balance chart
     // (Option B per product requirements) because we do not have historized
     // Coinbase balance snapshots.

--- a/src/navigation/tabs/settings/about/screens/PortfolioDebug.tsx
+++ b/src/navigation/tabs/settings/about/screens/PortfolioDebug.tsx
@@ -209,6 +209,18 @@ const getWalletLabel = (wallet: Wallet): string =>
     .filter(Boolean)
     .join(':');
 
+const formatDebugPayloadIso = (value?: number): string | undefined => {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+
+  try {
+    return new Date(value as number).toISOString();
+  } catch {
+    return undefined;
+  }
+};
+
 const buildHomeBalanceChartPopulateDebugPayload = (args: {
   chartWallets: Wallet[];
   populateStatus?: PortfolioPopulateStatus;
@@ -223,30 +235,29 @@ const buildHomeBalanceChartPopulateDebugPayload = (args: {
   const statusByWalletId = populateStatus?.walletStatusById || {};
   const decisionReasonByWalletId =
     populateStatus?.decisionReasonByWalletId || {};
-  const chartWalletSummaries = args.chartWallets
-    .map(wallet => {
-      const walletId = String(wallet?.id || '').trim();
-      if (!walletId) {
-        return undefined;
-      }
-      const reason = decisionReasonByWalletId[walletId];
+  const chartWalletSummaries = args.chartWallets.flatMap(wallet => {
+    const walletId = String(wallet?.id || '').trim();
+    if (!walletId) {
+      return [];
+    }
+    const reason = decisionReasonByWalletId[walletId];
 
-      return {
+    return [
+      {
         walletId,
         label: getWalletLabel(wallet),
         status: statusByWalletId[walletId],
         reason: reason || null,
         isCurrent: populateStatus?.currentWalletId === walletId,
-      };
-    })
-    .filter(Boolean);
+      },
+    ];
+  });
   const blockingWallets = chartWalletSummaries.filter(
     wallet =>
-      wallet?.isCurrent === true ||
-      (wallet?.walletId && statusByWalletId[wallet.walletId] === 'in_progress'),
+      wallet.isCurrent || statusByWalletId[wallet.walletId] === 'in_progress',
   );
   const selectedPopulateWallets = chartWalletSummaries.filter(
-    wallet => !!wallet?.reason,
+    wallet => !!wallet.reason,
   );
 
   return {
@@ -256,8 +267,8 @@ const buildHomeBalanceChartPopulateDebugPayload = (args: {
       inProgress: populateStatus?.inProgress === true,
       currentWalletId: populateStatus?.currentWalletId,
       decisionSource: populateStatus?.decisionSource,
-      startedAt: populateStatus?.startedAt,
-      finishedAt: populateStatus?.finishedAt,
+      startedAt: formatDebugPayloadIso(populateStatus?.startedAt),
+      finishedAt: formatDebugPayloadIso(populateStatus?.finishedAt),
       elapsedMs: populateStatus?.elapsedMs,
       stopReason: populateStatus?.stopReason,
       walletsCompleted: populateStatus?.walletsCompleted,

--- a/src/navigation/tabs/settings/about/screens/PortfolioDebug.tsx
+++ b/src/navigation/tabs/settings/about/screens/PortfolioDebug.tsx
@@ -20,6 +20,7 @@ import SearchSvg from '../../../../../../assets/img/search.svg';
 import {Network} from '../../../../../constants';
 import {useAppDispatch, useAppSelector} from '../../../../../utils/hooks';
 import {getPortfolioRuntimeClient} from '../../../../../portfolio/runtime/portfolioRuntime';
+import usePortfolioBalanceChartReadiness from '../../../../../portfolio/ui/hooks/usePortfolioBalanceChartReadiness';
 import type {
   SnapshotIndexV2,
   SnapshotPersistDebugMode,
@@ -28,6 +29,7 @@ import type {SnapshotInvalidHistoryMarkerV1} from '../../../../../portfolio/core
 import type {Wallet} from '../../../../../store/wallet/wallet.models';
 import type {
   InvalidDecimalsMarker,
+  PortfolioPopulateStatus,
   PortfolioQuarantineMarker,
   SnapshotBalanceMismatch,
 } from '../../../../../store/portfolio/portfolio.models';
@@ -38,6 +40,7 @@ import {
 import {remountHomeChart} from '../../../../../store/app/app.actions';
 import {clearShopStore} from '../../../../../store/shop/shop.actions';
 import {clearShopCatalogStore} from '../../../../../store/shop-catalog/shop-catalog.actions';
+import {getVisibleWalletsFromKeys} from '../../../../../utils/portfolio/assets';
 import {AboutGroupParamList, AboutScreens} from '../AboutGroup';
 import {
   DebugButtonRow,
@@ -195,6 +198,79 @@ const getAllMainnetWallets = (walletKeys: Record<string, any>): Wallet[] => {
     });
 };
 
+const getWalletLabel = (wallet: Wallet): string =>
+  [
+    wallet.currencyAbbreviation,
+    wallet.chain,
+    wallet.tokenAddress,
+    wallet.network,
+  ]
+    .map(value => String(value || '').trim())
+    .filter(Boolean)
+    .join(':');
+
+const buildHomeBalanceChartPopulateDebugPayload = (args: {
+  chartWallets: Wallet[];
+  populateStatus?: PortfolioPopulateStatus;
+  readiness: {
+    isBalanceChartDataReadyToQuery: boolean;
+    isScopePopulateLoading: boolean;
+    isSnapshotPresenceLoading: boolean;
+    shouldShowChartLoader: boolean;
+  };
+}) => {
+  const populateStatus = args.populateStatus;
+  const statusByWalletId = populateStatus?.walletStatusById || {};
+  const decisionReasonByWalletId =
+    populateStatus?.decisionReasonByWalletId || {};
+  const chartWalletSummaries = args.chartWallets
+    .map(wallet => {
+      const walletId = String(wallet?.id || '').trim();
+      if (!walletId) {
+        return undefined;
+      }
+      const reason = decisionReasonByWalletId[walletId];
+
+      return {
+        walletId,
+        label: getWalletLabel(wallet),
+        status: statusByWalletId[walletId],
+        reason: reason || null,
+        isCurrent: populateStatus?.currentWalletId === walletId,
+      };
+    })
+    .filter(Boolean);
+  const blockingWallets = chartWalletSummaries.filter(
+    wallet =>
+      wallet?.isCurrent === true ||
+      (wallet?.walletId && statusByWalletId[wallet.walletId] === 'in_progress'),
+  );
+  const selectedPopulateWallets = chartWalletSummaries.filter(
+    wallet => !!wallet?.reason,
+  );
+
+  return {
+    copiedAt: new Date().toISOString(),
+    chartReadiness: args.readiness,
+    populateStatus: {
+      inProgress: populateStatus?.inProgress === true,
+      currentWalletId: populateStatus?.currentWalletId,
+      decisionSource: populateStatus?.decisionSource,
+      startedAt: populateStatus?.startedAt,
+      finishedAt: populateStatus?.finishedAt,
+      elapsedMs: populateStatus?.elapsedMs,
+      stopReason: populateStatus?.stopReason,
+      walletsCompleted: populateStatus?.walletsCompleted,
+      walletsTotal: populateStatus?.walletsTotal,
+      txRequestsMade: populateStatus?.txRequestsMade,
+      txsProcessed: populateStatus?.txsProcessed,
+    },
+    blockingWallets,
+    selectedPopulateWallets,
+    decisionReasonByWalletId,
+  };
+};
+
 const PortfolioDebug = ({navigation}: PortfolioDebugScreenProps) => {
   const {t} = useTranslation();
   const theme = useTheme();
@@ -202,6 +278,9 @@ const PortfolioDebug = ({navigation}: PortfolioDebugScreenProps) => {
 
   const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
   const walletKeys = useAppSelector(({WALLET}) => WALLET?.keys || {});
+  const homeCarouselConfig = useAppSelector(({APP}) => APP?.homeCarouselConfig);
+  const hideAllBalances = useAppSelector(({APP}) => APP?.hideAllBalances);
+  const showPortfolioValue = useAppSelector(({APP}) => APP?.showPortfolioValue);
 
   const [walletRows, setWalletRows] = useState<RuntimeWalletRow[]>([]);
   const [rateEntries, setRateEntries] = useState<any[]>([]);
@@ -210,12 +289,24 @@ const PortfolioDebug = ({navigation}: PortfolioDebugScreenProps) => {
   const [isClearing, setIsClearing] = useState<boolean>(false);
   const [isClearingShop, setIsClearingShop] = useState<boolean>(false);
   const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle');
+  const [copyHomeChartState, setCopyHomeChartState] = useState<
+    'idle' | 'copied'
+  >('idle');
   const [runtimeError, setRuntimeError] = useState<string>('');
   const [lastRefreshedAt, setLastRefreshedAt] = useState<number | undefined>();
   const [query, setQuery] = useState('');
   const [populateDebugMode, setPopulateDebugMode] =
     useState<SnapshotPersistDebugMode>('link');
   const wallets = useMemo(() => getAllMainnetWallets(walletKeys), [walletKeys]);
+  const homeChartWallets = useMemo(
+    () => getVisibleWalletsFromKeys(walletKeys, homeCarouselConfig),
+    [homeCarouselConfig, walletKeys],
+  );
+  const homeChartReadiness = usePortfolioBalanceChartReadiness({
+    wallets: homeChartWallets,
+    enabled: showPortfolioValue === true,
+    hideAllBalances,
+  });
   const deferredQuery = useDeferredValue(query);
   const loadRequestIdRef = useRef(0);
   const walletsRef = useLatestRef(wallets);
@@ -500,6 +591,36 @@ const PortfolioDebug = ({navigation}: PortfolioDebugScreenProps) => {
     setTimeout(() => setCopyState('idle'), 1200);
   }, [rateEntries, summary, walletRows]);
 
+  const copyHomeChartPopulateDebug = useCallback(() => {
+    Clipboard.setString(
+      JSON.stringify(
+        buildHomeBalanceChartPopulateDebugPayload({
+          chartWallets: homeChartReadiness.chartableWallets,
+          populateStatus: portfolio.populateStatus,
+          readiness: {
+            isBalanceChartDataReadyToQuery:
+              homeChartReadiness.isBalanceChartDataReadyToQuery,
+            isScopePopulateLoading: homeChartReadiness.isScopePopulateLoading,
+            isSnapshotPresenceLoading:
+              homeChartReadiness.isSnapshotPresenceLoading,
+            shouldShowChartLoader: homeChartReadiness.shouldShowChartLoader,
+          },
+        }),
+        null,
+        2,
+      ),
+    );
+    setCopyHomeChartState('copied');
+    setTimeout(() => setCopyHomeChartState('idle'), 1200);
+  }, [
+    homeChartReadiness.chartableWallets,
+    homeChartReadiness.isBalanceChartDataReadyToQuery,
+    homeChartReadiness.isScopePopulateLoading,
+    homeChartReadiness.isSnapshotPresenceLoading,
+    homeChartReadiness.shouldShowChartLoader,
+    portfolio.populateStatus,
+  ]);
+
   const repopulate = useCallback(async () => {
     const startedAtMs = nowMs();
     const walletCount = wallets.length;
@@ -739,6 +860,15 @@ const PortfolioDebug = ({navigation}: PortfolioDebugScreenProps) => {
             <DebugPillButton onPress={copySummary}>
               <DebugPillButtonText>
                 {copyState === 'copied' ? t('Copied') : t('Copy JSON')}
+              </DebugPillButtonText>
+            </DebugPillButton>
+            <DebugPillButton
+              testID="portfolio-debug-copy-home-chart-populate-json"
+              onPress={copyHomeChartPopulateDebug}>
+              <DebugPillButtonText>
+                {copyHomeChartState === 'copied'
+                  ? t('Copied')
+                  : t('Copy PnL Debug')}
               </DebugPillButtonText>
             </DebugPillButton>
           </DebugButtonRow>

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -477,6 +477,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     shouldMountBalanceChart: shouldMountAccountBalanceChart,
     shouldShowChartLoader: shouldShowAccountChartLoader,
     shouldRenderZeroBalanceChart: shouldRenderZeroAccountBalanceChart,
+    shouldPreserveStaleBalanceChart: shouldPreserveStaleAccountBalanceChart,
     isBalanceChartDataReadyToQuery: isAccountBalanceChartDataReadyToQuery,
     chartableWallets: chartableAccountWallets,
   } = usePortfolioBalanceChartReadiness({
@@ -529,6 +530,8 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     fallbackCurrency: defaultAltCurrency.isoCode,
     enabled: shouldMountAccountBalanceChart,
     isBalanceChartDataReadyToQuery: isAccountBalanceChartDataReadyToQuery,
+    preserveChartDrivenStateWhileNotReady:
+      shouldPreserveStaleAccountBalanceChart,
     resetKey: `${keyId}:${selectedAccountAddress || ''}`,
   });
   const totalBalance =
@@ -1498,6 +1501,9 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
                     isBalanceChartDataReadyToQuery={
                       isAccountBalanceChartDataReadyToQuery
                     }
+                    preserveVisibleSeriesWhileNotReady={
+                      shouldPreserveStaleAccountBalanceChart
+                    }
                     showChangeRow={false}
                     onSelectedBalanceChange={
                       balanceChartSurface.chartCallbacks.onSelectedBalanceChange
@@ -1677,6 +1683,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     dispatch,
     groupedHistory,
     hideAllBalances,
+    isAccountBalanceChartDataReadyToQuery,
     isSmallScreen,
     isSvmAccount,
     balanceChartSurface,
@@ -1690,6 +1697,8 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     searchVal,
     selectedChainFilterOption,
     shouldMountAccountBalanceChart,
+    shouldPreserveStaleAccountBalanceChart,
+    shouldRenderZeroAccountBalanceChart,
     shouldShowAccountChartLoader,
     showPortfolioValue,
     t,

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -690,6 +690,7 @@ const KeyOverview = () => {
     shouldMountBalanceChart: shouldMountKeyBalanceChart,
     shouldShowChartLoader: shouldShowKeyChartLoader,
     shouldRenderZeroBalanceChart: shouldRenderZeroKeyBalanceChart,
+    shouldPreserveStaleBalanceChart: shouldPreserveStaleKeyBalanceChart,
     isBalanceChartDataReadyToQuery: isKeyBalanceChartDataReadyToQuery,
     chartableWallets: chartableVisibleKeyWallets,
   } = usePortfolioBalanceChartReadiness({
@@ -709,6 +710,7 @@ const KeyOverview = () => {
     fallbackCurrency: defaultAltCurrency.isoCode,
     enabled: shouldMountKeyBalanceChart,
     isBalanceChartDataReadyToQuery: isKeyBalanceChartDataReadyToQuery,
+    preserveChartDrivenStateWhileNotReady: shouldPreserveStaleKeyBalanceChart,
     resetKey: id,
   });
   const legacyLastDayChangeRowData = useLegacyLastDayChangeRowData({
@@ -1214,6 +1216,9 @@ const KeyOverview = () => {
                   isBalanceChartDataReadyToQuery={
                     isKeyBalanceChartDataReadyToQuery
                   }
+                  preserveVisibleSeriesWhileNotReady={
+                    shouldPreserveStaleKeyBalanceChart
+                  }
                   showChangeRow={false}
                   onSelectedBalanceChange={
                     balanceChartSurface.chartCallbacks.onSelectedBalanceChange
@@ -1262,7 +1267,10 @@ const KeyOverview = () => {
     rates,
     searchResults,
     searchVal,
+    isKeyBalanceChartDataReadyToQuery,
     shouldMountKeyBalanceChart,
+    shouldPreserveStaleKeyBalanceChart,
+    shouldRenderZeroKeyBalanceChart,
     shouldShowKeyChartLoader,
     t,
     timeframeSelectorWidth,

--- a/src/navigation/wallet/screens/WalletDetails.tsx
+++ b/src/navigation/wallet/screens/WalletDetails.tsx
@@ -625,6 +625,7 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
     shouldMountBalanceChart: shouldMountWalletBalanceChart,
     shouldShowChartLoader: shouldShowWalletChartLoader,
     shouldRenderZeroBalanceChart: shouldRenderZeroWalletBalanceChart,
+    shouldPreserveStaleBalanceChart: shouldPreserveStaleWalletBalanceChart,
     isBalanceChartDataReadyToQuery: isWalletBalanceChartDataReadyToQuery,
     chartableWallets,
   } = usePortfolioBalanceChartReadiness({
@@ -639,6 +640,8 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
     fallbackCurrency: defaultAltCurrency.isoCode,
     enabled: shouldMountWalletBalanceChart,
     isBalanceChartDataReadyToQuery: isWalletBalanceChartDataReadyToQuery,
+    preserveChartDrivenStateWhileNotReady:
+      shouldPreserveStaleWalletBalanceChart,
     resetKey: `${walletId}:${copayerId || ''}`,
   });
 
@@ -1397,6 +1400,9 @@ const WalletDetails: React.FC<WalletDetailsScreenProps> = ({route}) => {
                         }
                         isBalanceChartDataReadyToQuery={
                           isWalletBalanceChartDataReadyToQuery
+                        }
+                        preserveVisibleSeriesWhileNotReady={
+                          shouldPreserveStaleWalletBalanceChart
                         }
                         showChangeRow={false}
                         onSelectedBalanceChange={

--- a/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.spec.tsx
+++ b/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.spec.tsx
@@ -312,7 +312,7 @@ describe('AssetBalanceHistoryScreen', () => {
     );
   });
 
-  it('keeps asset chart work in loader mode during later incremental populate after initial success', async () => {
+  it('keeps asset chart work mounted with stale preservation during later incremental populate after initial success', async () => {
     isPopulateLoadingForWallets.mockReturnValue(true);
     mockState.PORTFOLIO.populateStatus = {
       currentWalletId: 'wallet-1',
@@ -332,13 +332,18 @@ describe('AssetBalanceHistoryScreen', () => {
     });
 
     expect(latestBalanceHistoryChartProps).toBeDefined();
-    expect(latestBalanceHistoryChartProps.showLoaderWhenNoSnapshots).toBe(true);
+    expect(latestBalanceHistoryChartProps.showLoaderWhenNoSnapshots).toBe(
+      false,
+    );
     expect(latestBalanceHistoryChartProps.isBalanceChartDataReadyToQuery).toBe(
       false,
     );
+    expect(
+      latestBalanceHistoryChartProps.preserveVisibleSeriesWhileNotReady,
+    ).toBe(true);
   });
 
-  it('ignores stale chart summary state while asset chart data is not ready', async () => {
+  it('preserves stale chart summary state while asset chart data is not ready during incremental populate', async () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
@@ -388,10 +393,17 @@ describe('AssetBalanceHistoryScreen', () => {
     expect(latestBalanceHistoryChartProps.isBalanceChartDataReadyToQuery).toBe(
       false,
     );
+    expect(
+      latestBalanceHistoryChartProps.preserveVisibleSeriesWhileNotReady,
+    ).toBe(true);
     expect(buildAssetBalanceHistoryDisplayedSummary).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        chartDisplayedPoint: undefined,
-        chartChangeRow: undefined,
+        chartDisplayedPoint: expect.objectContaining({
+          totalFiatBalance: 200,
+        }),
+        chartChangeRow: expect.objectContaining({
+          percent: 20,
+        }),
       }),
     );
   });

--- a/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.tsx
+++ b/src/navigation/wallet/screens/exchange-rate/AssetBalanceHistoryScreen.tsx
@@ -44,6 +44,7 @@ const AssetBalanceChartSection = React.memo(
     gradientStartColor,
     showLoaderWhenNoSnapshots,
     isBalanceChartDataReadyToQuery,
+    preserveVisibleSeriesWhileNotReady,
     onChangeRowData,
     onDisplayedAnalysisPointChange,
     onSelectionActiveChange,
@@ -58,6 +59,7 @@ const AssetBalanceChartSection = React.memo(
     gradientStartColor: string;
     showLoaderWhenNoSnapshots: boolean;
     isBalanceChartDataReadyToQuery?: boolean;
+    preserveVisibleSeriesWhileNotReady?: boolean;
     onChangeRowData: (data: AssetChartChangeRow) => void;
     onDisplayedAnalysisPointChange: (
       point: AssetDisplayedAnalysisPoint,
@@ -80,6 +82,9 @@ const AssetBalanceChartSection = React.memo(
           gradientStartColor={gradientStartColor}
           showLoaderWhenNoSnapshots={showLoaderWhenNoSnapshots}
           isBalanceChartDataReadyToQuery={isBalanceChartDataReadyToQuery}
+          preserveVisibleSeriesWhileNotReady={
+            preserveVisibleSeriesWhileNotReady
+          }
           onChangeRowData={onChangeRowData}
           onDisplayedAnalysisPointChange={onDisplayedAnalysisPointChange}
           onSelectionActiveChange={onSelectionActiveChange}
@@ -144,6 +149,10 @@ const AssetBalanceHistoryScreen = ({
     balanceChartReadiness.shouldShowChartLoader;
   const isAssetBalanceChartDataReadyToQuery =
     balanceChartReadiness.isBalanceChartDataReadyToQuery;
+  const shouldPreserveStaleAssetBalanceChart =
+    balanceChartReadiness.shouldPreserveStaleBalanceChart;
+  const canUseChartDisplayedState =
+    isAssetBalanceChartDataReadyToQuery || shouldPreserveStaleAssetBalanceChart;
   const isTimeframeTransitionPending =
     requestedTimeframe !== displayedTimeframe;
 
@@ -172,10 +181,10 @@ const AssetBalanceHistoryScreen = ({
 
   const {isRefreshing, onRefresh} = useAssetScreenRefresh(shared);
 
-  const effectiveChartDisplayedPoint = isAssetBalanceChartDataReadyToQuery
+  const effectiveChartDisplayedPoint = canUseChartDisplayedState
     ? chartDisplayedPoint
     : undefined;
-  const effectiveChartChangeRow = isAssetBalanceChartDataReadyToQuery
+  const effectiveChartChangeRow = canUseChartDisplayedState
     ? chartChangeRow
     : undefined;
   const displayedSummary = buildAssetBalanceHistoryDisplayedSummary({
@@ -262,6 +271,9 @@ const AssetBalanceHistoryScreen = ({
             isTimeframeTransitionPending
           }
           isBalanceChartDataReadyToQuery={isAssetBalanceChartDataReadyToQuery}
+          preserveVisibleSeriesWhileNotReady={
+            shouldPreserveStaleAssetBalanceChart
+          }
           onChangeRowData={handleChartChangeRowData}
           onDisplayedAnalysisPointChange={handleDisplayedAnalysisPointChange}
           onSelectionActiveChange={setSelectionActive}

--- a/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
+++ b/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
@@ -743,10 +743,12 @@ const resetState = (
   };
 };
 
+const withTheme = (element: React.ReactElement) => (
+  <ThemeProvider theme={testTheme as any}>{element}</ThemeProvider>
+);
+
 const renderWithTheme = (element: React.ReactElement) =>
-  TestRenderer.create(
-    <ThemeProvider theme={testTheme as any}>{element}</ThemeProvider>,
-  );
+  TestRenderer.create(withTheme(element));
 
 const collectRenderedText = (node: unknown): string[] => {
   if (typeof node === 'string') {
@@ -822,6 +824,9 @@ const chartSurfaceCases: Array<[string, () => React.ReactElement, string]> = [
     'account_details_balance_chart',
   ],
 ];
+const memoizedHeaderChartSurfaceCases = chartSurfaceCases.filter(([screen]) =>
+  ['Key Overview', 'AccountDetails'].includes(screen),
+);
 const portfolioChartSurfaceCases: Array<
   [string, () => React.ReactElement, string]
 > = [
@@ -1274,7 +1279,7 @@ describe('portfolio chart visibility guards', () => {
   });
 
   it.each(portfolioChartSurfaceCases)(
-    'keeps the %s chart in loader mode during later incremental populate after initial success',
+    'keeps the %s chart mounted with stale preservation during later incremental populate after initial success',
     async (_screen, makeScreen) => {
       resetState(true, {
         completedFullPopulate: true,
@@ -1288,8 +1293,9 @@ describe('portfolio chart visibility guards', () => {
 
       expect(mockBalanceHistoryChart).toHaveBeenCalledWith(
         expect.objectContaining({
-          showLoaderWhenNoSnapshots: true,
+          showLoaderWhenNoSnapshots: false,
           isBalanceChartDataReadyToQuery: false,
+          preserveVisibleSeriesWhileNotReady: true,
         }),
         undefined,
       );
@@ -1300,6 +1306,43 @@ describe('portfolio chart visibility guards', () => {
           }).length,
         ).toBeGreaterThan(0);
       }
+    },
+  );
+
+  it.each(memoizedHeaderChartSurfaceCases)(
+    'updates the memoized %s chart props when an already-mounted chart enters incremental populate',
+    async (_screen, makeScreen) => {
+      resetState(true, {completedFullPopulate: true});
+
+      let view!: TestRenderer.ReactTestRenderer;
+      await act(async () => {
+        view = renderWithTheme(makeScreen());
+      });
+
+      expect(mockBalanceHistoryChart).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          showLoaderWhenNoSnapshots: false,
+          isBalanceChartDataReadyToQuery: true,
+          preserveVisibleSeriesWhileNotReady: false,
+        }),
+        undefined,
+      );
+
+      mockBalanceHistoryChart.mockClear();
+      mockState.PORTFOLIO.populateStatus = makePopulateStatus();
+
+      await act(async () => {
+        view.update(withTheme(makeScreen()));
+      });
+
+      expect(mockBalanceHistoryChart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          showLoaderWhenNoSnapshots: false,
+          isBalanceChartDataReadyToQuery: false,
+          preserveVisibleSeriesWhileNotReady: true,
+        }),
+        undefined,
+      );
     },
   );
 

--- a/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
@@ -7,7 +7,7 @@ const mockTakeNextPortfolioTransferredSignHandleOnRuntime = jest.fn(() => ({
 }));
 
 jest.mock('./txHistorySigning', () => ({
-  DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS: 15000,
+  DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS: 100000,
   getPortfolioNitroFetchClientOnRuntime: () => ({
     requestSync: mockRequestSync,
   }),
@@ -45,6 +45,50 @@ const fetchTxHistoryArgs = {
 describe('fetchPortfolioTxHistoryPageByRequest', () => {
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('uses the BWS config timeout for Nitro Fetch requests', async () => {
+    mockRequestSync.mockReturnValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      bodyString: '[]',
+    });
+
+    await expect(
+      fetchPortfolioTxHistoryPageByRequest({
+        ...fetchTxHistoryArgs,
+        cfg: {
+          ...fetchTxHistoryArgs.cfg,
+          timeoutMs: 100000,
+        },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(mockRequestSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 100000,
+      }),
+    );
+  });
+
+  it('falls back to the default 100 second Nitro Fetch timeout', async () => {
+    mockRequestSync.mockReturnValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      bodyString: '[]',
+    });
+
+    await expect(
+      fetchPortfolioTxHistoryPageByRequest(fetchTxHistoryArgs),
+    ).resolves.toEqual([]);
+
+    expect(mockRequestSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 100000,
+      }),
+    );
   });
 
   it('includes native Nitro Fetch error details when requestSync throws', async () => {

--- a/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.spec.ts
@@ -1,9 +1,98 @@
+const mockRequestSync = jest.fn();
+const mockSignBwsGetRequestWithTransferredNitro = jest.fn(() => 'signature');
+const mockTakeNextPortfolioTransferredSignHandleOnRuntime = jest.fn(() => ({
+  firstHashHybrid: {},
+  signHandleHybrid: {},
+  privateKeyHandle: {},
+}));
+
+jest.mock('./txHistorySigning', () => ({
+  DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS: 15000,
+  getPortfolioNitroFetchClientOnRuntime: () => ({
+    requestSync: mockRequestSync,
+  }),
+  signBwsGetRequestWithTransferredNitro: (...args: unknown[]) =>
+    mockSignBwsGetRequestWithTransferredNitro(...args),
+  takeNextPortfolioTransferredSignHandleOnRuntime: () =>
+    mockTakeNextPortfolioTransferredSignHandleOnRuntime(),
+}));
+
 import {
   PORTFOLIO_BWS_CLIENT_VERSION_HEADER,
   appendPortfolioTxHistoryCacheBustParam,
   buildPortfolioTxHistoryRequestPath,
+  fetchPortfolioTxHistoryPageByRequest,
 } from './txHistoryRequest';
+import {
+  PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+  isPortfolioRemoteRequestError,
+} from '../../core/remoteRequestError';
 import {version as bitcoreWalletClientVersion} from '@bitpay-labs/bitcore-wallet-client/package.json';
+
+const fetchTxHistoryArgs = {
+  credentials: {
+    walletId: 'wallet-1',
+    copayerId: 'copayer-1',
+    chain: 'btc',
+    coin: 'btc',
+  },
+  cfg: {baseUrl: 'https://bws.example'},
+  skip: 0,
+  limit: 1000,
+  reverse: true,
+} as const;
+
+describe('fetchPortfolioTxHistoryPageByRequest', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes native Nitro Fetch error details when requestSync throws', async () => {
+    const error = new Error('socket timed out');
+    error.name = 'TimeoutError';
+    mockRequestSync.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const promise = fetchPortfolioTxHistoryPageByRequest(fetchTxHistoryArgs);
+
+    await expect(promise).rejects.toThrow(
+      'Portfolio Nitro Fetch txhistory request failed: TimeoutError: socket timed out',
+    );
+    await expect(promise).rejects.toMatchObject({
+      code: PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+      portfolioRemoteRequestKind: 'txhistory',
+      portfolioRemoteRequestFailureKind: 'nitro-fetch',
+    });
+    await expect(promise.catch(isPortfolioRemoteRequestError)).resolves.toBe(
+      true,
+    );
+  });
+
+  it('includes native Nitro Fetch error details when requestSync returns a non-HTTP failure response', async () => {
+    mockRequestSync.mockReturnValueOnce({
+      ok: false,
+      status: 0,
+      statusText: 'NSURLErrorDomain(-1001): The request timed out.',
+      bodyString: 'NSURLErrorDomain(-1001): The request timed out.',
+    });
+
+    const promise = fetchPortfolioTxHistoryPageByRequest(fetchTxHistoryArgs);
+
+    await expect(promise).rejects.toThrow(
+      'BWS txhistory request failed with status 0. NSURLErrorDomain(-1001): The request timed out.',
+    );
+    await expect(promise).rejects.toMatchObject({
+      code: PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+      portfolioRemoteRequestKind: 'txhistory',
+      portfolioRemoteRequestFailureKind: 'http-status',
+      portfolioRemoteRequestStatus: 0,
+    });
+    await expect(promise.catch(isPortfolioRemoteRequestError)).resolves.toBe(
+      true,
+    );
+  });
+});
 
 describe('PORTFOLIO_BWS_CLIENT_VERSION_HEADER', () => {
   it('matches the installed BWC package version in BWS-compatible format', () => {

--- a/src/portfolio/adapters/rn/txHistoryRequest.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.ts
@@ -3,6 +3,7 @@ import type {Tx} from '../../core/types';
 import type {PortfolioRuntimeWalletCredentials} from '../../core/runtimeWalletCredentials';
 import type {NitroResponse as NitroFetchResponse} from 'react-native-nitro-fetch';
 import {version as bitcoreWalletClientVersion} from '@bitpay-labs/bitcore-wallet-client/package.json';
+import {createPortfolioRemoteRequestError} from '../../core/remoteRequestError';
 import {
   buildTokenWalletTxHistoryContextFromCredentials,
   normalizeTokenWalletTxHistoryPage,
@@ -163,6 +164,64 @@ function tryParseJson(text: string): unknown {
   }
 }
 
+function formatThrownErrorForMessage(error: unknown): string {
+  'worklet';
+
+  if (error instanceof Error) {
+    const name = String(error.name || 'Error').trim();
+    const message = String(error.message || '').trim();
+    return message ? `${name}: ${message}` : name;
+  }
+
+  if (typeof error === 'string') {
+    return error.trim();
+  }
+
+  if (error == null) {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function buildNitroFetchTxHistoryError(error: unknown, url: string): Error {
+  'worklet';
+
+  const details = formatThrownErrorForMessage(error);
+  return createPortfolioRemoteRequestError({
+    kind: 'txhistory',
+    failureKind: 'nitro-fetch',
+    url,
+    message: details
+      ? `Portfolio Nitro Fetch txhistory request failed: ${details}`
+      : 'Portfolio Nitro Fetch txhistory request failed.',
+  });
+}
+
+function formatFailedNitroFetchResponseDetails(
+  response: NitroFetchResponse,
+  rawResponseText: string,
+): string {
+  'worklet';
+
+  const details: string[] = [];
+  const statusText = String(response.statusText || '').trim();
+  const body = String(rawResponseText || '').trim();
+
+  if (statusText) {
+    details.push(statusText);
+  }
+  if (body && body !== statusText) {
+    details.push(body.slice(0, 500));
+  }
+
+  return details.length ? ` ${details.join(' ')}` : '';
+}
+
 export async function fetchPortfolioTxHistoryPageByRequest(args: {
   credentials: PortfolioRuntimeWalletCredentials;
   cfg: BwsConfig;
@@ -193,25 +252,34 @@ export async function fetchPortfolioTxHistoryPageByRequest(args: {
   });
 
   const nitroFetchClient = getPortfolioNitroFetchClientOnRuntime();
+  const url = `${baseUrl}${signedRequestPath}`;
   let response: NitroFetchResponse;
   try {
     response = nitroFetchClient.requestSync({
-      url: `${baseUrl}${signedRequestPath}`,
+      url,
       method: 'GET',
       headers,
       timeoutMs: DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS,
       followRedirects: false,
     });
-  } catch {
-    throw new Error('Portfolio Nitro Fetch txhistory request failed.');
+  } catch (error: unknown) {
+    throw buildNitroFetchTxHistoryError(error, url);
   }
 
   const rawResponseText =
     typeof response.bodyString === 'string' ? response.bodyString : '';
   if (!response.ok) {
-    throw new Error(
-      `BWS txhistory request failed with status ${response.status}.`,
+    const responseDetails = formatFailedNitroFetchResponseDetails(
+      response,
+      rawResponseText,
     );
+    throw createPortfolioRemoteRequestError({
+      kind: 'txhistory',
+      failureKind: 'http-status',
+      status: response.status,
+      url,
+      message: `BWS txhistory request failed with status ${response.status}.${responseDetails}`,
+    });
   }
 
   const parsed = tryParseJson(rawResponseText);

--- a/src/portfolio/adapters/rn/txHistoryRequest.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.ts
@@ -3,7 +3,10 @@ import type {Tx} from '../../core/types';
 import type {PortfolioRuntimeWalletCredentials} from '../../core/runtimeWalletCredentials';
 import type {NitroResponse as NitroFetchResponse} from 'react-native-nitro-fetch';
 import {version as bitcoreWalletClientVersion} from '@bitpay-labs/bitcore-wallet-client/package.json';
-import {createPortfolioRemoteRequestError} from '../../core/remoteRequestError';
+import {
+  createPortfolioRemoteNitroFetchError,
+  createPortfolioRemoteRequestError,
+} from '../../core/remoteRequestError';
 import {
   buildTokenWalletTxHistoryContextFromCredentials,
   normalizeTokenWalletTxHistoryPage,
@@ -164,44 +167,6 @@ function tryParseJson(text: string): unknown {
   }
 }
 
-function formatThrownErrorForMessage(error: unknown): string {
-  'worklet';
-
-  if (error instanceof Error) {
-    const name = String(error.name || 'Error').trim();
-    const message = String(error.message || '').trim();
-    return message ? `${name}: ${message}` : name;
-  }
-
-  if (typeof error === 'string') {
-    return error.trim();
-  }
-
-  if (error == null) {
-    return '';
-  }
-
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-function buildNitroFetchTxHistoryError(error: unknown, url: string): Error {
-  'worklet';
-
-  const details = formatThrownErrorForMessage(error);
-  return createPortfolioRemoteRequestError({
-    kind: 'txhistory',
-    failureKind: 'nitro-fetch',
-    url,
-    message: details
-      ? `Portfolio Nitro Fetch txhistory request failed: ${details}`
-      : 'Portfolio Nitro Fetch txhistory request failed.',
-  });
-}
-
 function formatFailedNitroFetchResponseDetails(
   response: NitroFetchResponse,
   rawResponseText: string,
@@ -263,7 +228,13 @@ export async function fetchPortfolioTxHistoryPageByRequest(args: {
       followRedirects: false,
     });
   } catch (error: unknown) {
-    throw buildNitroFetchTxHistoryError(error, url);
+    throw createPortfolioRemoteNitroFetchError({
+      kind: 'txhistory',
+      url,
+      messagePrefix: 'Portfolio Nitro Fetch txhistory request failed',
+      error,
+      includeErrorName: true,
+    });
   }
 
   const rawResponseText =

--- a/src/portfolio/adapters/rn/txHistoryRequest.ts
+++ b/src/portfolio/adapters/rn/txHistoryRequest.ts
@@ -187,6 +187,17 @@ function formatFailedNitroFetchResponseDetails(
   return details.length ? ` ${details.join(' ')}` : '';
 }
 
+function resolveTxHistoryTimeoutMs(cfg: BwsConfig): number {
+  'worklet';
+
+  const timeoutMs = Number(cfg?.timeoutMs);
+  if (Number.isFinite(timeoutMs)) {
+    return Math.max(0, Math.floor(timeoutMs));
+  }
+
+  return DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS;
+}
+
 export async function fetchPortfolioTxHistoryPageByRequest(args: {
   credentials: PortfolioRuntimeWalletCredentials;
   cfg: BwsConfig;
@@ -224,7 +235,7 @@ export async function fetchPortfolioTxHistoryPageByRequest(args: {
       url,
       method: 'GET',
       headers,
-      timeoutMs: DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS,
+      timeoutMs: resolveTxHistoryTimeoutMs(args.cfg),
       followRedirects: false,
     });
   } catch (error: unknown) {

--- a/src/portfolio/adapters/rn/txHistorySigning.ts
+++ b/src/portfolio/adapters/rn/txHistorySigning.ts
@@ -99,7 +99,7 @@ const SECP256K1_CURVE_ORDER_HEX =
   'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141';
 const SECP256K1_CURVE_HALF_ORDER_HEX =
   '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0';
-export const DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS = 15000;
+export const DEFAULT_PORTFOLIO_NITRO_FETCH_TIMEOUT_MS = 100000;
 const QUICK_CRYPTO_ENUMS: QuickCryptoEnums = {
   KeyType: {
     PRIVATE: 2,

--- a/src/portfolio/core/remoteRequestError.spec.ts
+++ b/src/portfolio/core/remoteRequestError.spec.ts
@@ -1,0 +1,63 @@
+import {
+  PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+  createPortfolioRemoteRequestError,
+  isPortfolioRemoteRequestError,
+} from './remoteRequestError';
+
+describe('portfolio remote request errors', () => {
+  it('tags txhistory request failures with a stable worklet-safe code', () => {
+    const error = createPortfolioRemoteRequestError({
+      kind: 'txhistory',
+      failureKind: 'http-status',
+      status: 404,
+      url: 'https://bws.example/v1/txhistory/?limit=1000',
+      message: 'BWS txhistory request failed with status 404.',
+    }) as any;
+
+    expect(isPortfolioRemoteRequestError(error)).toBe(true);
+    expect(error.code).toBe(PORTFOLIO_REMOTE_REQUEST_ERROR_CODE);
+    expect(error.portfolioRemoteRequestKind).toBe('txhistory');
+    expect(error.portfolioRemoteRequestFailureKind).toBe('http-status');
+    expect(error.portfolioRemoteRequestStatus).toBe(404);
+    expect(error.portfolioRemoteRequestUrl).toBe(
+      'https://bws.example/v1/txhistory/?limit=1000',
+    );
+  });
+
+  it('tags fiat-rate request failures with kind and URL metadata', () => {
+    const error = createPortfolioRemoteRequestError({
+      kind: 'fiat-rate',
+      failureKind: 'nitro-fetch',
+      url: 'https://bws.example/v4/fiatrates/USD?days=1&chain=arb&tokenAddress=0xToken',
+      message:
+        'Portfolio Nitro Fetch fiat-rate request failed for https://bws.example/v4/fiatrates/USD?days=1&chain=arb&tokenAddress=0xToken: timeout',
+    }) as any;
+
+    expect(isPortfolioRemoteRequestError(error)).toBe(true);
+    expect(error.code).toBe(PORTFOLIO_REMOTE_REQUEST_ERROR_CODE);
+    expect(error.portfolioRemoteRequestKind).toBe('fiat-rate');
+    expect(error.portfolioRemoteRequestFailureKind).toBe('nitro-fetch');
+    expect(error.portfolioRemoteRequestUrl).toContain('/v4/fiatrates/USD');
+  });
+
+  it('detects legacy remote request messages without explicit metadata', () => {
+    expect(
+      isPortfolioRemoteRequestError(
+        new Error('BWS txhistory request failed with status 500.'),
+      ),
+    ).toBe(true);
+    expect(
+      isPortfolioRemoteRequestError(
+        new Error('Failed to fetch fiat rates (503).'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not classify invalid tx history as a remote request failure', () => {
+    expect(
+      isPortfolioRemoteRequestError(
+        new Error('Invalid tx history: negative balance after tx tx-1 (-1).'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/portfolio/core/remoteRequestError.ts
+++ b/src/portfolio/core/remoteRequestError.ts
@@ -12,6 +12,35 @@ export type PortfolioRemoteRequestError = Error & {
   portfolioRemoteRequestUrl?: string;
 };
 
+function formatThrownErrorForPortfolioRequest(
+  error: unknown,
+  options?: {includeErrorName?: boolean},
+): string {
+  'worklet';
+
+  if (error instanceof Error) {
+    const name = String(error.name || 'Error').trim();
+    const message = String(error.message || '').trim();
+    return options?.includeErrorName && message
+      ? `${name}: ${message}`
+      : message || name;
+  }
+
+  if (typeof error === 'string') {
+    return error.trim();
+  }
+
+  if (error == null) {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(error) || '';
+  } catch {
+    return String(error);
+  }
+}
+
 export function createPortfolioRemoteRequestError(args: {
   kind: PortfolioRemoteRequestKind;
   failureKind: PortfolioRemoteRequestFailureKind;
@@ -40,6 +69,28 @@ export function createPortfolioRemoteRequestError(args: {
   }
 
   return error;
+}
+
+export function createPortfolioRemoteNitroFetchError(args: {
+  kind: PortfolioRemoteRequestKind;
+  url: string;
+  messagePrefix: string;
+  error: unknown;
+  includeErrorName?: boolean;
+}): Error {
+  'worklet';
+
+  const details = formatThrownErrorForPortfolioRequest(args.error, {
+    includeErrorName: args.includeErrorName,
+  });
+  return createPortfolioRemoteRequestError({
+    kind: args.kind,
+    failureKind: 'nitro-fetch',
+    url: args.url,
+    message: details
+      ? `${args.messagePrefix}: ${details}`
+      : `${args.messagePrefix}.`,
+  });
 }
 
 export function isPortfolioRemoteRequestError(

--- a/src/portfolio/core/remoteRequestError.ts
+++ b/src/portfolio/core/remoteRequestError.ts
@@ -1,0 +1,67 @@
+export const PORTFOLIO_REMOTE_REQUEST_ERROR_CODE =
+  'PORTFOLIO_REMOTE_REQUEST_FAILED';
+
+export type PortfolioRemoteRequestKind = 'txhistory' | 'fiat-rate';
+export type PortfolioRemoteRequestFailureKind = 'nitro-fetch' | 'http-status';
+
+export type PortfolioRemoteRequestError = Error & {
+  code?: string;
+  portfolioRemoteRequestKind?: PortfolioRemoteRequestKind;
+  portfolioRemoteRequestFailureKind?: PortfolioRemoteRequestFailureKind;
+  portfolioRemoteRequestStatus?: number;
+  portfolioRemoteRequestUrl?: string;
+};
+
+export function createPortfolioRemoteRequestError(args: {
+  kind: PortfolioRemoteRequestKind;
+  failureKind: PortfolioRemoteRequestFailureKind;
+  message: string;
+  status?: number;
+  url?: string;
+}): Error {
+  'worklet';
+
+  const error = new Error(
+    String(args.message || 'Portfolio remote request failed.'),
+  ) as PortfolioRemoteRequestError;
+  error.name = 'PortfolioRemoteRequestError';
+  error.code = PORTFOLIO_REMOTE_REQUEST_ERROR_CODE;
+  error.portfolioRemoteRequestKind = args.kind;
+  error.portfolioRemoteRequestFailureKind = args.failureKind;
+
+  const status = Number(args.status);
+  if (Number.isFinite(status)) {
+    error.portfolioRemoteRequestStatus = status;
+  }
+
+  const url = String(args.url || '').trim();
+  if (url) {
+    error.portfolioRemoteRequestUrl = url;
+  }
+
+  return error;
+}
+
+export function isPortfolioRemoteRequestError(
+  error: unknown,
+): error is PortfolioRemoteRequestError {
+  'worklet';
+
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+    return false;
+  }
+
+  const typedError = error as PortfolioRemoteRequestError & {message?: unknown};
+  if (typedError.code === PORTFOLIO_REMOTE_REQUEST_ERROR_CODE) {
+    return true;
+  }
+
+  const message = String(typedError.message || '');
+  return (
+    message.startsWith('Portfolio Nitro Fetch txhistory request failed') ||
+    message.startsWith('BWS txhistory request failed with status ') ||
+    message.startsWith('Portfolio Nitro Fetch fiat-rate request failed') ||
+    message.startsWith('Failed to fetch fiat rates (') ||
+    message.startsWith('BWS fiat-rate request failed with status ')
+  );
+}

--- a/src/portfolio/runtime/worklet/portfolioPopulateJobWorklet.spec.ts
+++ b/src/portfolio/runtime/worklet/portfolioPopulateJobWorklet.spec.ts
@@ -29,6 +29,8 @@ import {
   handleStartPopulateJobOnWorklet,
   resetPortfolioPopulateJobWorkletState,
 } from './portfolioPopulateJobWorklet';
+import {createNegativeBalanceInvalidHistoryError} from '../../core/pnl/invalidHistory';
+import {createPortfolioRemoteRequestError} from '../../core/remoteRequestError';
 import {
   disposePortfolioTxHistorySigningDispatchContext,
   takeNextPortfolioTransferredSignHandleOnRuntime,
@@ -327,7 +329,7 @@ describe('portfolioPopulateJobWorklet', () => {
     expectNoSerializedSecrets(activeJobState());
   });
 
-  it('skips a wallet prepare failure and continues populating the remaining wallets', async () => {
+  it('skips a wallet fiat-rate prepare failure without clearing snapshots and continues populating the remaining wallets', async () => {
     const paramsWithTwoWallets = {
       ...params,
       wallets: [
@@ -351,8 +353,17 @@ describe('portfolioPopulateJobWorklet', () => {
       ],
     } as any;
 
+    const fiatRateError = createPortfolioRemoteRequestError({
+      kind: 'fiat-rate',
+      failureKind: 'http-status',
+      status: 400,
+      url: 'https://bws.example/v4/fiatrates/USD?days=1',
+      message:
+        'Failed to fetch fiat rates (400) for https://bws.example/v4/fiatrates/USD?days=1.',
+    });
+
     mockHandlePrepareWalletOnPopulateWorklet
-      .mockRejectedValueOnce(new Error('Failed to fetch fiat rates (400).'))
+      .mockRejectedValueOnce(fiatRateError)
       .mockResolvedValueOnce({
         checkpoint: {nextSkip: 0},
       });
@@ -391,7 +402,8 @@ describe('portfolioPopulateJobWorklet', () => {
     expect(status?.errors).toEqual([
       {
         walletId: 'w1',
-        message: 'Failed to fetch fiat rates (400).',
+        message:
+          'Failed to fetch fiat rates (400) for https://bws.example/v4/fiatrates/USD?days=1.',
       },
     ]);
     expect(status?.result?.results).toHaveLength(1);
@@ -403,17 +415,7 @@ describe('portfolioPopulateJobWorklet', () => {
     expectNoSerializedSecrets(activeJobState());
     expect(mockHandlePrepareWalletOnPopulateWorklet).toHaveBeenCalledTimes(2);
     expect(mockHandleFinishWalletOnPopulateWorklet).toHaveBeenCalledTimes(1);
-    expect(mockClearWorkletWalletSnapshots).toHaveBeenCalledTimes(1);
-    expect(mockClearWorkletWalletSnapshots).toHaveBeenCalledWith(
-      {
-        storage: config.storage,
-        registryKey: config.registryKey,
-      },
-      'w1',
-      {
-        preserveInvalidHistoryMarker: false,
-      },
-    );
+    expect(mockClearWorkletWalletSnapshots).not.toHaveBeenCalled();
   });
 
   it('skips a wallet txhistory page failure and continues populating the remaining wallets', async () => {
@@ -499,6 +501,82 @@ describe('portfolioPopulateJobWorklet', () => {
     expect(mockHandlePrepareWalletOnPopulateWorklet).toHaveBeenCalledTimes(2);
     expect(mockHandleProcessNextPageOnPopulateWorklet).toHaveBeenCalledTimes(2);
     expect(mockHandleFinishWalletOnPopulateWorklet).toHaveBeenCalledTimes(1);
+    expect(mockClearWorkletWalletSnapshots).not.toHaveBeenCalled();
+  });
+
+  it('clears snapshots and preserves the invalid-history marker when invalid tx history fails a wallet', async () => {
+    const paramsWithTwoWallets = {
+      ...params,
+      wallets: [
+        params.wallets[0],
+        {
+          walletId: 'w2',
+          credentials: {
+            walletId: 'w2',
+            requestPrivKey: 'priv-key-2',
+          },
+          summary: {
+            walletId: 'w2',
+            walletName: 'Wallet 2',
+            chain: 'btc',
+            network: 'livenet',
+            currencyAbbreviation: 'btc',
+            balanceAtomic: '200000000',
+            balanceFormatted: '2',
+          },
+        },
+      ],
+    } as any;
+    const invalidHistoryError = createNegativeBalanceInvalidHistoryError({
+      txId: 'bad-tx',
+      balanceAtomic: '-1',
+      source: 'populate-job-test',
+    });
+
+    mockHandlePrepareWalletOnPopulateWorklet
+      .mockResolvedValueOnce({
+        checkpoint: {nextSkip: 0},
+      })
+      .mockResolvedValueOnce({
+        checkpoint: {nextSkip: 0},
+      });
+    mockHandleProcessNextPageOnPopulateWorklet
+      .mockRejectedValueOnce(invalidHistoryError)
+      .mockResolvedValueOnce({
+        checkpoint: {nextSkip: 0},
+        appendedSnapshots: 0,
+        fetchedTxs: 0,
+        logicalPageSize: 0,
+        done: true,
+        fetchMs: 1,
+        computeMs: 0,
+      });
+    mockHandleFinishWalletOnPopulateWorklet.mockResolvedValueOnce({
+      checkpoint: {nextSkip: 0},
+      appendedSnapshots: 1,
+    });
+
+    const started = await handleStartPopulateJobOnWorklet(
+      config,
+      paramsWithTwoWallets,
+      {
+        w1: signingContext('der-w1'),
+        w2: signingContext('der-w2'),
+      },
+    );
+    const status = await waitForTerminalStatus(started.jobId);
+
+    expect(status?.state).toBe('completed');
+    expect(status?.walletStatusById).toMatchObject({
+      w1: 'error',
+      w2: 'done',
+    });
+    expect(status?.errors).toEqual([
+      {
+        walletId: 'w1',
+        message: 'Invalid tx history: negative balance after tx bad-tx (-1).',
+      },
+    ]);
     expect(mockClearWorkletWalletSnapshots).toHaveBeenCalledTimes(1);
     expect(mockClearWorkletWalletSnapshots).toHaveBeenCalledWith(
       {
@@ -507,7 +585,7 @@ describe('portfolioPopulateJobWorklet', () => {
       },
       'w1',
       {
-        preserveInvalidHistoryMarker: false,
+        preserveInvalidHistoryMarker: true,
       },
     );
   });

--- a/src/portfolio/runtime/worklet/portfolioPopulateJobWorklet.ts
+++ b/src/portfolio/runtime/worklet/portfolioPopulateJobWorklet.ts
@@ -13,6 +13,7 @@ import type {
   WorkerRequest,
   WorkerResponse,
 } from '../../core/engine/workerProtocol';
+import {isPortfolioRemoteRequestError} from '../../core/remoteRequestError';
 import {toPortfolioRuntimeWalletCredentials} from '../../core/runtimeWalletCredentials';
 import {
   clearPortfolioTxHistorySigningDispatchContextOnRuntime,
@@ -663,20 +664,22 @@ async function runPortfolioPopulateJobLoop(args: {
           error instanceof Error
             ? error.message
             : String(error || 'Unknown error');
-        try {
-          await clearWorkletWalletSnapshots(
-            {
-              storage: config.storage,
-              registryKey: config.registryKey,
-            },
-            walletId,
-            {
-              preserveInvalidHistoryMarker:
-                isSnapshotInvalidHistoryError(error),
-            },
-          );
-        } catch {
-          // Ignore cleanup failures so the job can continue with the next wallet.
+        if (!isPortfolioRemoteRequestError(error)) {
+          try {
+            await clearWorkletWalletSnapshots(
+              {
+                storage: config.storage,
+                registryKey: config.registryKey,
+              },
+              walletId,
+              {
+                preserveInvalidHistoryMarker:
+                  isSnapshotInvalidHistoryError(error),
+              },
+            );
+          } catch {
+            // Ignore cleanup failures so the job can continue with the next wallet.
+          }
         }
         markWalletStatus(job, walletId, 'error');
         appendJobError(job, walletId, message);

--- a/src/portfolio/runtime/worklet/portfolioWorkletRates.spec.ts
+++ b/src/portfolio/runtime/worklet/portfolioWorkletRates.spec.ts
@@ -1,5 +1,9 @@
 import {clearPortfolioTxHistorySigningDispatchContextOnRuntime} from '../../adapters/rn/txHistorySigning';
 import {
+  PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+  isPortfolioRemoteRequestError,
+} from '../../core/remoteRequestError';
+import {
   createFakeWorkletStorage,
   installNitroFetchMock,
   type FakeNitroRequest,
@@ -243,6 +247,94 @@ describe('portfolioWorkletRates', () => {
         method: 'GET',
       }),
     );
+  });
+
+  it('tags native coin fiat-rate Nitro Fetch failures across snapshot intervals', async () => {
+    const requestSyncMock = installNitroFetchMock(() => {
+      throw new Error('socket timed out');
+    });
+
+    const promise = ensureWorkletSnapshotRateSeriesCache({
+      storage: createFakeWorkletStorage(),
+      registryKey: '__registry__',
+      cfg: {baseUrl: 'https://bws.bitpay.com/bws/api'},
+      quoteCurrency: 'USD',
+      wallet: {
+        walletId: 'w-native-fail',
+        walletName: 'BCH Wallet',
+        chain: 'bch',
+        network: 'livenet',
+        currencyAbbreviation: 'bch',
+        balanceAtomic: '0',
+        balanceFormatted: '0',
+      },
+    });
+
+    await expect(promise).rejects.toThrow(
+      'Portfolio Nitro Fetch fiat-rate request failed for https://bws.bitpay.com/bws/api/v4/fiatrates/USD: socket timed out',
+    );
+    await expect(promise).rejects.toMatchObject({
+      code: PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+      portfolioRemoteRequestKind: 'fiat-rate',
+      portfolioRemoteRequestFailureKind: 'nitro-fetch',
+      portfolioRemoteRequestUrl:
+        'https://bws.bitpay.com/bws/api/v4/fiatrates/USD',
+    });
+    await expect(promise.catch(isPortfolioRemoteRequestError)).resolves.toBe(
+      true,
+    );
+    expect(requestSyncMock.mock.calls.map(call => call[0].url)).toEqual([
+      'https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=1',
+      'https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=7',
+      'https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=30',
+      'https://bws.bitpay.com/bws/api/v4/fiatrates/USD',
+    ]);
+  });
+
+  it('tags token fiat-rate non-OK responses across snapshot intervals with chain and tokenAddress params', async () => {
+    const tokenAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const requestSyncMock = installNitroFetchMock(() => ({
+      ok: false,
+      status: 503,
+      bodyString: 'rate service down',
+    }));
+
+    const promise = ensureWorkletSnapshotRateSeriesCache({
+      storage: createFakeWorkletStorage(),
+      registryKey: '__registry__',
+      cfg: {baseUrl: 'https://bws.bitpay.com/bws/api'},
+      quoteCurrency: 'USD',
+      wallet: {
+        walletId: 'w-token-fail',
+        walletName: 'USDC SOL Wallet',
+        chain: 'sol',
+        network: 'livenet',
+        currencyAbbreviation: 'usdc',
+        tokenAddress,
+        balanceAtomic: '0',
+        balanceFormatted: '0',
+      },
+    });
+
+    await expect(promise).rejects.toThrow(
+      `Failed to fetch fiat rates (503) for https://bws.bitpay.com/bws/api/v4/fiatrates/USD?chain=sol&tokenAddress=${tokenAddress}. rate service down`,
+    );
+    await expect(promise).rejects.toMatchObject({
+      code: PORTFOLIO_REMOTE_REQUEST_ERROR_CODE,
+      portfolioRemoteRequestKind: 'fiat-rate',
+      portfolioRemoteRequestFailureKind: 'http-status',
+      portfolioRemoteRequestStatus: 503,
+      portfolioRemoteRequestUrl: `https://bws.bitpay.com/bws/api/v4/fiatrates/USD?chain=sol&tokenAddress=${tokenAddress}`,
+    });
+    await expect(promise.catch(isPortfolioRemoteRequestError)).resolves.toBe(
+      true,
+    );
+    expect(requestSyncMock.mock.calls.map(call => call[0].url)).toEqual([
+      `https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=1&chain=sol&tokenAddress=${tokenAddress}`,
+      `https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=7&chain=sol&tokenAddress=${tokenAddress}`,
+      `https://bws.bitpay.com/bws/api/v4/fiatrates/USD?days=30&chain=sol&tokenAddress=${tokenAddress}`,
+      `https://bws.bitpay.com/bws/api/v4/fiatrates/USD?chain=sol&tokenAddress=${tokenAddress}`,
+    ]);
   });
 
   it('continues fetching later intervals for a token when earlier rate requests fail', async () => {

--- a/src/portfolio/runtime/worklet/portfolioWorkletRates.ts
+++ b/src/portfolio/runtime/worklet/portfolioWorkletRates.ts
@@ -1,5 +1,6 @@
 import type {BwsConfig} from '../../core/shared/bws';
 import type {NitroResponse as NitroFetchResponse} from 'react-native-nitro-fetch';
+import {createPortfolioRemoteRequestError} from '../../core/remoteRequestError';
 import {
   CANONICAL_FIAT_QUOTE,
   DEFAULT_STORED_FIAT_RATE_INTERVALS,
@@ -159,19 +160,26 @@ async function fetchFiatRatePayload(args: {
   } catch (error: unknown) {
     const runtimeError =
       error instanceof Error ? error : new Error(String(error));
-    throw new Error(
-      `Portfolio Nitro Fetch fiat-rate request failed for ${url}: ${runtimeError.message}`,
-    );
+    throw createPortfolioRemoteRequestError({
+      kind: 'fiat-rate',
+      failureKind: 'nitro-fetch',
+      url,
+      message: `Portfolio Nitro Fetch fiat-rate request failed for ${url}: ${runtimeError.message}`,
+    });
   }
 
   const rawText =
     typeof response.bodyString === 'string' ? response.bodyString : '';
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch fiat rates (${
+    throw createPortfolioRemoteRequestError({
+      kind: 'fiat-rate',
+      failureKind: 'http-status',
+      status: response.status,
+      url,
+      message: `Failed to fetch fiat rates (${
         response.status
       }) for ${url}. ${rawText.slice(0, 400)}`,
-    );
+    });
   }
 
   try {

--- a/src/portfolio/runtime/worklet/portfolioWorkletRates.ts
+++ b/src/portfolio/runtime/worklet/portfolioWorkletRates.ts
@@ -1,6 +1,9 @@
 import type {BwsConfig} from '../../core/shared/bws';
 import type {NitroResponse as NitroFetchResponse} from 'react-native-nitro-fetch';
-import {createPortfolioRemoteRequestError} from '../../core/remoteRequestError';
+import {
+  createPortfolioRemoteNitroFetchError,
+  createPortfolioRemoteRequestError,
+} from '../../core/remoteRequestError';
 import {
   CANONICAL_FIAT_QUOTE,
   DEFAULT_STORED_FIAT_RATE_INTERVALS,
@@ -158,13 +161,11 @@ async function fetchFiatRatePayload(args: {
       followRedirects: true,
     });
   } catch (error: unknown) {
-    const runtimeError =
-      error instanceof Error ? error : new Error(String(error));
-    throw createPortfolioRemoteRequestError({
+    throw createPortfolioRemoteNitroFetchError({
       kind: 'fiat-rate',
-      failureKind: 'nitro-fetch',
       url,
-      message: `Portfolio Nitro Fetch fiat-rate request failed for ${url}: ${runtimeError.message}`,
+      messagePrefix: `Portfolio Nitro Fetch fiat-rate request failed for ${url}`,
+      error,
     });
   }
 

--- a/src/portfolio/ui/hooks/usePortfolioBalanceChartReadiness.ts
+++ b/src/portfolio/ui/hooks/usePortfolioBalanceChartReadiness.ts
@@ -20,6 +20,7 @@ export type PortfolioBalanceChartReadiness = {
   isSnapshotPresenceLoading: boolean;
   isBalanceChartDataReadyToQuery: boolean;
   shouldRenderZeroBalanceChart: boolean;
+  shouldPreserveStaleBalanceChart: boolean;
   shouldMountBalanceChart: boolean;
   shouldShowChartLoader: boolean;
 };
@@ -78,6 +79,8 @@ export default function usePortfolioBalanceChartReadiness(args: {
     canCheckSnapshotPresence &&
     !isScopePopulateLoading &&
     !isSnapshotPresenceLoading;
+  const shouldPreserveStaleBalanceChart =
+    hasHistoricalChartData && isScopePopulateLoading;
   const shouldRenderZeroBalanceChart =
     isBalanceChartDataReadyToQuery &&
     args.renderZeroBalanceChartWhenNoSnapshots === true &&
@@ -85,10 +88,13 @@ export default function usePortfolioBalanceChartReadiness(args: {
     !snapshotPresence.hasAnySnapshots &&
     !hasNonZeroLiveBalance;
   const isChartDataPending =
-    canCheckSnapshotPresence && !isBalanceChartDataReadyToQuery;
+    canCheckSnapshotPresence &&
+    !isBalanceChartDataReadyToQuery &&
+    !shouldPreserveStaleBalanceChart;
   const canRenderBalanceChart =
-    isBalanceChartDataReadyToQuery &&
-    (hasHistoricalChartData || shouldRenderZeroBalanceChart);
+    (isBalanceChartDataReadyToQuery &&
+      (hasHistoricalChartData || shouldRenderZeroBalanceChart)) ||
+    shouldPreserveStaleBalanceChart;
   const shouldShowChartLoader = !canRenderBalanceChart && isChartDataPending;
   const shouldMountBalanceChart =
     canRenderBalanceChart || shouldShowChartLoader;
@@ -104,6 +110,7 @@ export default function usePortfolioBalanceChartReadiness(args: {
     isScopePopulateLoading,
     isSnapshotPresenceLoading,
     shouldRenderZeroBalanceChart,
+    shouldPreserveStaleBalanceChart,
     shouldMountBalanceChart,
     shouldShowChartLoader,
   };

--- a/src/portfolio/ui/hooks/usePortfolioBalanceChartSurface.spec.tsx
+++ b/src/portfolio/ui/hooks/usePortfolioBalanceChartSurface.spec.tsx
@@ -15,12 +15,14 @@ const HookHarness = ({
   fallbackCurrency = 'USD',
   fallbackBalance = 100,
   isBalanceChartDataReadyToQuery = true,
+  preserveChartDrivenStateWhileNotReady = false,
   resetKey = 'a',
 }: {
   quoteCurrency?: string;
   fallbackCurrency?: string;
   fallbackBalance?: number;
   isBalanceChartDataReadyToQuery?: boolean;
+  preserveChartDrivenStateWhileNotReady?: boolean;
   resetKey?: string;
 }) => {
   latestResult = usePortfolioBalanceChartSurface({
@@ -29,6 +31,7 @@ const HookHarness = ({
     fallbackCurrency,
     fallbackBalance,
     isBalanceChartDataReadyToQuery,
+    preserveChartDrivenStateWhileNotReady,
     resetKey,
   });
   return null;
@@ -135,5 +138,41 @@ describe('usePortfolioBalanceChartSurface', () => {
     expect(latestResult?.displayedTopBalance).toBe(100);
     expect(latestResult?.displayedTopBalanceCurrency).toBe('USD');
     expect(latestResult?.changeRowData).toBeUndefined();
+  });
+
+  it('preserves chart-driven values while chart data is not ready when requested', async () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(<HookHarness />);
+    });
+
+    await act(async () => {
+      latestResult?.chartCallbacks.onDisplayedAnalysisPointChange({
+        totalFiatBalance: 125,
+        totalPnlChange: 10,
+        totalPnlPercent: 5,
+        totalCryptoBalanceFormatted: '1.25',
+      });
+      latestResult?.chartCallbacks.onChangeRowData({
+        percent: 5,
+        deltaFiatFormatted: '$10.00',
+        rangeLabel: '1D',
+      });
+    });
+
+    await act(async () => {
+      renderer.update(
+        <HookHarness
+          isBalanceChartDataReadyToQuery={false}
+          preserveChartDrivenStateWhileNotReady={true}
+        />,
+      );
+    });
+
+    expect(latestResult?.displayedBalance).toBe(125);
+    expect(latestResult?.displayedAnalysisPoint?.totalFiatBalance).toBe(125);
+    expect(latestResult?.changeRowData?.percent).toBe(5);
+    expect(latestResult?.displayedTopBalance).toBe(125);
+    expect(latestResult?.displayedTopBalanceCurrency).toBe('EUR');
   });
 });

--- a/src/portfolio/ui/hooks/usePortfolioBalanceChartSurface.ts
+++ b/src/portfolio/ui/hooks/usePortfolioBalanceChartSurface.ts
@@ -22,11 +22,14 @@ export function usePortfolioBalanceChartSurface(args: {
   fallbackCurrency?: string;
   enabled?: boolean;
   isBalanceChartDataReadyToQuery?: boolean;
+  preserveChartDrivenStateWhileNotReady?: boolean;
   resetKey?: string;
 }) {
   const enabled = args.enabled !== false;
   const canUseChartDrivenState =
-    enabled && args.isBalanceChartDataReadyToQuery !== false;
+    enabled &&
+    (args.isBalanceChartDataReadyToQuery !== false ||
+      args.preserveChartDrivenStateWhileNotReady === true);
   const [selectedBalance, setSelectedBalance] = useState<number | undefined>();
   const [displayedBalance, setDisplayedBalance] = useState<
     number | undefined
@@ -46,17 +49,34 @@ export function usePortfolioBalanceChartSurface(args: {
       .join('|');
   }, [args.wallets]);
 
-  useEffect(() => {
+  const clearChartDrivenState = useCallback(() => {
     setSelectedBalance(undefined);
     setDisplayedBalance(undefined);
     setDisplayedAnalysisPoint(undefined);
     setChangeRowData(undefined);
+  }, []);
+
+  useEffect(() => {
+    clearChartDrivenState();
   }, [
-    args.isBalanceChartDataReadyToQuery,
     args.quoteCurrency,
     args.resetKey,
+    clearChartDrivenState,
     enabled,
     walletIdsSignature,
+  ]);
+
+  useEffect(() => {
+    if (
+      args.isBalanceChartDataReadyToQuery === false &&
+      args.preserveChartDrivenStateWhileNotReady !== true
+    ) {
+      clearChartDrivenState();
+    }
+  }, [
+    args.isBalanceChartDataReadyToQuery,
+    args.preserveChartDrivenStateWhileNotReady,
+    clearChartDrivenState,
   ]);
 
   const onDisplayedAnalysisPointChange = useCallback(

--- a/src/store/portfolio/portfolio.actions.ts
+++ b/src/store/portfolio/portfolio.actions.ts
@@ -5,6 +5,7 @@ import type {
   WalletIdMap,
   WalletPopulateState,
 } from './portfolio.models';
+import type {PortfolioPopulateDecisionReason} from '../../portfolio/service';
 import {PortfolioActionType, PortfolioActionTypes} from './portfolio.types';
 
 export const clearPortfolio = (): PortfolioActionType => ({
@@ -17,6 +18,8 @@ export const cancelPopulatePortfolio = (): PortfolioActionType => ({
 
 export const startPopulatePortfolio = (payload: {
   quoteCurrency: string;
+  decisionReasonByWalletId?: WalletIdMap<PortfolioPopulateDecisionReason>;
+  decisionSource?: string;
 }): PortfolioActionType => ({
   type: PortfolioActionTypes.START_POPULATE_PORTFOLIO,
   payload,

--- a/src/store/portfolio/portfolio.models.ts
+++ b/src/store/portfolio/portfolio.models.ts
@@ -1,3 +1,5 @@
+import type {PortfolioPopulateDecisionReason} from '../../portfolio/service';
+
 export interface PortfolioPopulateError {
   walletId: string;
   message: string;
@@ -66,6 +68,8 @@ export interface PortfolioPopulateStatus {
   txsProcessed: number;
   errors: PortfolioPopulateError[];
   walletStatusById?: WalletIdMap<WalletPopulateState>;
+  decisionReasonByWalletId?: WalletIdMap<PortfolioPopulateDecisionReason>;
+  decisionSource?: string;
 }
 
 export interface PortfolioState {

--- a/src/store/portfolio/portfolio.reducer.spec.ts
+++ b/src/store/portfolio/portfolio.reducer.spec.ts
@@ -11,6 +11,7 @@ import {
   setInvalidDecimalsByWalletIdUpdates,
   setQuarantinesByWalletIdUpdates,
   setSnapshotBalanceMismatchesByWalletIdUpdates,
+  startPopulatePortfolio,
 } from './portfolio.actions';
 import {selectCanRenderPortfolioBalanceCharts} from './portfolio.selectors';
 
@@ -163,6 +164,22 @@ describe('portfolioReducer', () => {
     expect(cancelled.lastFullPopulateCompletedAt).toBe(150);
   });
 
+  it('stores active populate decision reasons when populate starts', () => {
+    const result = portfolioReducer(
+      makeState(),
+      startPopulatePortfolio({
+        quoteCurrency: 'USD',
+        decisionReasonByWalletId: {'wallet-1': 'missing_index'},
+        decisionSource: 'app_launch_staleness',
+      }),
+    );
+
+    expect(result.populateStatus.decisionReasonByWalletId).toEqual({
+      'wallet-1': 'missing_index',
+    });
+    expect(result.populateStatus.decisionSource).toBe('app_launch_staleness');
+  });
+
   it('stores and clears atomic snapshot balance mismatches by wallet id', () => {
     const mismatch = {
       walletId: 'wallet-1',
@@ -244,6 +261,28 @@ describe('portfolioReducer', () => {
       ...marker,
       walletId: 'wallet-2',
     });
+  });
+
+  it('clears populate decision reasons with wallet portfolio state', () => {
+    const cleared = portfolioReducer(
+      makeState({
+        populateStatus: {
+          ...makeState().populateStatus,
+          decisionReasonByWalletId: {
+            'wallet-1': 'missing_index',
+            'wallet-2': 'balance_mismatch',
+          },
+        },
+      }),
+      clearWalletPortfolioState({walletIds: ['wallet-1']}),
+    );
+
+    expect(
+      cleared.populateStatus.decisionReasonByWalletId?.['wallet-1'],
+    ).toBeUndefined();
+    expect(cleared.populateStatus.decisionReasonByWalletId?.['wallet-2']).toBe(
+      'balance_mismatch',
+    );
   });
 
   it('marks the initial baseline complete and unblocks last-populated render paths', () => {

--- a/src/store/portfolio/portfolio.reducer.ts
+++ b/src/store/portfolio/portfolio.reducer.ts
@@ -22,6 +22,8 @@ const initialState: PortfolioState = {
     txsProcessed: 0,
     errors: [],
     walletStatusById: {},
+    decisionReasonByWalletId: {},
+    decisionSource: undefined,
   },
   snapshotBalanceMismatchesByWalletId: {},
   invalidDecimalsByWalletId: {},
@@ -129,6 +131,9 @@ export const portfolioReducer = (
           txsProcessed: 0,
           errors: [],
           walletStatusById: {},
+          decisionReasonByWalletId:
+            action.payload.decisionReasonByWalletId || {},
+          decisionSource: action.payload.decisionSource,
         },
       };
     }
@@ -186,6 +191,10 @@ export const portfolioReducer = (
         state.populateStatus.walletStatusById,
         walletIds,
       );
+      const nextDecisionReasonByWalletId = clearWalletIdsFromMap(
+        state.populateStatus.decisionReasonByWalletId,
+        walletIds,
+      );
 
       const currentWalletId =
         state.populateStatus.currentWalletId &&
@@ -199,6 +208,7 @@ export const portfolioReducer = (
           ...state.populateStatus,
           currentWalletId,
           walletStatusById: nextWalletStatusById,
+          decisionReasonByWalletId: nextDecisionReasonByWalletId,
         },
         snapshotBalanceMismatchesByWalletId:
           nextSnapshotBalanceMismatchesByWalletId,

--- a/src/store/portfolio/portfolio.runtime.effects.spec.ts
+++ b/src/store/portfolio/portfolio.runtime.effects.spec.ts
@@ -1728,27 +1728,6 @@ describe('portfolio runtime effects lock deferral', () => {
     expect(mockPortfolioService).toHaveBeenCalledTimes(1);
   });
 
-  it('app launch falls back to full populate when startup wallet init is not confirmed completed', async () => {
-    const state = makeState();
-    const {dispatch} = makeStore(state);
-    mockWaitForStartupWalletStoreInitForPortfolio.mockResolvedValueOnce({
-      status: 'skipped',
-      walletInitSuccess: false,
-    });
-    mockPopulateWallets.mockResolvedValueOnce(
-      successfulPopulateResult({
-        results: [],
-        status: {walletStatusById: {}, walletsCompleted: 0},
-      }),
-    );
-
-    await dispatchAppLaunchPopulateWithUsd(dispatch);
-
-    expect(mockGetPortfolioPopulateDecisionsForWallets).not.toHaveBeenCalled();
-    expectStartPopulateWithUsd();
-    expect(mockPortfolioService).toHaveBeenCalledTimes(1);
-  });
-
   it('app launch marks the initial baseline complete when all wallets are up to date', async () => {
     const state = makeInitialBaselineState();
     const {dispatch, dispatched} = makeStore(state);

--- a/src/store/portfolio/portfolio.runtime.effects.spec.ts
+++ b/src/store/portfolio/portfolio.runtime.effects.spec.ts
@@ -413,9 +413,11 @@ const expectPopulateResumeSettledAction = (dispatched: any[]) =>
   );
 
 const expectStartPopulateWithUsd = () =>
-  expect(mockStartPopulatePortfolio).toHaveBeenCalledWith({
-    quoteCurrency: 'USD',
-  });
+  expect(mockStartPopulatePortfolio).toHaveBeenCalledWith(
+    expect.objectContaining({
+      quoteCurrency: 'USD',
+    }),
+  );
 
 const expectFinishedFullPopulate = (overrides: Record<string, any> = {}) =>
   expect(mockFinishPopulatePortfolio).toHaveBeenCalledWith(
@@ -1489,6 +1491,12 @@ describe('portfolio runtime effects lock deferral', () => {
     expect(
       mockGetPortfolioPopulateDecisionsForWallets.mock.calls[0][0].wallets,
     ).toEqual([wallet]);
+    expect(mockStartPopulatePortfolio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decisionReasonByWalletId: {'wallet-from-state': 'missing_snapshot'},
+        decisionSource: 'scoped_staleness',
+      }),
+    );
     expect(mockPopulateWallets.mock.calls[0][0].wallets).toEqual([
       {walletId: 'wallet-from-state', summary: {walletId: 'wallet-from-state'}},
     ]);
@@ -1763,6 +1771,12 @@ describe('portfolio runtime effects lock deferral', () => {
     await dispatchAppLaunchPopulateWithUsd(dispatch);
 
     expectStartPopulateWithUsd();
+    expect(mockStartPopulatePortfolio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decisionReasonByWalletId: {'wallet-1': 'missing_index'},
+        decisionSource: 'app_launch_staleness',
+      }),
+    );
     expect(mockFinishPopulatePortfolio).toHaveBeenCalledWith(
       expect.objectContaining({
         finishedAt: 1234,

--- a/src/store/portfolio/portfolio.runtime.effects.ts
+++ b/src/store/portfolio/portfolio.runtime.effects.ts
@@ -72,6 +72,8 @@ type PopulatePortfolioWithRuntimeArgs = {
   quoteCurrency?: string;
   snapshotDebugMode?: SnapshotPersistDebugMode;
   completesInitialBaseline?: boolean;
+  decisionReasonByWalletId?: WalletIdMap<PortfolioPopulateDecision['reason']>;
+  decisionSource?: string;
 } & PortfolioQuarantineRetryOptions;
 
 type MaybePopulatePortfolioForWalletsWithRuntimeArgs = {
@@ -729,6 +731,21 @@ const isSettledInitialBaselineNoopDecision = (
   decision.reason === 'invalid_decimals' ||
   decision.reason === 'excessive_balance_mismatch' ||
   decision.reason === 'zero_balance_token_missing_index';
+
+const buildPopulateDecisionReasonByWalletId = (args: {
+  decisions: PortfolioPopulateDecision[];
+  walletIdsToPopulate: string[];
+}): WalletIdMap<PortfolioPopulateDecision['reason']> => {
+  const walletIdsToPopulate = new Set(args.walletIdsToPopulate);
+  return Object.fromEntries(
+    args.decisions
+      .filter(
+        decision =>
+          decision.shouldPopulate && walletIdsToPopulate.has(decision.walletId),
+      )
+      .map(decision => [decision.walletId, decision.reason]),
+  );
+};
 
 const dispatchWalletIdMapUpdates = <T>(
   dispatch: any,
@@ -1471,6 +1488,11 @@ export const maybePopulatePortfolioForWalletsWithRuntime =
       populatePortfolioWithRuntime({
         wallets: walletsToPopulate,
         quoteCurrency: args.quoteCurrency,
+        decisionReasonByWalletId: buildPopulateDecisionReasonByWalletId({
+          decisions: decisions.decisions,
+          walletIdsToPopulate: decisions.walletIdsToPopulate,
+        }),
+        decisionSource: 'scoped_staleness',
       }),
     );
   };
@@ -1599,6 +1621,11 @@ export const maybePopulatePortfolioOnAppLaunchWithRuntime =
         ),
         wallets: walletsToPopulate,
         quoteCurrency,
+        decisionReasonByWalletId: buildPopulateDecisionReasonByWalletId({
+          decisions: decisions.decisions,
+          walletIdsToPopulate: decisions.walletIdsToPopulate,
+        }),
+        decisionSource: 'app_launch_staleness',
       }),
     );
   };
@@ -1698,7 +1725,15 @@ export const populatePortfolioWithRuntime =
       return;
     }
 
-    dispatch(startPopulatePortfolio({quoteCurrency}));
+    dispatch(
+      startPopulatePortfolio({
+        quoteCurrency,
+        ...(args?.decisionReasonByWalletId
+          ? {decisionReasonByWalletId: args.decisionReasonByWalletId}
+          : {}),
+        ...(args?.decisionSource ? {decisionSource: args.decisionSource} : {}),
+      }),
+    );
     if (invalidDecimalsErrors.length) {
       dispatch(
         updatePopulateProgress({

--- a/src/store/portfolio/portfolio.types.ts
+++ b/src/store/portfolio/portfolio.types.ts
@@ -5,6 +5,7 @@ import type {
   WalletIdMap,
   WalletPopulateState,
 } from './portfolio.models';
+import type {PortfolioPopulateDecisionReason} from '../../portfolio/service';
 
 export enum PortfolioActionTypes {
   CLEAR_PORTFOLIO = 'PORTFOLIO/CLEAR_PORTFOLIO',
@@ -33,7 +34,11 @@ export type PortfolioActionType =
   | PortfolioAction<PortfolioActionTypes.CANCEL_POPULATE_PORTFOLIO>
   | PortfolioPayloadAction<
       PortfolioActionTypes.START_POPULATE_PORTFOLIO,
-      {quoteCurrency: string}
+      {
+        quoteCurrency: string;
+        decisionReasonByWalletId?: WalletIdMap<PortfolioPopulateDecisionReason>;
+        decisionSource?: string;
+      }
     >
   | PortfolioPayloadAction<
       PortfolioActionTypes.UPDATE_POPULATE_PROGRESS,

--- a/src/store/transforms/transforms.spec.ts
+++ b/src/store/transforms/transforms.spec.ts
@@ -428,13 +428,38 @@ describe('transformPortfolioPopulateStatus', () => {
       populateStatus: {
         inProgress: true,
         currentWalletId: 'w1',
+        decisionReasonByWalletId: {w1: 'missing_index'},
+        decisionSource: 'app_launch_staleness',
         walletStatusById: {w1: 'in_progress'},
       },
     };
     const result = getOutbound()(state);
     expect(result.populateStatus.inProgress).toBe(false);
     expect(result.populateStatus.currentWalletId).toBeUndefined();
+    expect(result.populateStatus.decisionReasonByWalletId).toEqual({});
+    expect(result.populateStatus.decisionSource).toBeUndefined();
     expect(result.populateStatus.walletStatusById).toEqual({});
+  });
+
+  it('clears persisted populate debug decisions when inProgress is false', () => {
+    const state: any = {
+      populateStatus: {
+        inProgress: false,
+        currentWalletId: undefined,
+        decisionReasonByWalletId: {w1: 'missing_index'},
+        decisionSource: 'app_launch_staleness',
+        finishedAt: 200,
+        startedAt: 100,
+        stopReason: 'completed',
+      },
+    };
+    const result = getOutbound()(state);
+    expect(result).not.toBe(state);
+    expect(result.populateStatus).toEqual({
+      ...state.populateStatus,
+      decisionReasonByWalletId: {},
+      decisionSource: undefined,
+    });
   });
 
   it('returns state unchanged when inProgress is false', () => {

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -211,24 +211,25 @@ export const transformPortfolioPopulateStatus = createTransform<
       !!populateStatus.decisionSource ||
       !!Object.keys(populateStatus.decisionReasonByWalletId || {}).length;
 
-    if (populateStatus.inProgress || hasPersistedPopulateDebugData) {
-      return {
-        ...outboundState,
-        populateStatus: {
-          ...populateStatus,
-          ...(populateStatus.inProgress
-            ? {
-                inProgress: false,
-                currentWalletId: undefined,
-                walletStatusById: {},
-              }
-            : {}),
-          decisionReasonByWalletId: {},
-          decisionSource: undefined,
-        },
-      };
+    if (!populateStatus.inProgress && !hasPersistedPopulateDebugData) {
+      return outboundState;
     }
-    return outboundState;
+
+    return {
+      ...outboundState,
+      populateStatus: {
+        ...populateStatus,
+        ...(populateStatus.inProgress
+          ? {
+              inProgress: false,
+              currentWalletId: undefined,
+              walletStatusById: {},
+            }
+          : {}),
+        decisionReasonByWalletId: {},
+        decisionSource: undefined,
+      },
+    };
   },
   {whitelist: ['PORTFOLIO']},
 );

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -202,14 +202,29 @@ export const transformPortfolioPopulateStatus = createTransform<
 >(
   inboundState => inboundState,
   outboundState => {
-    if (outboundState?.populateStatus?.inProgress) {
+    const populateStatus = outboundState?.populateStatus;
+    if (!populateStatus) {
+      return outboundState;
+    }
+
+    const hasPersistedPopulateDebugData =
+      !!populateStatus.decisionSource ||
+      !!Object.keys(populateStatus.decisionReasonByWalletId || {}).length;
+
+    if (populateStatus.inProgress || hasPersistedPopulateDebugData) {
       return {
         ...outboundState,
         populateStatus: {
-          ...outboundState.populateStatus,
-          inProgress: false,
-          currentWalletId: undefined,
-          walletStatusById: {},
+          ...populateStatus,
+          ...(populateStatus.inProgress
+            ? {
+                inProgress: false,
+                currentWalletId: undefined,
+                walletStatusById: {},
+              }
+            : {}),
+          decisionReasonByWalletId: {},
+          decisionSource: undefined,
         },
       };
     }

--- a/src/store/wallet/effects/init/init.spec.ts
+++ b/src/store/wallet/effects/init/init.spec.ts
@@ -72,10 +72,7 @@ describe('wallet store init portfolio wait', () => {
   });
 
   it('waits when called before wallet init starts, then joins completion', async () => {
-    const waitPromise = waitForStartupWalletStoreInitForPortfolio({
-      beginTimeoutMs: 1000,
-      timeoutMs: 1000,
-    });
+    const waitPromise = waitForStartupWalletStoreInitForPortfolio();
     const {dispatch} = makeStore();
 
     await expect(dispatch(startWalletStoreInit())).resolves.toEqual({
@@ -93,7 +90,7 @@ describe('wallet store init portfolio wait', () => {
     await dispatch(startWalletStoreInit());
 
     await expect(
-      waitForStartupWalletStoreInitForPortfolio({timeoutMs: 1000}),
+      waitForStartupWalletStoreInitForPortfolio(),
     ).resolves.toMatchObject({
       status: 'completed',
       walletInitSuccess: true,
@@ -110,25 +107,32 @@ describe('wallet store init portfolio wait', () => {
       walletInitSuccess: false,
     });
     await expect(
-      waitForStartupWalletStoreInitForPortfolio({timeoutMs: 1000}),
+      waitForStartupWalletStoreInitForPortfolio(),
     ).resolves.toMatchObject({
       status: 'failed',
       walletInitSuccess: false,
     });
   });
 
-  it('resolves with timeout when startup wallet init never begins', async () => {
-    jest.useFakeTimers();
-
-    const waitPromise = waitForStartupWalletStoreInitForPortfolio({
-      beginTimeoutMs: 25,
-      timeoutMs: 25,
+  it('keeps waiting while startup wallet init has not begun', async () => {
+    const waitPromise = waitForStartupWalletStoreInitForPortfolio();
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
     });
-    jest.advanceTimersByTime(25);
+
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    const {dispatch} = makeStore();
+    await expect(dispatch(startWalletStoreInit())).resolves.toEqual({
+      walletInitSuccess: true,
+    });
 
     await expect(waitPromise).resolves.toMatchObject({
-      status: 'timeout',
-      walletInitSuccess: false,
+      status: 'completed',
+      walletInitSuccess: true,
     });
   });
 });

--- a/src/store/wallet/effects/init/init.ts
+++ b/src/store/wallet/effects/init/init.ts
@@ -77,20 +77,9 @@ const waitForWalletStoreInitToStart = (): Promise<void> => {
   }
 
   return new Promise(resolve => {
-    const listener = () => {
-      walletStoreInitStartListeners = walletStoreInitStartListeners.filter(
-        candidate => candidate !== listener,
-      );
-      resolve();
-    };
-    walletStoreInitStartListeners.push(listener);
+    walletStoreInitStartListeners.push(resolve);
   });
 };
-
-const waitForActiveWalletStoreInit = (
-  activePromise: Promise<WalletStoreInitResult>,
-): Promise<StartupWalletStoreInitWaitResult> =>
-  activePromise.then(toStartupWaitResult, toStartupFailureWaitResult);
 
 export const waitForStartupWalletStoreInitForPortfolio =
   async (): Promise<StartupWalletStoreInitWaitResult> => {
@@ -101,7 +90,10 @@ export const waitForStartupWalletStoreInitForPortfolio =
 
       const activePromise = activeWalletStoreInitPromise;
       if (activePromise) {
-        return waitForActiveWalletStoreInit(activePromise);
+        return activePromise.then(
+          toStartupWaitResult,
+          toStartupFailureWaitResult,
+        );
       }
 
       await waitForWalletStoreInitToStart();

--- a/src/store/wallet/effects/init/init.ts
+++ b/src/store/wallet/effects/init/init.ts
@@ -9,17 +9,13 @@ import {formatUnknownError} from '../../../../utils/errors/formatUnknownError';
 export type WalletStoreInitResult = {walletInitSuccess: boolean};
 
 export type StartupWalletStoreInitWaitResult = {
-  status: 'completed' | 'failed' | 'skipped' | 'timeout';
+  status: 'completed' | 'failed';
   walletInitSuccess: boolean;
   errorMessage?: string;
 };
 
-const STARTUP_WALLET_STORE_INIT_PORTFOLIO_WAIT_MS = 15000;
-const STARTUP_WALLET_STORE_INIT_BEGIN_WAIT_MS = 1000;
-
 let activeWalletStoreInitPromise: Promise<WalletStoreInitResult> | undefined;
 let lastWalletStoreInitWaitResult: StartupWalletStoreInitWaitResult | undefined;
-let walletStoreInitHasStarted = false;
 let walletStoreInitStartListeners: Array<() => void> = [];
 
 const runWalletStoreInit = async (
@@ -54,14 +50,6 @@ const runWalletStoreInit = async (
   }
 };
 
-const normalizeTimeoutMs = (
-  value: number | undefined,
-  fallback: number,
-): number =>
-  typeof value === 'number' && Number.isFinite(value)
-    ? Math.max(0, Math.floor(value))
-    : fallback;
-
 const toStartupWaitResult = (
   result: WalletStoreInitResult,
 ): StartupWalletStoreInitWaitResult => ({
@@ -83,128 +71,46 @@ const notifyWalletStoreInitStarted = (): void => {
   listeners.forEach(listener => listener());
 };
 
-const waitForWalletStoreInitToStart = (timeoutMs: number): Promise<boolean> => {
-  if (
-    activeWalletStoreInitPromise ||
-    lastWalletStoreInitWaitResult ||
-    walletStoreInitHasStarted
-  ) {
-    return Promise.resolve(true);
-  }
-
-  if (timeoutMs <= 0) {
-    return Promise.resolve(false);
+const waitForWalletStoreInitToStart = (): Promise<void> => {
+  if (activeWalletStoreInitPromise || lastWalletStoreInitWaitResult) {
+    return Promise.resolve();
   }
 
   return new Promise(resolve => {
-    let settled = false;
-    let listener: (() => void) | undefined;
-    const settle = (didStart: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeoutId);
-      if (listener) {
-        walletStoreInitStartListeners = walletStoreInitStartListeners.filter(
-          candidate => candidate !== listener,
-        );
-      }
-      resolve(didStart);
+    const listener = () => {
+      walletStoreInitStartListeners = walletStoreInitStartListeners.filter(
+        candidate => candidate !== listener,
+      );
+      resolve();
     };
-    const timeoutId = setTimeout(() => settle(false), timeoutMs);
-    listener = () => settle(true);
     walletStoreInitStartListeners.push(listener);
   });
 };
 
 const waitForActiveWalletStoreInit = (
   activePromise: Promise<WalletStoreInitResult>,
-  timeoutMs: number,
-): Promise<StartupWalletStoreInitWaitResult> => {
-  if (timeoutMs <= 0) {
-    return Promise.resolve({
-      status: 'timeout',
-      walletInitSuccess: false,
-    });
-  }
+): Promise<StartupWalletStoreInitWaitResult> =>
+  activePromise.then(toStartupWaitResult, toStartupFailureWaitResult);
 
-  return new Promise(resolve => {
-    let settled = false;
-    const settle = (result: StartupWalletStoreInitWaitResult) => {
-      if (settled) {
-        return;
+export const waitForStartupWalletStoreInitForPortfolio =
+  async (): Promise<StartupWalletStoreInitWaitResult> => {
+    while (true) {
+      if (lastWalletStoreInitWaitResult) {
+        return lastWalletStoreInitWaitResult;
       }
-      settled = true;
-      clearTimeout(timeoutId);
-      resolve(result);
-    };
-    const timeoutId = setTimeout(() => {
-      settle({
-        status: 'timeout',
-        walletInitSuccess: false,
-      });
-    }, timeoutMs);
 
-    activePromise.then(
-      result => settle(toStartupWaitResult(result)),
-      error => settle(toStartupFailureWaitResult(error)),
-    );
-  });
-};
+      const activePromise = activeWalletStoreInitPromise;
+      if (activePromise) {
+        return waitForActiveWalletStoreInit(activePromise);
+      }
 
-export const waitForStartupWalletStoreInitForPortfolio = (args?: {
-  timeoutMs?: number;
-  beginTimeoutMs?: number;
-}): Promise<StartupWalletStoreInitWaitResult> => {
-  const timeoutMs = normalizeTimeoutMs(
-    args?.timeoutMs,
-    STARTUP_WALLET_STORE_INIT_PORTFOLIO_WAIT_MS,
-  );
-  const beginTimeoutMs = Math.min(
-    timeoutMs,
-    normalizeTimeoutMs(
-      args?.beginTimeoutMs,
-      STARTUP_WALLET_STORE_INIT_BEGIN_WAIT_MS,
-    ),
-  );
-
-  const wait = async (): Promise<StartupWalletStoreInitWaitResult> => {
-    if (lastWalletStoreInitWaitResult) {
-      return lastWalletStoreInitWaitResult;
+      await waitForWalletStoreInitToStart();
     }
-
-    const activePromise = activeWalletStoreInitPromise;
-    if (activePromise) {
-      return waitForActiveWalletStoreInit(activePromise, timeoutMs);
-    }
-
-    const startedAt = Date.now();
-    const didStart = await waitForWalletStoreInitToStart(beginTimeoutMs);
-    if (lastWalletStoreInitWaitResult) {
-      return lastWalletStoreInitWaitResult;
-    }
-    if (activeWalletStoreInitPromise) {
-      const elapsedMs = Date.now() - startedAt;
-      return waitForActiveWalletStoreInit(
-        activeWalletStoreInitPromise,
-        Math.max(0, timeoutMs - elapsedMs),
-      );
-    }
-
-    return {
-      status: didStart ? 'skipped' : 'timeout',
-      walletInitSuccess: false,
-    };
   };
-
-  return wait();
-};
 
 export const clearWalletStoreInitPromiseForTests = (): void => {
   activeWalletStoreInitPromise = undefined;
   lastWalletStoreInitWaitResult = undefined;
-  walletStoreInitHasStarted = false;
   walletStoreInitStartListeners = [];
 };
 
@@ -215,7 +121,6 @@ export const startWalletStoreInit =
       return activeWalletStoreInitPromise;
     }
 
-    walletStoreInitHasStarted = true;
     lastWalletStoreInitWaitResult = undefined;
     const initPromise = runWalletStoreInit(dispatch, getState)
       .then(


### PR DESCRIPTION
Also preserves stale chart data during incremental populates, increases txhistory request timeouts to 100s, and adds additional copyable logging to portfolio debug screens to make it easy to see what triggered a new populate and how long it took.