### PR TITLE
Fix: Simplex icon in sell offer card

### DIFF
--- a/src/navigation/services/buy-crypto/utils/simplex-utils.ts
+++ b/src/navigation/services/buy-crypto/utils/simplex-utils.ts
@@ -400,7 +400,7 @@ export const simplexPaymentRequest = (
           address,
           tag: '',
         },
-        original_http_ref_url: 'https://' + getPassthroughUri(),
+        original_http_ref_url: getPassthroughUri(),
       },
     },
   };

--- a/src/navigation/services/components/externalServicesOfferSelector.tsx
+++ b/src/navigation/services/components/externalServicesOfferSelector.tsx
@@ -419,6 +419,7 @@ const sellOffersDefault: {
     showOffer: true,
     logo: (
       <SimplexLogo
+        iconOnly={true}
         widthIcon={25}
         heightIcon={25}
         widthLogo={60}


### PR DESCRIPTION
Fix to correctly display the Simplex icon on the offer card in Sell flow.