### PR TITLE
LogProvider: Fix - Defer LogProvider state updates to avoid setState-…

### DIFF
--- a/src/contexts/LogContext.tsx
+++ b/src/contexts/LogContext.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useRef,
   ReactNode,
 } from 'react';
 import {logManager, LogData} from '../managers/LogManager';
@@ -12,12 +13,26 @@ const LogContext = createContext<LogData | null>(null);
 
 export const LogProvider: React.FC<{children: ReactNode}> = ({children}) => {
   const [logData, setLogData] = useState<LogData>(logManager.getLogData());
+  const frameRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(
+    null,
+  );
 
   useEffect(() => {
-    const unsubscribe = logManager.subscribe(data => {
-      setLogData(data);
+    const unsubscribe = logManager.subscribe(() => {
+      if (frameRef.current != null) {
+        return;
+      }
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        setLogData(logManager.getLogData());
+      });
     });
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      if (frameRef.current != null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+    };
   }, []);
 
   return <LogContext.Provider value={logData}>{children}</LogContext.Provider>;


### PR DESCRIPTION
Jira: [RN-2888](https://bitpayprod.atlassian.net/browse/RN-2888)

…during-render warning

Fix:

```
"Cannot update a component (LogProvider) while rendering a different
   component (KeyOverview)."
```

Fix it at the source of the setState rather than at each render site: LogProvider now coalesces logManager notifications and applies them after the current render/commit via requestAnimationFrame, cancelling any pending frame on unmount. This covers every screen that logs during render and batches chatty log bursts into a single state update.