### PR TITLE
Home : Fix - transactMenu disabled buttons conditions

### DIFF
--- a/src/components/modal/transact-menu/TransactMenu.tsx
+++ b/src/components/modal/transact-menu/TransactMenu.tsx
@@ -121,7 +121,7 @@ const TransactModal = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const hideModal = () => setModalVisible(false);
   const showModal = () => setModalVisible(true);
-  const {keys} = useAppSelector(({WALLET}) => WALLET);
+  const keys = useAppSelector(({WALLET}) => WALLET.keys);
   const showArchaxBanner = useAppSelector(({APP}) => APP.showArchaxBanner);
   const availableWallets = Object.values(keys as Keys)
     .filter(key => key.backupComplete)
@@ -131,15 +131,16 @@ const TransactModal = () => {
         !wallet.hideWallet &&
         !wallet.hideWalletByAccount &&
         wallet.isComplete() &&
-        !wallet.pendingTssSession &&
-        wallet.balance.sat > 0,
+        !wallet.pendingTssSession,
     );
 
   const availableWalletsWithFunds = availableWallets.filter(
     wallet => wallet.balance.sat > 0,
   );
 
+  // Receive / Buy: disabled only when no wallet exists at all.
   const disabledReceivingOptions = availableWallets.length === 0;
+  // Send / Sell / Swap / Gift cards: disabled when no wallet has funds.
   const disabledSendingOptions = availableWalletsWithFunds.length === 0;
   const dispatch = useAppDispatch();
 


### PR DESCRIPTION
Related ticket: [RN-2799](https://bitpayprod.atlassian.net/browse/RN-2799)

The wallet filtering logic used to compute which actions should be enabled was incorrect, causing Receive and Buy Crypto to be disabled whenever all wallets had a zero balance — exactly the scenario where a user needs those actions most.


Fixed conditions:

Receive / Buy: disabled only when no wallet exists at all.
Send / Sell / Swap / Gift cards: disabled when no wallet has funds.