### PR TITLE
Fix: Check ABI filters before build for old Android devices

### DIFF
--- a/scripts/check-abi-filters.js
+++ b/scripts/check-abi-filters.js
@@ -1,0 +1,52 @@
+// scripts/check-abi-filters.js
+const fs = require('fs');
+const path = require('path');
+
+const gradlePath = path.join(process.cwd(), 'android', 'app', 'build.gradle');
+const gradleLines = fs.readFileSync(gradlePath, 'utf8').split('\n');
+
+const propsPath = path.join(process.cwd(), 'android', 'gradle.properties');
+const propsLines = fs.readFileSync(propsPath, 'utf8').split('\n');
+
+const checks = [
+  {
+    file: 'android/app/build.gradle',
+    description: 'reactNativeArchitectures() default return',
+    lines: gradleLines,
+    match: line =>
+      line.includes('return value ? value.split') &&
+      line.includes('armeabi-v7a'),
+  },
+  {
+    file: 'android/app/build.gradle',
+    description: 'ndk { abiFilters }',
+    lines: gradleLines,
+    match: line => line.includes('abiFilters') && line.includes('armeabi-v7a'),
+  },
+  {
+    file: 'android/app/build.gradle',
+    description: 'versionCodes map',
+    lines: gradleLines,
+    match: line =>
+      line.includes('def versionCodes') && line.includes('armeabi-v7a'),
+  },
+  {
+    file: 'android/gradle.properties',
+    description: 'reactNativeArchitectures property',
+    lines: propsLines,
+    match: line =>
+      line.replace(/\s/g, '').startsWith('reactNativeArchitectures=') &&
+      line.includes('armeabi-v7a'),
+  },
+];
+
+const failed = checks.filter(check => !check.lines.some(check.match));
+
+if (failed.length > 0) {
+  console.error('\narmeabi-v7a is missing in:');
+  failed.forEach(c => console.error(`   - ${c.file} → ${c.description}`));
+  console.error('\n   See PR #2078 for reference\n');
+  process.exit(1);
+}
+
+console.log(`ABI filters check passed (${checks.length}/${checks.length})`);

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -5,3 +5,4 @@ node ./scripts/mute-require-cycle-warnings.js
 node ./scripts/multi-modal-patch.js
 node ./scripts/git-commit-hash.js
 node ./scripts/generate-dkls-vendor.js
+node ./scripts/check-abi-filters.js


### PR DESCRIPTION
## Problem
The SIGABRT crash caused by missing `armeabi-v7a` ABI filters has happened twice (14.39.15 and 14.43.2). Both times the root cause was the same: `armeabi-v7a` missing from `android/app/build.gradle`, affecting mid/low-end Android devices running in 32-bit mode.

## Solution
Add a `postinstall` script that validates `armeabi-v7a` is present in all 3 required locations in `android/app/build.gradle`:

- `reactNativeArchitectures()` default return value
- `ndk { abiFilters }` block
- `versionCodes` map