### PR TITLE
Moonpay: Feature - Render payment disclosures from embedded Buy Quote

### DIFF
--- a/src/navigation/services/buy-crypto/constants/MoonpayDisclosures.ts
+++ b/src/navigation/services/buy-crypto/constants/MoonpayDisclosures.ts
@@ -1,43 +1,164 @@
-// MoonPay's embedded Buy Quote returns paymentDisclosures as {id, version} only
+// MoonPay's embedded Buy Quote returns paymentDisclosures as {id, version} only.
+// Each disclosure maps to an array of segments (plain text or tappable link)
+// so the UI can render them inline with individually pressable links.
+// Verbatim copy sourced from: https://dev.moonpay.com/platform/overview/going-live
 
 import {
   MoonpayPaymentDisclosure,
   MoonpayPaymentDisclosureId,
 } from '../../../../store/buy-crypto/buy-crypto.models';
 
+/** A plain-text run within a disclosure. */
+export type DisclosureTextSegment = {type: 'text'; value: string};
+
+/** A tappable link run within a disclosure. */
+export type DisclosureLinkSegment = {type: 'link'; label: string; url: string};
+
+export type DisclosureSegment = DisclosureTextSegment | DisclosureLinkSegment;
+
 export interface MoonpayDisclosureCopy {
-  text: string;
-  url?: string;
+  segments: DisclosureSegment[];
   isFallback: boolean;
 }
 
-const DISCLOSURE_COPY: Record<
-  MoonpayPaymentDisclosureId,
-  Omit<MoonpayDisclosureCopy, 'isFallback'>
-> = {
-  'us-transaction-finality': {
-    text: '[TODO] us-transaction-finality',
-  },
-  'eea-crypto-asset-risk': {
-    text: '[TODO] eea-crypto-asset-risk',
-  },
-  'eea-unregulated-stablecoin-risk': {
-    text: '[TODO] eea-unregulated-stablecoin-risk',
-  },
-  'gateway-token': {
-    text: 'Your payment will be processed by MoonPay. By continuing you authorise MoonPay to process this transaction.',
-  },
-};
+export const MOONPAY_TERMS_URL = 'https://www.moonpay.com/legal/terms';
+export const MOONPAY_PRIVACY_URL =
+  'https://www.moonpay.com/legal/privacy_policy';
+export const MOONPAY_LEGAL_URL = 'https://www.moonpay.com/legal';
+export const MOONPAY_WHITEPAPER_URL =
+  'https://dev.moonpay.com/docs/list-of-supported-cryptocurrencies';
 
-const CONSERVATIVE_DISCLOSURE =
-  'By continuing, you acknowledge the terms and risks associated with this transaction as provided by MoonPay.';
+const DISCLOSURE_COPY: Record<MoonpayPaymentDisclosureId, DisclosureSegment[]> =
+  {
+    // Shown to customers in US states that require transaction-finality notice (NY, WA).
+    'us-transaction-finality': [
+      {type: 'text', value: "I agree to MoonPay's "},
+      {type: 'link', label: 'Terms of Use', url: MOONPAY_TERMS_URL},
+      {
+        type: 'text',
+        value:
+          ' and understand that, once executed, this transaction cannot be cancelled, recalled, refunded, or otherwise undone. Fraudulent transactions may result in the loss of funds with no recourse.',
+      },
+    ],
+
+    // Shown to EEA customers buying a MiCA-compliant crypto asset.
+    'eea-crypto-asset-risk': [
+      {
+        type: 'text',
+        value:
+          'By continuing, you agree to transact with MoonPay Europe, subject to its ',
+      },
+      {type: 'link', label: 'Terms of Use', url: MOONPAY_TERMS_URL},
+      {type: 'text', value: ' and '},
+      {type: 'link', label: 'Privacy Policy', url: MOONPAY_PRIVACY_URL},
+      {
+        type: 'text',
+        value:
+          '. Crypto-assets can be risky and values may decrease quickly. Transfers are irreversible once broadcast to the blockchain. The quoted exchange rate may include a spread. ',
+      },
+      {type: 'link', label: 'Learn more', url: MOONPAY_LEGAL_URL},
+      {type: 'text', value: ' and '},
+      {
+        type: 'link',
+        label: 'review the whitepaper',
+        url: MOONPAY_WHITEPAPER_URL,
+      },
+      {type: 'text', value: ' (if available).'},
+    ],
+
+    // Shown to EEA customers buying a stablecoin that is NOT MiCA-compliant (e.g. USDT, DAI, PYUSD).
+    'eea-unregulated-stablecoin-risk': [
+      {
+        type: 'text',
+        value:
+          'Important: You are about to transact in a stablecoin that is not MiCA-compliant, carries fewer safeguards, and may be difficult to sell. By continuing, you agree to transact with MoonPay Europe subject to its ',
+      },
+      {type: 'link', label: 'Terms of Use', url: MOONPAY_TERMS_URL},
+      {type: 'text', value: ' and '},
+      {type: 'link', label: 'Privacy Policy', url: MOONPAY_PRIVACY_URL},
+      {
+        type: 'text',
+        value:
+          '. Transfers are irreversible once broadcast to the blockchain. The quoted exchange rate may include a spread. ',
+      },
+      {type: 'link', label: 'Learn more', url: MOONPAY_LEGAL_URL},
+      {type: 'text', value: ' and '},
+      {
+        type: 'link',
+        label: 'review the whitepaper',
+        url: MOONPAY_WHITEPAPER_URL,
+      },
+      {type: 'text', value: ' (if available).'},
+    ],
+
+    // Shown when the customer buys a DeFi token via Gateway (USA, excluding NY and WA).
+    // Gateway purchases are two-step: buy stablecoin from MoonPay, then swap on a DEX.
+    'gateway-token': [
+      {type: 'text', value: 'By proceeding, you agree to two steps under '},
+      {type: 'link', label: 'these terms', url: MOONPAY_TERMS_URL},
+      {
+        type: 'text',
+        value:
+          ': (1) Buying stablecoin from MoonPay and (2) Swapping stablecoin for your chosen destination asset via a decentralised exchange.',
+      },
+    ],
+  };
+
+// Fallback used when an unknown disclosure id is received.
+// Per MoonPay spec, partners should render a conservative message and alert their team.
+// Links point to the canonical MoonPay documents as required by the terms-acceptance guide:
+// https://dev.moonpay.com/platform/guides/terms-acceptance
+const CONSERVATIVE_DISCLOSURE_SEGMENTS: DisclosureSegment[] = [
+  {
+    type: 'text',
+    value: 'By continuing, you agree to transact with MoonPay subject to its ',
+  },
+  {type: 'link', label: 'Terms of Use', url: MOONPAY_TERMS_URL},
+  {type: 'text', value: ' and '},
+  {type: 'link', label: 'Privacy Policy', url: MOONPAY_PRIVACY_URL},
+  {type: 'text', value: '.'},
+];
 
 export const getMoonpayDisclosureCopy = (
   disclosure: MoonpayPaymentDisclosure,
 ): MoonpayDisclosureCopy => {
-  const copy = DISCLOSURE_COPY[disclosure.id];
-  if (!copy) {
-    return {text: CONSERVATIVE_DISCLOSURE, isFallback: true};
+  const segments = DISCLOSURE_COPY[disclosure.id];
+  if (!segments) {
+    return {segments: CONSERVATIVE_DISCLOSURE_SEGMENTS, isFallback: true};
   }
-  return {...copy, isFallback: false};
+  return {segments, isFallback: false};
+};
+
+// Geo-specific disclosure ids that, when present in the API response, already
+// satisfy the legal requirement — no supplemental LegalText block is needed.
+const GEO_DISCLOSURE_IDS: MoonpayPaymentDisclosureId[] = [
+  'us-transaction-finality',
+  'eea-crypto-asset-risk',
+  'eea-unregulated-stablecoin-risk',
+];
+
+/**
+ * Returns the segments for the supplemental LegalText block rendered below the
+ * payment frame. Returns null when the API response already contains a
+ * geo-specific disclosure that covers the requirement.
+ *
+ * Priority:
+ * 1. Any of the geo-specific ids is present in the API response → null.
+ * 2. isNYorWA is true → us-transaction-finality copy (verbatim fallback).
+ * 3. Otherwise → generic Terms of Use / Privacy Policy notice.
+ */
+export const getMoonpayDefaultDisclosure = (
+  disclosures: MoonpayPaymentDisclosure[] | undefined | null,
+  isNYorWA: boolean,
+): DisclosureSegment[] | null => {
+  const hasGeoDisclosure = disclosures?.some(d =>
+    (GEO_DISCLOSURE_IDS as string[]).includes(d.id),
+  );
+  if (hasGeoDisclosure) {
+    return null;
+  }
+  if (isNYorWA) {
+    return DISCLOSURE_COPY['us-transaction-finality'];
+  }
+  return CONSERVATIVE_DISCLOSURE_SEGMENTS;
 };

--- a/src/navigation/services/buy-crypto/constants/MoonpayDisclosures.ts
+++ b/src/navigation/services/buy-crypto/constants/MoonpayDisclosures.ts
@@ -1,0 +1,43 @@
+// MoonPay's embedded Buy Quote returns paymentDisclosures as {id, version} only
+
+import {
+  MoonpayPaymentDisclosure,
+  MoonpayPaymentDisclosureId,
+} from '../../../../store/buy-crypto/buy-crypto.models';
+
+export interface MoonpayDisclosureCopy {
+  text: string;
+  url?: string;
+  isFallback: boolean;
+}
+
+const DISCLOSURE_COPY: Record<
+  MoonpayPaymentDisclosureId,
+  Omit<MoonpayDisclosureCopy, 'isFallback'>
+> = {
+  'us-transaction-finality': {
+    text: '[TODO] us-transaction-finality',
+  },
+  'eea-crypto-asset-risk': {
+    text: '[TODO] eea-crypto-asset-risk',
+  },
+  'eea-unregulated-stablecoin-risk': {
+    text: '[TODO] eea-unregulated-stablecoin-risk',
+  },
+  'gateway-token': {
+    text: 'Your payment will be processed by MoonPay. By continuing you authorise MoonPay to process this transaction.',
+  },
+};
+
+const CONSERVATIVE_DISCLOSURE =
+  'By continuing, you acknowledge the terms and risks associated with this transaction as provided by MoonPay.';
+
+export const getMoonpayDisclosureCopy = (
+  disclosure: MoonpayPaymentDisclosure,
+): MoonpayDisclosureCopy => {
+  const copy = DISCLOSURE_COPY[disclosure.id];
+  if (!copy) {
+    return {text: CONSERVATIVE_DISCLOSURE, isFallback: true};
+  }
+  return {...copy, isFallback: false};
+};

--- a/src/navigation/services/screens/MoonpayBuyEmbeddedCheckout.tsx
+++ b/src/navigation/services/screens/MoonpayBuyEmbeddedCheckout.tsx
@@ -81,12 +81,13 @@ import {RootStacks} from '../../../Root';
 import {TabsScreens} from '../../tabs/TabsStack';
 import {ExternalServicesSettingsScreens} from '../../tabs/settings/external-services/ExternalServicesGroup';
 import MoonpayEmbeddedCheckoutSkeleton from '../components/MoonpayEmbeddedCheckoutSkeleton';
-import {getMoonpayDisclosureCopy} from '../buy-crypto/constants/MoonpayDisclosures';
+import {
+  getMoonpayDisclosureCopy,
+  getMoonpayDefaultDisclosure,
+} from '../buy-crypto/constants/MoonpayDisclosures';
 import {HEIGHT, WIDTH} from '../../../components/styled/Containers';
 import {TouchableOpacity} from '../../../components/base/TouchableOpacity';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-
-const MOONPAY_TERMS_URL = 'https://www.moonpay.com/legal/terms';
 
 // Styled
 export const MoonpayEmbeddedCheckoutContainer = styled.SafeAreaView`
@@ -901,46 +902,55 @@ const MoonpayBuyEmbeddedCheckout: React.FC = () => {
         </ScrollView>
 
         <BottomSection>
-          {embeddedQuoteData?.paymentDisclosures?.length
-            ? embeddedQuoteData.paymentDisclosures.map(
+          {(() => {
+            if (!embeddedQuoteData) return null;
+            // If the API returned specific disclosures, render only those.
+            if (embeddedQuoteData?.paymentDisclosures?.length) {
+              return embeddedQuoteData.paymentDisclosures.map(
                 (disclosure: {id: string; version: string}) => {
-                  const {text, url} = getMoonpayDisclosureCopy(
+                  const {segments} = getMoonpayDisclosureCopy(
                     disclosure as any,
                   );
                   return (
                     <DisclosureText
                       key={`${disclosure.id}-${disclosure.version}`}>
-                      {url ? (
-                        <LegalLink onPress={() => openUrl(url)}>
-                          {text}
-                        </LegalLink>
-                      ) : (
-                        text
+                      {segments.map((segment, i) =>
+                        segment.type === 'link' ? (
+                          <LegalLink
+                            key={i}
+                            onPress={() => openUrl(segment.url)}>
+                            {segment.label}
+                          </LegalLink>
+                        ) : (
+                          segment.value
+                        ),
                       )}
                     </DisclosureText>
                   );
                 },
-              )
-            : null}
-          {isNYorWA ? (
-            <LegalText>
-              {t("I agree to MoonPay's")}{' '}
-              <LegalLink onPress={() => openUrl(MOONPAY_TERMS_URL)}>
-                {t('Terms of Use')}
-              </LegalLink>{' '}
-              {t(
-                'and understand that, once executed, this transaction cannot be cancelled, recalled, refunded, or otherwise undone. Fraudulent transactions may result in the loss of funds with no recourse.',
-              )}
-            </LegalText>
-          ) : (
-            <LegalText>
-              {t("By clicking below, you agree to MoonPay's")}{' '}
-              <LegalLink onPress={() => openUrl(MOONPAY_TERMS_URL)}>
-                {t('Terms of Use')}
-              </LegalLink>
-              {'.'}
-            </LegalText>
-          )}
+              );
+            } else {
+              // No API disclosures — fall back to geo/generic legal text.
+              const legalSegments = getMoonpayDefaultDisclosure(
+                embeddedQuoteData?.paymentDisclosures,
+                isNYorWA,
+              );
+              if (!legalSegments) return null;
+              return (
+                <LegalText>
+                  {legalSegments.map((segment, i) =>
+                    segment.type === 'link' ? (
+                      <LegalLink key={i} onPress={() => openUrl(segment.url)}>
+                        {segment.label}
+                      </LegalLink>
+                    ) : (
+                      segment.value
+                    ),
+                  )}
+                </LegalText>
+              );
+            }
+          })()}
           {!isLoading && !paymentExpired && initialQuoteSignature ? (
             <MoonPayApplePayFrame
               ref={applePayFrameRef}

--- a/src/navigation/services/screens/MoonpayBuyEmbeddedCheckout.tsx
+++ b/src/navigation/services/screens/MoonpayBuyEmbeddedCheckout.tsx
@@ -81,6 +81,7 @@ import {RootStacks} from '../../../Root';
 import {TabsScreens} from '../../tabs/TabsStack';
 import {ExternalServicesSettingsScreens} from '../../tabs/settings/external-services/ExternalServicesGroup';
 import MoonpayEmbeddedCheckoutSkeleton from '../components/MoonpayEmbeddedCheckoutSkeleton';
+import {getMoonpayDisclosureCopy} from '../buy-crypto/constants/MoonpayDisclosures';
 import {HEIGHT, WIDTH} from '../../../components/styled/Containers';
 import {TouchableOpacity} from '../../../components/base/TouchableOpacity';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -169,6 +170,14 @@ const LegalText = styled(BaseText)`
 
 const LegalLink = styled.Text`
   color: ${({theme: {dark}}) => (dark ? LinkBlue : Action)};
+`;
+
+const DisclosureText = styled(BaseText)`
+  font-size: 12px;
+  text-align: center;
+  color: ${({theme: {dark}}) => (dark ? Slate30 : SlateDark)};
+  margin-bottom: 12px;
+  line-height: 18px;
 `;
 
 const PoweredByContainer = styled.View`
@@ -646,6 +655,21 @@ const MoonpayBuyEmbeddedCheckout: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const disclosures = embeddedQuoteData?.paymentDisclosures;
+    if (!disclosures?.length) {
+      return;
+    }
+    disclosures.forEach((d: {id: string; version: string}) => {
+      const {isFallback} = getMoonpayDisclosureCopy(d as any);
+      if (isFallback) {
+        logger.warn(
+          `[MoonpayEmbeddedCheckout] Unknown MoonPay payment disclosure (id: ${d.id}, version: ${d.version}). Rendering conservative fallback — update MoonpayDisclosures.ts.`,
+        );
+      }
+    });
+  }, [embeddedQuoteData?.paymentDisclosures]);
+
+  useEffect(() => {
     if (
       remainingTimeStr === 'expired' &&
       !expiredAnalyticSent &&
@@ -752,7 +776,7 @@ const MoonpayBuyEmbeddedCheckout: React.FC = () => {
               // copyText(toAddress);
             }}
           />
-        </RowDataContainer> 
+        </RowDataContainer>
         <ItemDivisor />*/}
           {isLoading ? (
             <MoonpayEmbeddedCheckoutSkeleton context="data" />
@@ -877,6 +901,27 @@ const MoonpayBuyEmbeddedCheckout: React.FC = () => {
         </ScrollView>
 
         <BottomSection>
+          {embeddedQuoteData?.paymentDisclosures?.length
+            ? embeddedQuoteData.paymentDisclosures.map(
+                (disclosure: {id: string; version: string}) => {
+                  const {text, url} = getMoonpayDisclosureCopy(
+                    disclosure as any,
+                  );
+                  return (
+                    <DisclosureText
+                      key={`${disclosure.id}-${disclosure.version}`}>
+                      {url ? (
+                        <LegalLink onPress={() => openUrl(url)}>
+                          {text}
+                        </LegalLink>
+                      ) : (
+                        text
+                      )}
+                    </DisclosureText>
+                  );
+                },
+              )
+            : null}
           {isNYorWA ? (
             <LegalText>
               {t("I agree to MoonPay's")}{' '}

--- a/src/store/buy-crypto/buy-crypto.models.ts
+++ b/src/store/buy-crypto/buy-crypto.models.ts
@@ -332,6 +332,17 @@ export interface MoonpayGetQuoteEmbeddedRequestData {
   env: string;
 }
 
+export type MoonpayPaymentDisclosureId =
+  | 'us-transaction-finality'
+  | 'eea-crypto-asset-risk'
+  | 'eea-unregulated-stablecoin-risk'
+  | 'gateway-token';
+
+export interface MoonpayPaymentDisclosure {
+  id: MoonpayPaymentDisclosureId;
+  version: string;
+}
+
 export interface MoonpayQuoteEmbeddedData {
   source: MoonpayEmbeddedAmount;
   destination: MoonpayEmbeddedAmount;
@@ -345,6 +356,7 @@ export interface MoonpayQuoteEmbeddedData {
   exchangeRate: string; // numeric string
   signature: string; // long JWT
   executable: boolean;
+  paymentDisclosures?: MoonpayPaymentDisclosure[];
 }
 
 interface MoonpayEmbeddedAmount {


### PR DESCRIPTION
- Add MoonpayPaymentDisclosure(Id) types + paymentDisclosures on `MoonpayQuoteEmbeddedData`
- Add MoonpayDisclosures.ts with getMoonpayDisclosureCopy() and a conservative fallback for unknown `ids`
- Render disclosures in the embedded checkout above the Terms of Use, and warn when an unrecognised id arrives