### PR TITLE
Buy/Sell: Ref - consistency in externalCustomerId, moonpay params update

### DIFF
--- a/src/navigation/services/screens/BuyAndSellRoot.tsx
+++ b/src/navigation/services/screens/BuyAndSellRoot.tsx
@@ -499,6 +499,8 @@ const BuyAndSellRoot = ({
   const user: User | undefined = useAppSelector(
     ({BITPAY_ID}) => BITPAY_ID.user[network],
   );
+  const anonymousEid = useAppSelector(({APP}) => APP.brazeEid);
+  const userEid = user?.eid ?? anonymousEid;
   const allRates = useAppSelector(({RATE}) => RATE.rates);
   const accessTokenTransak: TransakAccessTokenData | undefined = useAppSelector(
     ({BUY_CRYPTO}) => BUY_CRYPTO.tokens?.transak?.[transakEnv],
@@ -2611,6 +2613,7 @@ const BuyAndSellRoot = ({
       colorCode: Action,
       theme: theme.dark ? 'dark' : 'light',
       showWalletAddressForm: false,
+      externalCustomerId: userEid,
     };
 
     let _paymentMethod: MoonpayPaymentType | undefined =
@@ -3400,7 +3403,7 @@ const BuyAndSellRoot = ({
       baseCurrencyAmount: offer.sellAmount || +curValRef.current,
       externalTransactionId: externalTransactionId,
       paymentMethod: getMoonpaySellPayoutMethodFormat(paymentMethod!.method),
-      externalCustomerId: user?.eid ?? selectedWallet.id,
+      externalCustomerId: userEid,
       redirectURL:
         APP_DEEPLINK_PREFIX +
         `moonpay?flow=sell&externalId=${externalTransactionId}` +

--- a/src/store/buy-crypto/buy-crypto.models.ts
+++ b/src/store/buy-crypto/buy-crypto.models.ts
@@ -291,7 +291,22 @@ export interface MoonpayGetSignedPaymentUrlReqData {
   paymentMethod?: MoonpayPaymentType;
   colorCode?: string;
   theme?: 'dark' | 'light';
+  themeId?: string;
   language?: string;
+  externalCustomerId?: string;
+  defaultCurrencyCode?: string;
+  walletAddressTag?: string;
+  walletAddresses?: string; // JSON string, e.g. {"btc":"...","eos":"..."}
+  walletAddressTags?: string; // JSON string, e.g. {"eos":"...","xrp":"..."}
+  quoteCurrencyAmount?: number;
+  contractAddress?: string; // Only supported for DeFi Buy integrations
+  networkCode?: string; // Only supported for DeFi Buy integrations
+  email?: string;
+  areFeesIncluded?: boolean;
+  showAllCurrencies?: boolean;
+  showOnlyCurrencies?: string;
+  unsupportedRegionRedirectUrl?: string;
+  skipUnsupportedRegionScreen?: boolean;
 }
 
 export interface MoonpayGetSignedPaymentUrlData {

--- a/src/store/sell-crypto/models/moonpay-sell.models.ts
+++ b/src/store/sell-crypto/models/moonpay-sell.models.ts
@@ -149,10 +149,16 @@ export interface MoonpayGetSellSignedPaymentUrlRequestData {
   externalCustomerId?: string;
   colorCode?: string;
   theme?: 'dark' | 'light';
+  themeId?: string;
   language?: string;
+  email?: string;
   showWalletAddressForm?: boolean;
   unsupportedRegionRedirectUrl?: string;
   skipUnsupportedRegionScreen?: string;
+  defaultBaseCurrencyCode?: string;
+  quoteCurrencyAmount?: number;
+  refundWalletAddresses?: string; // JSON string, e.g. {"btc":"...","bch":"..."}
+  showAllCurrencies?: boolean;
 }
 
 export interface MoonpayGetSellSignedPaymentUrlData {


### PR DESCRIPTION
Consistency in the externalCustomerId parameter of Moonpay will be necessary for handling webhooks.

Related bitcore PR: https://github.com/bitpay/bitcore/pull/4220