### PR TITLE
Wallet: Fix - Crash adding custom token to read-only key

### DIFF
--- a/src/navigation/wallet/screens/AddingOptions.tsx
+++ b/src/navigation/wallet/screens/AddingOptions.tsx
@@ -197,14 +197,15 @@ const AddingOptions: React.FC = () => {
             );
           }
           if (
+            key.methods &&
             !key?.properties?.xPrivKeyEDDSA &&
             !key?.properties?.xPrivKeyEDDSAEncrypted
           ) {
             try {
               showOngoingProcess('ADDING_WALLET');
               await sleep(500);
-              key.methods!.addKeyByAlgorithm('EDDSA', {password});
-              key.properties = key.methods!.toObj();
+              key.methods.addKeyByAlgorithm('EDDSA', {password});
+              key.properties = key.methods.toObj();
             } catch (err) {
               hideOngoingProcess();
               const errstring =

--- a/src/store/wallet/effects/create/create.ts
+++ b/src/store/wallet/effects/create/create.ts
@@ -207,13 +207,14 @@ export const addWallet =
           );
         }
         if (
+          key.methods &&
           !key?.properties?.xPrivKeyEDDSA &&
           !key?.properties?.xPrivKeyEDDSAEncrypted
         ) {
           try {
             await sleep(500);
-            key.methods!.addKeyByAlgorithm('EDDSA', {password});
-            key.properties = key.methods!.toObj();
+            key.methods.addKeyByAlgorithm('EDDSA', {password});
+            key.properties = key.methods.toObj();
           } catch (err) {
             const errstring =
               err instanceof Error ? err.message : JSON.stringify(err);

--- a/src/utils/helper-methods.ts
+++ b/src/utils/helper-methods.ts
@@ -1774,12 +1774,13 @@ export const checkEncryptedKeysForEddsaMigration =
   (key: Key, password: string) =>
   async (dispatch: any): Promise<void> => {
     if (
+      key.methods &&
       checkEncryptPassword(key, password) &&
       !key?.properties?.xPrivKeyEDDSAEncrypted &&
       !key?.properties?.xPrivKeyEDDSA
     ) {
-      key.methods!.addKeyByAlgorithm('EDDSA', {password});
-      key.properties = key.methods!.toObj();
+      key.methods.addKeyByAlgorithm('EDDSA', {password});
+      key.properties = key.methods.toObj();
       dispatch(successImport({key}));
     }
   };


### PR DESCRIPTION
Adding a custom token (or a Solana wallet via AddingOptions) crashed with "Cannot read property 'addKeyByAlgorithm' of undefined" when the key had no live methods instance (read-only/watch-only keys, where buildKeyObj sets `methods: undefined`)