### PR TITLE
Guidepoint: Feat - Display last login info on profile settings

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1975,5 +1975,9 @@
   "To continue you will need to add a wallet to your key.": "To continue you will need to add a wallet to your key.",
   "Add wallet": "Add wallet",
   "Key and wallet required": "Key and wallet required",
-  "To continue you will need to create a key and add a wallet.": "To continue you will need to create a key and add a wallet."
+  "To continue you will need to create a key and add a wallet.": "To continue you will need to create a key and add a wallet.",
+  "Last Login": "Last Login",
+  "IP Address": "IP Address",
+  "Don't recognize this activity?": "Don't recognize this activity?",
+  "Secure your account": "Secure your account"
 }

--- a/src/navigation/bitpay-id/screens/ProfileSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ProfileSettings.tsx
@@ -1,6 +1,7 @@
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React, {useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
+import moment from 'moment';
 import styled from 'styled-components/native';
 import Avatar from '../../../components/avatar/BitPayIdAvatar';
 import {
@@ -100,6 +101,14 @@ const SettingsSectionDescription = styled(BaseText)`
   line-height: 18px;
 `;
 
+const LastLoginDetail = styled(SettingsSectionDescription)`
+  color: ${({theme: {dark}}) => (dark ? Slate : SlateDark)};
+`;
+
+const LastLoginAlert = styled(SettingsSectionDescription)`
+  margin-top: 10px;
+`;
+
 export const ProfileSettingsScreen = ({}: ProfileProps) => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
@@ -109,16 +118,27 @@ export const ProfileSettingsScreen = ({}: ProfileProps) => {
   const apiToken = useAppSelector(
     ({APP, BITPAY_ID}) => BITPAY_ID.apiToken[APP.network],
   );
+  const lastLogin = useAppSelector(
+    ({BITPAY_ID}) => BITPAY_ID.lastLogin[network],
+  );
 
   useEffect(() => {
     dispatch(BitPayIdEffects.startFetchSession());
     if (apiToken) {
       dispatch(BitPayIdEffects.startFetchSecuritySettings()).catch(() => {});
       dispatch(BitPayIdEffects.startFetchBasicInfo(apiToken)).catch(() => {});
+      dispatch(BitPayIdEffects.startFetchLastLogin()).catch(() => {});
     }
   }, [apiToken, dispatch]);
 
   const hasName = user?.givenName || user?.familyName;
+  const lastLoginLocation = [
+    lastLogin?.city,
+    lastLogin?.region,
+    lastLogin?.country,
+  ]
+    .filter(Boolean)
+    .join(', ');
 
   if (!user) {
     return <></>;
@@ -187,6 +207,40 @@ export const ProfileSettingsScreen = ({}: ProfileProps) => {
                 <ChevronRight />
               </SettingsItem>
             </TouchableOpacity>
+
+            {lastLogin?.date ? (
+              <>
+                <SectionSpacer />
+                <H5>{t('Last Login')}</H5>
+                <SettingsItem>
+                  <SettingsSectionBody>
+                    <SettingsSectionHeader>
+                      {moment(lastLogin.date).format('MMM DD, YYYY hh:mm a')}
+                    </SettingsSectionHeader>
+                    {lastLogin.device ? (
+                      <LastLoginDetail>{lastLogin.device}</LastLoginDetail>
+                    ) : null}
+                    {lastLoginLocation ? (
+                      <LastLoginDetail>{lastLoginLocation}</LastLoginDetail>
+                    ) : null}
+                    {lastLogin.ipAddress ? (
+                      <LastLoginDetail>
+                        {t('IP Address')}: {lastLogin.ipAddress}
+                      </LastLoginDetail>
+                    ) : null}
+                    <LastLoginAlert>
+                      {t("Don't recognize this activity?")}{' '}
+                      <Link
+                        onPress={() => {
+                          navigation.navigate(SecurityScreens.HOME);
+                        }}>
+                        {t('Secure your account')}
+                      </Link>
+                    </LastLoginAlert>
+                  </SettingsSectionBody>
+                </SettingsItem>
+              </>
+            ) : null}
           </>
         ) : null}
         <SectionSpacer />

--- a/src/store/bitpay-id/bitpay-id.actions.ts
+++ b/src/store/bitpay-id/bitpay-id.actions.ts
@@ -1,6 +1,7 @@
 import {InitialUserData} from '../../api/user/user.types';
 import {Network} from '../../constants';
 import {
+  LastLogin,
   PasskeyCredential,
   ReceivingAddress,
   SecuritySettings,
@@ -253,6 +254,14 @@ export const successFetchSecuritySettings = (
 ): BitPayIdActionType => ({
   type: BitPayIdActionTypes.SUCCESS_FETCH_SECURITY_SETTINGS,
   payload: {network, securitySettings},
+});
+
+export const successFetchLastLogin = (
+  network: Network,
+  lastLogin: LastLogin,
+): BitPayIdActionType => ({
+  type: BitPayIdActionTypes.SUCCESS_FETCH_LAST_LOGIN,
+  payload: {network, lastLogin},
 });
 
 export const setPasskeyStatus = (passkey: boolean): BitPayIdActionType => ({

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -20,7 +20,12 @@ import {ShopActions, ShopEffects} from '../shop';
 import {BitPayIdActions} from './index';
 import {t} from 'i18next';
 import BitPayIdApi from '../../api/bitpay';
-import {ReceivingAddress, SecuritySettings, Session} from './bitpay-id.models';
+import {
+  LastLogin,
+  ReceivingAddress,
+  SecuritySettings,
+  Session,
+} from './bitpay-id.models';
 import {getCoinAndChainFromCurrencyCode} from '../../navigation/bitpay-id/utils/bitpay-id-utils';
 import axios from 'axios';
 import {BASE_BITPAY_URLS, NO_CACHE_HEADERS} from '../../constants/config';
@@ -716,6 +721,27 @@ export const startFetchSecuritySettings =
         const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
         logManager.error(
           '[startFetchSecuritySettings] Failed to fetch security settings.',
+          errMsg,
+        );
+        throw err;
+      }
+    })();
+
+export const startFetchLastLogin =
+  (): Effect<Promise<LastLogin>> => async (dispatch, getState) =>
+    (async () => {
+      try {
+        const {APP, BITPAY_ID} = getState();
+        const lastLogin = await BitPayIdApi.apiCall(
+          BITPAY_ID.apiToken[APP.network],
+          'getLastLogin',
+        );
+        dispatch(BitPayIdActions.successFetchLastLogin(APP.network, lastLogin));
+        return lastLogin;
+      } catch (err: any) {
+        const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+        logManager.error(
+          '[startFetchLastLogin] Failed to fetch last login.',
           errMsg,
         );
         throw err;

--- a/src/store/bitpay-id/bitpay-id.models.ts
+++ b/src/store/bitpay-id/bitpay-id.models.ts
@@ -41,6 +41,19 @@ export interface SecuritySettings {
   email: string;
 }
 
+/**
+ * Fields are optional until the backend method is finalized — render only what
+ * is actually returned.
+ */
+export interface LastLogin {
+  date?: string;
+  ipAddress?: string;
+  city?: string;
+  region?: string;
+  country?: string;
+  device?: string;
+}
+
 export interface User {
   email: string;
   eid: string;

--- a/src/store/bitpay-id/bitpay-id.reducer.ts
+++ b/src/store/bitpay-id/bitpay-id.reducer.ts
@@ -1,5 +1,6 @@
 import {BitPayIdActionType, BitPayIdActionTypes} from './bitpay-id.types';
 import {
+  LastLogin,
   ReceivingAddress,
   SecuritySettings,
   Session,
@@ -25,6 +26,7 @@ export const bitPayIdReduxPersistBlackList: (keyof BitPayIdState)[] = [
   'doshToken',
   'fetchDoshTokenStatus',
   'forgotPasswordEmailStatus',
+  'lastLogin',
 ];
 
 export type FetchSessionStatus = 'loading' | 'success' | 'failed' | null;
@@ -66,6 +68,9 @@ export interface BitPayIdState {
   };
   securitySettings: {
     [key in Network]: SecuritySettings | null;
+  };
+  lastLogin: {
+    [key in Network]: LastLogin | null;
   };
   fetchSessionStatus: FetchSessionStatus;
   createAccountStatus: CreateAccountStatus;
@@ -114,6 +119,11 @@ const initialState: BitPayIdState = {
     [Network.regtest]: [],
   },
   securitySettings: {
+    [Network.mainnet]: null,
+    [Network.testnet]: null,
+    [Network.regtest]: null,
+  },
+  lastLogin: {
     [Network.mainnet]: null,
     [Network.testnet]: null,
     [Network.regtest]: null,
@@ -348,6 +358,10 @@ export const bitPayIdReducer = (
           ...state.doshToken,
           [action.payload.network]: null,
         },
+        lastLogin: {
+          ...state.lastLogin,
+          [action.payload.network]: null,
+        },
       };
 
     case BitPayIdActionTypes.SUCCESS_FETCH_DOSH_TOKEN:
@@ -419,6 +433,16 @@ export const bitPayIdReducer = (
         securitySettings: {
           ...state.securitySettings,
           [action.payload.network]: action.payload.securitySettings,
+        },
+      };
+    }
+
+    case BitPayIdActionTypes.SUCCESS_FETCH_LAST_LOGIN: {
+      return {
+        ...state,
+        lastLogin: {
+          ...state.lastLogin,
+          [action.payload.network]: action.payload.lastLogin,
         },
       };
     }

--- a/src/store/bitpay-id/bitpay-id.types.ts
+++ b/src/store/bitpay-id/bitpay-id.types.ts
@@ -1,5 +1,6 @@
 import {Network} from '../../constants';
 import {
+  LastLogin,
   ReceivingAddress,
   SecuritySettings,
   Session,
@@ -56,6 +57,7 @@ export enum BitPayIdActionTypes {
   RESET_FORGOT_PASSWORD_EMAIL_STATUS = 'BitPayId/RESET_FORGOT_PASSWORD_EMAIL_STATUS',
   SUCCESS_FETCH_RECEIVING_ADDRESSES = 'BitPayId/SUCCESS_FETCH_RECEIVING_ADDRESSES',
   SUCCESS_FETCH_SECURITY_SETTINGS = 'BitPayId/SUCCESS_FETCH_SECURITY_SETTINGS',
+  SUCCESS_FETCH_LAST_LOGIN = 'BitPayId/SUCCESS_FETCH_LAST_LOGIN',
   SUCCESS_RESET_METHOD_USER = 'BitPayId/SUCCESS_RESET_METHOD_USER',
   PASSKEY_STATUS = 'BitPayId/PASSKEY_STATUS',
   PASSKEY_CREDENTIALS = 'BitPayId/PASSKEY_CREDENTIALS',
@@ -244,6 +246,14 @@ interface SuccessFetchSecuritySettings {
   };
 }
 
+interface SuccessFetchLastLogin {
+  type: typeof BitPayIdActionTypes.SUCCESS_FETCH_LAST_LOGIN;
+  payload: {
+    network: Network;
+    lastLogin: LastLogin;
+  };
+}
+
 interface PasskeyStatus {
   type: typeof BitPayIdActionTypes.PASSKEY_STATUS;
   payload: {
@@ -305,6 +315,7 @@ export type BitPayIdActionType =
   | UpdateFetchDoshTokenStatus
   | SuccessFetchReceivingAddresses
   | SuccessFetchSecuritySettings
+  | SuccessFetchLastLogin
   | SuccessResetMethodUser
   // Reset Password
   | ForgotPasswordEmailStatus


### PR DESCRIPTION
Adds a "Last Login" section to ProfileSettingsScreen showing the last authentication time, device, approximate location and IP address, so users can notice activity they don't recognize. Includes a link to the security settings as the follow-up action.


TODO:
The backend method does not exist yet — 'getLastLogin' is a placeholder and the GraphQL UserType has no last-login fields, so once the real method and response shape are confirmed only the effect and the LastLogin model change.
The whole section is gated on the response, so it renders nothing until the data is available.