### PR TITLE
Buy/Sell: Fix - params update for ramp network signed payment url generation

### DIFF
--- a/src/navigation/services/screens/BuyAndSellRoot.tsx
+++ b/src/navigation/services/screens/BuyAndSellRoot.tsx
@@ -2828,14 +2828,14 @@ const BuyAndSellRoot = ({
       env: rampEnv,
       hostLogoUrl: 'https://bitpay.com/_nuxt/img/bitpay-logo-blue.1c0494b.svg',
       hostAppName: APP_NAME_UPPERCASE,
-      swapAsset: getRampCoinFormat(coin, getRampChainFormat(chain)),
-      swapAmount: offer.amountReceivingUnit!,
-      fiatCurrency: offer.fiatCurrency,
+      enabledCryptoAssets: getRampCoinFormat(coin, getRampChainFormat(chain)),
+      outAssetValue: offer.amountReceivingUnit!,
+      inAsset: offer.fiatCurrency,
       enabledFlows: ['ONRAMP'],
       defaultFlow: 'ONRAMP',
       userAddress: address,
       selectedCountryCode: country,
-      defaultAsset: getRampCoinFormat(coin, getRampChainFormat(chain)),
+      outAsset: getRampCoinFormat(coin, getRampChainFormat(chain)),
       finalUrl: redirectUrl,
       paymentMethodType: getRampPaymentMethodFormat(paymentMethod.method),
     };
@@ -3535,18 +3535,16 @@ const BuyAndSellRoot = ({
       userAddress: address, // TODO: ask Ramp team about this for UTXO coins
       hostLogoUrl: 'https://bitpay.com/_nuxt/img/bitpay-logo-blue.1c0494b.svg',
       hostAppName: APP_NAME_UPPERCASE,
-      offrampAsset: rampAsset,
-      swapAsset: rampAsset,
-      swapAmount: offer.decimals
+      enabledCryptoAssets: rampAsset,
+      inAssetValue: offer.decimals
         ? Number(offer.sellAmount) * 10 ** offer.decimals
         : undefined,
-      fiatCurrency: offer.fiatCurrency,
+      outAsset: offer.fiatCurrency,
       enabledFlows: 'OFFRAMP',
       defaultFlow: 'OFFRAMP',
       selectedCountryCode: country,
-      defaultAsset: rampAsset,
+      inAsset: rampAsset,
       useSendCryptoCallback: true,
-      useSendCryptoCallbackVersion: 1,
       hideExitButton: false,
     };
 

--- a/src/store/buy-crypto/models/ramp.models.ts
+++ b/src/store/buy-crypto/models/ramp.models.ts
@@ -118,27 +118,26 @@ export interface RampPaymentUrlConfigParams {
   flow?: 'buy' | 'sell'; // Default: buy
   hostLogoUrl: string;
   hostAppName: string;
-  swapAsset?: string; // E.g. MATIC_*,ETH_DAI,ETH_USDC,ETH_USDS,ETH_USDT
-  offrampAsset?: string; // E.g. MATIC_*,ETH_DAI,ETH_USDC,ETH_USDS,ETH_USDT
-  // swapAmount(number): the amount should be provided in wei or token units. You can block editing value of the transaction by providing swapAmount and single swapAsset parameters e.g. https://buy.rampnetwork.com/?swapAmount=100000000000000000&swapAsset=ETH for 0.1 ETH
-  swapAmount?: string | number;
-  // fiatCurrency (string) and fiatValue (int): are two optional parameters that allow you to pre-set the total fiat value of the purchase that will be suggested to the user. They have to be used together as they don't work separately.
-  fiatCurrency?: string;
-  fiatValue?: number;
+  enabledCryptoAssets?: string; // Comma-separated list of enabled crypto assets (applies to all flows). E.g. MATIC_*,ETH_DAI,ETH_USDC,ETH_USDS,ETH_USDT
+  // inAsset (string: The incoming asset (sent by the user), can be a crypto asset key or fiat currency code) and inAssetValue (int): are two optional parameters that allow you to pre-set the total fiat value of the purchase that will be suggested to the user. They have to be used together as they don't work separately.
+  inAsset?: string;
+  // inAssetValue(number): the amount should be provided in wei or token units. You can block editing value of the transaction by providing swapAmount and single swapAsset parameters e.g. https://buy.rampnetwork.com/?swapAmount=100000000000000000&swapAsset=ETH for 0.1 ETH
+  inAssetValue?: number;
+  // outAsset (string: The outgoing asset (received by the user), can be a crypto asset key or fiat currency code)
+  outAsset?: string; // E.g. USD, EUR, BRL, ARS, BASE_USDC, BTC_BTC
+  outAssetValue?: string; // The outgoing asset value in units (no decimals) E.g. 10000 for $100.00 USD, 1000 for $10.00 USD
   enabledFlows: RampFlow[] | RampFlow;
   defaultFlow: RampFlow;
   // userAddress: An optional string parameter that pre-sets the address the crypto will be sent to. For off-ramp, will be treated as a source address from which the crypto will be sent from.
   userAddress?: string;
   userEmailAddress?: string;
   selectedCountryCode: string;
-  defaultAsset: string;
   finalUrl?: string; // On-ramp param to return to the app
   useSendCryptoCallback?: boolean; // Off-ramp param to show wallet button in checkout page
   // paymentMethodType: ON-ramp only. An optional string parameter that pre-selects payment method for your user to make their onramping experience even quicker.
   paymentMethodType?: RampPaymentMethodType;
   // hideExitButton: An optional boolean parameter to show or hide internal exit button on widget.
   hideExitButton?: boolean;
-  useSendCryptoCallbackVersion?: number;
 }
 
 export interface RampGetSellSignedPaymentUrlData {


### PR DESCRIPTION
Ticket reference: [RN-2486](https://bitpayprod.atlassian.net/browse/RN-2486)

Ramp deprecated the legacy per-flow search params in favor of a unified format.
Ref: https://docs.rampnetwork.com/search-params-migration
Older app versions still send the legacy fields, so we translate them into the new unified params in BWS (With this PR: https://github.com/bitpay/bitcore/pull/4204) to keep those requests working going forward. If a newer client already sends the new params, those take precedence.

The `useSendCryptoCallbackVersion: 1` param was removed, as it was causing errors in Offramp integration.