### PR TITLE
Transaction List: Fix - Fallback to 'en' for locales moment doesn't bundle

### DIFF
--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -590,12 +590,10 @@ const IsFirstInCoinbaseGroup = (index: number, history: any[]) => {
 
 const getMomentLocale = (language?: string): string => {
   const lang = (language || '').toLowerCase();
-
-  if (lang.startsWith('zh')) return 'zh-cn';
-
-  const base = lang.split('-')[0];
-
-  return base || 'en';
+  const candidate = lang.startsWith('zh')
+    ? 'zh-cn'
+    : lang.split('-')[0] || 'en';
+  return moment.locales().includes(candidate) ? candidate : 'en';
 };
 
 const getMonthName = (time: MomentInput): string => {


### PR DESCRIPTION
PR #2126 only special-cased zh -> zh-cn; any other unsupported locale
(such as 'co' Corsican) still reached moment().locale().

Fix: Validate the candidate against moment.locales() and fall back to 'en' when it's not bundled.

