### PR TITLE
fix: handle Cloudflare challenge during login

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -23,6 +23,7 @@ import 'react-native-gesture-handler';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import BottomNotificationModal from './components/modal/bottom-notification/BottomNotification';
 import OnGoingProcessModal from './components/modal/ongoing-process/OngoingProcess';
+import CloudflareChallengeModal from './components/modal/cloudflare-challenge/CloudflareChallenge';
 import {DeviceEmitterEvents} from './constants/device-emitter-events';
 import {baseNavigatorOptions} from './constants/NavigationOptions';
 import {LOCK_AUTHORIZED_TIME} from './constants/Lock';
@@ -1108,6 +1109,7 @@ export default () => {
           <OnGoingProcessModal />
           <InAppNotification />
           <BottomNotificationModal />
+          <CloudflareChallengeModal />
           <DecryptEnterPasswordModal />
           <BlurContainer />
           <PinModal />

--- a/src/components/modal/cloudflare-challenge/CloudflareChallenge.tsx
+++ b/src/components/modal/cloudflare-challenge/CloudflareChallenge.tsx
@@ -1,0 +1,241 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {ActivityIndicator} from 'react-native';
+import {WebView, WebViewNavigation} from 'react-native-webview';
+import CookieManager from '@preeternal/react-native-cookie-manager';
+import styled from 'styled-components/native';
+import {useTranslation} from 'react-i18next';
+import {IS_ANDROID} from '../../../constants';
+import {LightBlack, SlateDark, White} from '../../../styles/colors';
+import {BaseText} from '../../styled/Text';
+import SheetModal from '../base/sheet/SheetModal';
+import {logManager} from '../../../managers/LogManager';
+import {
+  cloudflareChallengeManager,
+  CloudflareChallengeState,
+} from '../../../managers/CloudflareChallengeManager';
+import {challengeOriginFor} from '../../../utils/cloudflare';
+
+// Cookie Cloudflare sets once a challenge is cleared.
+const CLEARANCE_COOKIE = 'cf_clearance';
+
+// How often to re-check for the clearance cookie while the challenge is up.
+// Turnstile can set the cookie without a navigation event, so load callbacks
+// alone aren't a reliable success signal.
+const CLEARANCE_POLL_MS = 1000;
+
+const Container = styled.SafeAreaView`
+  flex: 1;
+  background-color: ${({theme}) => (theme.dark ? LightBlack : White)};
+`;
+
+const Header = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+`;
+
+const Title = styled(BaseText)`
+  font-size: 16px;
+  font-weight: 700;
+  color: ${({theme}) => (theme.dark ? White : SlateDark)};
+`;
+
+const CancelButton = styled.TouchableOpacity`
+  padding: 8px;
+`;
+
+const CancelText = styled(BaseText)`
+  font-size: 16px;
+  color: ${({theme}) => (theme.dark ? White : SlateDark)};
+`;
+
+const Loader = styled.View`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
+`;
+
+const CloudflareChallengeModal: React.FC = () => {
+  const {t} = useTranslation();
+  const [state, setState] = useState<CloudflareChallengeState>(
+    cloudflareChallengeManager.getState(),
+  );
+  const [loading, setLoading] = useState(true);
+  // The URL being solved. Kept in local state rather than read straight off
+  // the manager so the WebView survives the hide animation after resolve()
+  // clears the manager's url, and so the sheet stays mounted through hide
+  // rather than being torn out mid-animation.
+  const [displayUrl, setDisplayUrl] = useState<string | null>(null);
+  // Guards against resolving twice when the cookie check and a navigation
+  // event land together.
+  const settled = useRef(false);
+  // cf_clearance value present BEFORE the user solved anything. A stale
+  // clearance cookie (plausibly the reason Cloudflare challenged us at all)
+  // must not read as success — only a new value counts. `undefined` means the
+  // snapshot hasn't been taken yet, so success checks hold off.
+  const priorClearance = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => cloudflareChallengeManager.subscribe(setState), []);
+
+  // Cookies are host-scoped, so clearance is read against the origin — but the
+  // WebView loads the challenged URL itself, which is what Cloudflare actually
+  // has a rule for. Loading the bare origin may not re-trigger a path-scoped
+  // challenge, leaving the user with nothing to solve.
+  const origin = displayUrl ? challengeOriginFor(displayUrl) : null;
+
+  const finish = useCallback((solved: boolean) => {
+    if (settled.current) {
+      return;
+    }
+    settled.current = true;
+    cloudflareChallengeManager.resolve(solved);
+  }, []);
+
+  useEffect(() => {
+    if (!state.isVisible) {
+      return;
+    }
+
+    settled.current = false;
+    setLoading(true);
+
+    const nextOrigin = state.url ? challengeOriginFor(state.url) : null;
+    if (!state.url || !nextOrigin) {
+      // Nothing solvable to show. Resolve instead of leaving the caller
+      // awaiting present() forever.
+      logManager.error(
+        '[Cloudflare] Challenge URL missing or malformed:',
+        String(state.url),
+      );
+      finish(false);
+      return;
+    }
+
+    setDisplayUrl(state.url);
+
+    // Snapshot any pre-existing clearance so it can't be mistaken for success.
+    priorClearance.current = undefined;
+    CookieManager.get(nextOrigin, false)
+      .then(cookies => {
+        priorClearance.current = cookies?.[CLEARANCE_COOKIE]?.value ?? null;
+      })
+      .catch(() => {
+        priorClearance.current = null;
+      });
+  }, [state.isVisible, state.url, finish]);
+
+  /**
+   * Cloudflare clears a challenge by setting a fresh `cf_clearance`. On iOS the
+   * WebView writes to the shared NSHTTPCookieStorage (via sharedCookiesEnabled)
+   * that fetch/axios read, so useWebKit is false here; on Android the WebView
+   * and OkHttp already share a cookie jar.
+   */
+  const checkCleared = useCallback(async () => {
+    if (!origin || settled.current || priorClearance.current === undefined) {
+      return;
+    }
+    try {
+      const cookies = await CookieManager.get(origin, false);
+      const clearance = cookies?.[CLEARANCE_COOKIE]?.value;
+      if (clearance && clearance !== priorClearance.current) {
+        logManager.debug('[Cloudflare] Challenge cleared.');
+        finish(true);
+      }
+    } catch (err) {
+      const errStr = err instanceof Error ? err.message : JSON.stringify(err);
+      logManager.error('[Cloudflare] Failed reading cookies:', errStr);
+    }
+  }, [origin, finish]);
+
+  useEffect(() => {
+    if (!state.isVisible) {
+      return;
+    }
+    const poll = setInterval(checkCleared, CLEARANCE_POLL_MS);
+    return () => clearInterval(poll);
+  }, [state.isVisible, checkCleared]);
+
+  const onNavigationStateChange = useCallback(
+    (nav: WebViewNavigation) => {
+      if (!nav.loading) {
+        checkCleared();
+      }
+    },
+    [checkCleared],
+  );
+
+  return (
+    <SheetModal
+      modalLibrary={'bottom-sheet'}
+      isVisible={state.isVisible && !!origin}
+      fullscreen={true}
+      backdropOpacity={0.85}
+      // A stray backdrop tap must not abandon a challenge mid-solve. Matches
+      // RecaptchaModal, the sibling bot-challenge sheet in this same flow.
+      enableBackdropDismiss={false}
+      onBackdropPress={() => {}}
+      paddingTop={0}
+      onModalHide={() => {
+        // Keep the WebView if another present() raced in during the hide
+        // animation; otherwise release it.
+        if (!cloudflareChallengeManager.getState().isVisible) {
+          setDisplayUrl(null);
+        }
+      }}>
+      {displayUrl && origin ? (
+        <Container>
+          <Header>
+            <Title>{t('Verifying your browser')}</Title>
+            <CancelButton
+              onPress={() => finish(false)}
+              accessibilityLabel="Cancel verification">
+              <CancelText>{t('Cancel')}</CancelText>
+            </CancelButton>
+          </Header>
+
+          <WebView
+            source={{uri: displayUrl}}
+            // iOS: write to the cookie store fetch/axios read from.
+            sharedCookiesEnabled={true}
+            thirdPartyCookiesEnabled={true}
+            javaScriptEnabled={true}
+            domStorageEnabled={true}
+            originWhitelist={['*']}
+            // A cached challenge page is a stale challenge page.
+            cacheEnabled={false}
+            cacheMode={IS_ANDROID ? 'LOAD_NO_CACHE' : undefined}
+            // No userAgent override on purpose. Cloudflare scores the UA against
+            // the TLS/HTTP2 fingerprint, so claiming to be Safari from a WebView
+            // makes a challenge likelier to fail, not likelier to clear.
+            onLoadStart={() => setLoading(true)}
+            onLoadEnd={() => {
+              setLoading(false);
+              checkCleared();
+            }}
+            onNavigationStateChange={onNavigationStateChange}
+            onError={syntheticEvent => {
+              const {nativeEvent} = syntheticEvent;
+              logManager.error(
+                '[Cloudflare] WebView error:',
+                nativeEvent.description,
+              );
+            }}
+          />
+
+          {loading ? (
+            <Loader pointerEvents={'none'}>
+              <ActivityIndicator />
+            </Loader>
+          ) : null}
+        </Container>
+      ) : null}
+    </SheetModal>
+  );
+};
+
+export default CloudflareChallengeModal;

--- a/src/managers/CloudflareChallengeManager.spec.ts
+++ b/src/managers/CloudflareChallengeManager.spec.ts
@@ -1,0 +1,123 @@
+import {
+  cloudflareChallengeManager,
+  PRESENT_TIMEOUT_MS,
+} from './CloudflareChallengeManager';
+
+jest.mock('./LogManager', () => ({
+  logManager: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const URL = 'https://bitpay.com/auth/login';
+
+describe('CloudflareChallengeManager', () => {
+  afterEach(() => {
+    // Settle any presentation a test left open so state can't leak across tests.
+    cloudflareChallengeManager.resolve(false);
+  });
+
+  it('starts hidden', () => {
+    expect(cloudflareChallengeManager.getState()).toEqual({isVisible: false});
+  });
+
+  it('present() shows the challenge and resolve(true) settles it', async () => {
+    const pending = cloudflareChallengeManager.present(URL);
+
+    expect(cloudflareChallengeManager.getState()).toEqual({
+      isVisible: true,
+      url: URL,
+    });
+
+    cloudflareChallengeManager.resolve(true);
+
+    await expect(pending).resolves.toBe(true);
+    expect(cloudflareChallengeManager.getState().isVisible).toBe(false);
+  });
+
+  it('resolve(false) settles a dismissal', async () => {
+    const pending = cloudflareChallengeManager.present(URL);
+    cloudflareChallengeManager.resolve(false);
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('concurrent presenters share one presentation and one outcome', async () => {
+    const listener = jest.fn();
+    const unsubscribe = cloudflareChallengeManager.subscribe(listener);
+    listener.mockClear(); // drop the immediate snapshot emit
+
+    const first = cloudflareChallengeManager.present(URL);
+    const second = cloudflareChallengeManager.present(
+      'https://bitpay.com/other',
+    );
+
+    // Only the first presentation shows; the second joins it.
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(cloudflareChallengeManager.getState().url).toBe(URL);
+
+    cloudflareChallengeManager.resolve(true);
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+
+    unsubscribe();
+  });
+
+  it('subscribe() emits the current state immediately and stops after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = cloudflareChallengeManager.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledWith({isVisible: false});
+
+    unsubscribe();
+    listener.mockClear();
+
+    const pending = cloudflareChallengeManager.present(URL);
+    expect(listener).not.toHaveBeenCalled();
+
+    cloudflareChallengeManager.resolve(false);
+    return pending;
+  });
+
+  it('resolve() with nothing pending is a no-op', () => {
+    expect(() => cloudflareChallengeManager.resolve(true)).not.toThrow();
+    expect(cloudflareChallengeManager.getState().isVisible).toBe(false);
+  });
+
+  it('times out as unsolved if nothing ever settles the challenge', async () => {
+    jest.useFakeTimers();
+    try {
+      const pending = cloudflareChallengeManager.present(URL);
+
+      jest.advanceTimersByTime(PRESENT_TIMEOUT_MS);
+
+      await expect(pending).resolves.toBe(false);
+      expect(cloudflareChallengeManager.getState().isVisible).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('resolving normally cancels the safety timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const pending = cloudflareChallengeManager.present(URL);
+      cloudflareChallengeManager.resolve(true);
+      await expect(pending).resolves.toBe(true);
+
+      // A second presentation right away must not be killed by the first
+      // presentation's stale timeout.
+      const secondPending = cloudflareChallengeManager.present(URL);
+      jest.advanceTimersByTime(PRESENT_TIMEOUT_MS - 1);
+      expect(cloudflareChallengeManager.getState().isVisible).toBe(true);
+
+      cloudflareChallengeManager.resolve(true);
+      await expect(secondPending).resolves.toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/managers/CloudflareChallengeManager.ts
+++ b/src/managers/CloudflareChallengeManager.ts
@@ -1,0 +1,116 @@
+import {logManager} from './LogManager';
+
+export interface CloudflareChallengeState {
+  isVisible: boolean;
+  url?: string;
+}
+
+type Listener = (state: CloudflareChallengeState) => void;
+type Waiter = (solved: boolean) => void;
+
+// Safety net: if the modal can never settle the challenge (not mounted, torn
+// down mid-challenge), the login flow must not await present() forever.
+export const PRESENT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Presents the Cloudflare interstitial and lets the caller await the outcome.
+ *
+ * Effects can't render, so this mirrors OngoingProcessManager: a singleton the
+ * modal subscribes to, exposing a promise that settles once the user clears the
+ * challenge or backs out.
+ */
+class CloudflareChallengeManager {
+  private static instance: CloudflareChallengeManager;
+
+  private listeners = new Set<Listener>();
+  private waiters: Waiter[] = [];
+  private state: CloudflareChallengeState = {isVisible: false};
+  private presentTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  static getInstance(): CloudflareChallengeManager {
+    if (!CloudflareChallengeManager.instance) {
+      CloudflareChallengeManager.instance = new CloudflareChallengeManager();
+    }
+    return CloudflareChallengeManager.instance;
+  }
+
+  getState(): CloudflareChallengeState {
+    return {...this.state};
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.getState());
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Show the interstitial for `url`. Resolves true once the challenge clears,
+   * false if the user dismisses it. Concurrent callers share one presentation —
+   * several requests are usually challenged at once and one solve covers them.
+   */
+  present(url: string): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      this.waiters.push(resolve);
+
+      if (!this.state.isVisible) {
+        this.state = {isVisible: true, url};
+        this.presentTimeout = setTimeout(() => {
+          logManager.warn(
+            '[CloudflareChallengeManager] Challenge timed out without a result.',
+          );
+          this.resolve(false);
+        }, PRESENT_TIMEOUT_MS);
+        this.notifyListeners();
+      }
+    });
+  }
+
+  /**
+   * Called by the modal once the challenge is cleared or dismissed.
+   */
+  resolve(solved: boolean): void {
+    if (this.presentTimeout) {
+      clearTimeout(this.presentTimeout);
+      this.presentTimeout = null;
+    }
+
+    const waiters = this.waiters;
+    this.waiters = [];
+    this.state = {isVisible: false, url: undefined};
+    this.notifyListeners();
+
+    waiters.forEach(waiter => {
+      try {
+        waiter(solved);
+      } catch (err) {
+        const errStr = err instanceof Error ? err.message : JSON.stringify(err);
+        logManager.error(
+          '[CloudflareChallengeManager] Error resolving waiter:',
+          errStr,
+        );
+      }
+    });
+  }
+
+  private notifyListeners(): void {
+    const data = this.getState();
+    this.listeners.forEach(listener => {
+      try {
+        listener(data);
+      } catch (err) {
+        const errStr = err instanceof Error ? err.message : JSON.stringify(err);
+        logManager.error(
+          '[CloudflareChallengeManager] Error notifying listener:',
+          errStr,
+        );
+      }
+    });
+  }
+}
+
+export const cloudflareChallengeManager =
+  CloudflareChallengeManager.getInstance();

--- a/src/store/bitpay-id/bitpay-id.effects.spec.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.spec.ts
@@ -21,6 +21,7 @@ import {
   startBitPayIdStoreInit,
   startBitPayIdAnalyticsInit,
   checkLoginWithPasskey,
+  startLogin,
   startSubmitForgotPasswordEmail,
   startTwoFactorAuth,
   startDisconnectBitPayId,
@@ -45,6 +46,12 @@ jest.mock('../../managers/OngoingProcessManager', () => ({
   ongoingProcessManager: {
     show: jest.fn(),
     hide: jest.fn(),
+  },
+}));
+
+jest.mock('../../managers/CloudflareChallengeManager', () => ({
+  cloudflareChallengeManager: {
+    present: jest.fn(),
   },
 }));
 
@@ -152,6 +159,8 @@ jest.mock('../../api/bitpay', () => ({
 import AuthApi from '../../api/auth';
 import UserApi from '../../api/user';
 import {getPasskeyStatus, signInWithPasskey} from '../../utils/passkey';
+import {CloudflareChallengeError} from '../../utils/cloudflare';
+import {cloudflareChallengeManager} from '../../managers/CloudflareChallengeManager';
 import * as helperMethods from '../../utils/helper-methods';
 import {isAnonymousBrazeEid} from '../app/app.effects';
 import {BrazeWrapper} from '../../lib/Braze';
@@ -160,6 +169,7 @@ const MockAuthApi = AuthApi as jest.Mocked<typeof AuthApi>;
 const MockUserApi = UserApi as jest.Mocked<typeof UserApi>;
 const MockGetPasskeyStatus = getPasskeyStatus as jest.Mock;
 const MockSignInWithPasskey = signInWithPasskey as jest.Mock;
+const MockCloudflarePresent = cloudflareChallengeManager.present as jest.Mock;
 const MockIsAnonymousBrazeEid = isAnonymousBrazeEid as jest.Mock;
 const MockBrazeWrapperMerge = BrazeWrapper.merge as jest.Mock;
 const MockSleep = jest
@@ -425,6 +435,100 @@ describe('checkLoginWithPasskey', () => {
         checkLoginWithPasskey('alice@example.com', Network.mainnet, 'csrf'),
       ),
     ).rejects.toThrow('Unexpected passkey failure');
+  });
+
+  it('rethrows a CloudflareChallengeError unwrapped so startLogin can present the challenge', async () => {
+    MockGetPasskeyStatus.mockResolvedValueOnce({passkey: true});
+    MockSignInWithPasskey.mockRejectedValueOnce(
+      new CloudflareChallengeError('https://bitpay.com/auth/passkey', 403),
+    );
+    const store = baseStore();
+    await expect(
+      store.dispatch(
+        checkLoginWithPasskey('alice@example.com', Network.mainnet, 'csrf'),
+      ),
+    ).rejects.toBeInstanceOf(CloudflareChallengeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startLogin (Cloudflare challenge handling)
+// ---------------------------------------------------------------------------
+
+describe('startLogin (Cloudflare challenge handling)', () => {
+  const CHALLENGED_URL = 'https://bitpay.com/auth/passkey/status?email=a%40b.c';
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('presents the challenge and fails without retrying when the user dismisses it', async () => {
+    MockGetPasskeyStatus.mockRejectedValueOnce(
+      new CloudflareChallengeError(CHALLENGED_URL, 403),
+    );
+    MockCloudflarePresent.mockResolvedValueOnce(false);
+
+    const store = baseStore();
+    const result = await store.dispatch(
+      startLogin({email: 'alice@example.com', password: 'hunter2'}),
+    );
+
+    expect(result).toBe(false);
+    expect(MockCloudflarePresent).toHaveBeenCalledTimes(1);
+    expect(MockCloudflarePresent).toHaveBeenCalledWith(CHALLENGED_URL);
+    expect(MockGetPasskeyStatus).toHaveBeenCalledTimes(1);
+    expect(store.getState().BITPAY_ID.loginStatus).toBe('failed');
+  });
+
+  it('replays the login once after the challenge is solved', async () => {
+    MockGetPasskeyStatus.mockRejectedValueOnce(
+      new CloudflareChallengeError(CHALLENGED_URL, 403),
+    ).mockRejectedValueOnce(new Error('Invalid credentials'));
+    MockCloudflarePresent.mockResolvedValueOnce(true);
+
+    const store = baseStore();
+    const result = await store.dispatch(
+      startLogin({email: 'alice@example.com', password: 'hunter2'}),
+    );
+
+    expect(result).toBe(false);
+    expect(MockCloudflarePresent).toHaveBeenCalledTimes(1);
+    // Login ran twice: original attempt + one replay.
+    expect(MockGetPasskeyStatus).toHaveBeenCalledTimes(2);
+    expect(store.getState().BITPAY_ID.loginStatus).toBe('failed');
+    expect(store.getState().BITPAY_ID.loginError).toBe('Invalid credentials');
+  });
+
+  it('does not loop when the replayed login is challenged again', async () => {
+    MockGetPasskeyStatus.mockRejectedValue(
+      new CloudflareChallengeError(CHALLENGED_URL, 403),
+    );
+    MockCloudflarePresent.mockResolvedValue(true);
+
+    const store = baseStore();
+    const result = await store.dispatch(
+      startLogin({email: 'alice@example.com', password: 'hunter2'}),
+    );
+
+    expect(result).toBe(false);
+    expect(MockCloudflarePresent).toHaveBeenCalledTimes(1);
+    expect(MockGetPasskeyStatus).toHaveBeenCalledTimes(2);
+    expect(store.getState().BITPAY_ID.loginStatus).toBe('failed');
+  });
+
+  it('skips the interstitial when the challenge URL is unusable', async () => {
+    MockGetPasskeyStatus.mockRejectedValueOnce(
+      new CloudflareChallengeError('', 403),
+    );
+
+    const store = baseStore();
+    const result = await store.dispatch(
+      startLogin({email: 'alice@example.com', password: 'hunter2'}),
+    );
+
+    expect(result).toBe(false);
+    // Presenting a modal with nothing to load would strand the user; the
+    // friendly error is the correct outcome.
+    expect(MockCloudflarePresent).not.toHaveBeenCalled();
+    expect(store.getState().BITPAY_ID.loginStatus).toBe('failed');
   });
 });
 

--- a/src/store/bitpay-id/bitpay-id.effects.ts
+++ b/src/store/bitpay-id/bitpay-id.effects.ts
@@ -47,6 +47,13 @@ import {
 } from '../../store/bitpay-id/bitpay-id.actions';
 import {logManager} from '../../managers/LogManager';
 import {ongoingProcessManager} from '../../managers/OngoingProcessManager';
+import {cloudflareChallengeManager} from '../../managers/CloudflareChallengeManager';
+import {
+  asCloudflareChallenge,
+  challengeOriginFor,
+  isCloudflareChallengeError,
+  safeErrorMessage,
+} from '../../utils/cloudflare';
 import {clearAllCookiesEverywhere} from '../../utils/cookieAuth';
 import {sleep} from '../../utils/helper-methods';
 
@@ -54,6 +61,11 @@ interface StartLoginParams {
   email?: string;
   password?: string;
   gCaptchaResponse?: string;
+  /**
+   * Set internally when replaying a login after the user cleared a Cloudflare
+   * challenge, so a still-challenged request can't loop.
+   */
+  isChallengeRetry?: boolean;
 }
 
 export const startBitPayIdAnalyticsInit =
@@ -143,7 +155,7 @@ export const startFetchSession =
       const session = await AuthApi.fetchSession(APP.network);
 
       dispatch(BitPayIdActions.successFetchSession(session));
-    } catch (err) {
+    } catch {
       dispatch(BitPayIdActions.failedFetchSession());
     }
   };
@@ -253,6 +265,12 @@ export const checkLoginWithPasskey =
       }
       return Promise.resolve(true);
     } catch (err: any) {
+      // Rethrow unwrapped so startLogin can present the interstitial —
+      // rewrapping below would launder the error type.
+      if (isCloudflareChallengeError(err)) {
+        throw err;
+      }
+
       const errMsg = err.message || JSON.stringify(err);
 
       // No show error, user canceled
@@ -268,6 +286,7 @@ export const startLogin =
     email,
     password,
     gCaptchaResponse,
+    isChallengeRetry,
   }: StartLoginParams): Effect<Promise<boolean>> =>
   async (dispatch, getState) => {
     try {
@@ -355,16 +374,63 @@ export const startLogin =
       dispatch(BitPayIdActions.successLogin(APP.network, session));
       return true;
     } catch (err: any) {
+      const challenge = asCloudflareChallenge(err);
+
+      // Cloudflare wants the user to prove they're human. Present the
+      // interstitial, then replay the login once with the clearance cookie set.
+      // Only present when the challenge URL is usable — presenting with a
+      // malformed URL would give the modal nothing to load, and the friendly
+      // error below is the better outcome.
+      if (challenge && !isChallengeRetry && challengeOriginFor(challenge.url)) {
+        logManager.info(
+          '[startLogin] Cloudflare challenge received — prompting user.',
+        );
+        ongoingProcessManager.hide();
+
+        const solved = await cloudflareChallengeManager.present(challenge.url);
+
+        if (solved) {
+          // Await the retry to completion before returning: `return dispatch(...)`
+          // would run this frame's `finally` as soon as the inner thunk started,
+          // hiding the LOGGING_IN indicator the retry just showed.
+          const retried: boolean = await dispatch(
+            startLogin({
+              email,
+              password,
+              gCaptchaResponse,
+              isChallengeRetry: true,
+            }),
+          );
+          return retried;
+        }
+
+        dispatch(
+          BitPayIdActions.failedLogin(
+            t('Verification was not completed. Please try again.'),
+          ),
+        );
+        return false;
+      }
+
       let errMsg;
 
-      if (isAxiosError<LoginErrorResponse>(err)) {
+      if (challenge) {
+        errMsg = t(
+          'We could not verify your connection. Please try again in a moment.',
+        );
+      } else if (isAxiosError<LoginErrorResponse>(err)) {
         errMsg = upperFirst(
-          err.response?.data.message ||
+          err.response?.data?.message ||
+            safeErrorMessage(err.response?.data, '') ||
             err.message ||
             t('An unexpected error occurred.'),
         );
       } else {
-        errMsg = err.message || JSON.stringify(err);
+        // Never surface a raw response body — it may be an HTML error page.
+        errMsg = safeErrorMessage(
+          err.message,
+          t('An unexpected error occurred.'),
+        );
       }
       dispatch(BitPayIdActions.failedLogin(errMsg));
       logManager.error('[startLogin]', err.status, errMsg);
@@ -911,7 +977,7 @@ export const startSubmitForgotPasswordEmail =
           ),
         );
       }
-    } catch (e) {
+    } catch {
       dispatch(BitPayIdActions.forgotPasswordEmailStatus('failed', errMsg));
     } finally {
       ongoingProcessManager.hide();

--- a/src/utils/cloudflare.spec.ts
+++ b/src/utils/cloudflare.spec.ts
@@ -1,0 +1,193 @@
+import {
+  asCloudflareChallenge,
+  challengeOriginFor,
+  CloudflareChallengeError,
+  isCloudflareChallenge,
+  isCloudflareChallengeBody,
+  isCloudflareChallengeError,
+  looksLikeHtml,
+  safeErrorMessage,
+} from './cloudflare';
+
+// Trimmed version of the interstitial that was rendered to users verbatim.
+const CHALLENGE_HTML = `<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'nonce-yaG1Fqu84tw5pzQXrwvmw6' 'unsafe-eval' https://challenges.cloudflare.com;"></head><body></body></html>`;
+
+describe('looksLikeHtml', () => {
+  it('detects a doctype-prefixed document', () => {
+    expect(looksLikeHtml(CHALLENGE_HTML)).toBe(true);
+  });
+
+  it('detects a bare <html> document', () => {
+    expect(looksLikeHtml('<html><body>nope</body></html>')).toBe(true);
+  });
+
+  it('ignores leading whitespace', () => {
+    expect(looksLikeHtml('\n  <!doctype html><html></html>')).toBe(true);
+  });
+
+  it('does not flag a plain error string', () => {
+    expect(looksLikeHtml('Invalid password')).toBe(false);
+  });
+
+  it('does not flag non-strings', () => {
+    expect(looksLikeHtml({message: 'nope'})).toBe(false);
+    expect(looksLikeHtml(undefined)).toBe(false);
+  });
+});
+
+describe('isCloudflareChallengeBody', () => {
+  it('matches the challenges.cloudflare.com marker', () => {
+    expect(isCloudflareChallengeBody(CHALLENGE_HTML)).toBe(true);
+  });
+
+  it('matches the challenge-platform script path', () => {
+    expect(
+      isCloudflareChallengeBody('<html>/cdn-cgi/challenge-platform/x</html>'),
+    ).toBe(true);
+  });
+
+  it('does not match an unrelated HTML error page', () => {
+    expect(
+      isCloudflareChallengeBody('<html><body>502 Bad Gateway</body></html>'),
+    ).toBe(false);
+  });
+
+  it('does not match a JSON body', () => {
+    expect(isCloudflareChallengeBody('{"message":"Invalid password"}')).toBe(
+      false,
+    );
+  });
+});
+
+describe('isCloudflareChallenge', () => {
+  it('trusts the cf-mitigated header regardless of body', () => {
+    expect(
+      isCloudflareChallenge({
+        status: 403,
+        headers: {'cf-mitigated': 'challenge'},
+        body: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('matches the header case-insensitively', () => {
+    expect(
+      isCloudflareChallenge({
+        status: 503,
+        headers: {'CF-Mitigated': 'challenge'},
+        body: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('reads a fetch Headers object', () => {
+    const headers = new Map([['cf-mitigated', 'challenge']]);
+    expect(isCloudflareChallenge({status: 403, headers, body: ''})).toBe(true);
+  });
+
+  it('falls back to body markers on a challenge status', () => {
+    expect(
+      isCloudflareChallenge({status: 403, headers: {}, body: CHALLENGE_HTML}),
+    ).toBe(true);
+  });
+
+  it('ignores challenge markers on a non-challenge status', () => {
+    expect(
+      isCloudflareChallenge({status: 400, headers: {}, body: CHALLENGE_HTML}),
+    ).toBe(false);
+  });
+
+  it('does not flag an ordinary 403 with a JSON body', () => {
+    expect(
+      isCloudflareChallenge({
+        status: 403,
+        headers: {},
+        body: '{"message":"Forbidden"}',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('asCloudflareChallenge', () => {
+  it('passes a CloudflareChallengeError straight through', () => {
+    const err = new CloudflareChallengeError('https://bitpay.com/x', 403);
+    expect(asCloudflareChallenge(err)).toBe(err);
+  });
+
+  it('converts an axios-shaped challenge response', () => {
+    const err = {
+      config: {url: 'https://bitpay.com/auth/login'},
+      response: {status: 403, headers: {}, data: CHALLENGE_HTML},
+    };
+    const challenge = asCloudflareChallenge(err);
+    expect(challenge).toBeInstanceOf(CloudflareChallengeError);
+    expect(challenge?.url).toBe('https://bitpay.com/auth/login');
+    expect(challenge?.status).toBe(403);
+  });
+
+  it('returns null for an ordinary API error', () => {
+    const err = {
+      config: {url: 'https://bitpay.com/auth/login'},
+      response: {status: 401, headers: {}, data: {message: 'Bad password'}},
+    };
+    expect(asCloudflareChallenge(err)).toBeNull();
+  });
+
+  it('returns null for a plain Error', () => {
+    expect(asCloudflareChallenge(new Error('boom'))).toBeNull();
+  });
+});
+
+describe('isCloudflareChallengeError', () => {
+  it('identifies the error type', () => {
+    expect(
+      isCloudflareChallengeError(
+        new CloudflareChallengeError('https://bitpay.com', 403),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a plain Error', () => {
+    expect(isCloudflareChallengeError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('safeErrorMessage', () => {
+  it('suppresses an HTML body in favor of the fallback', () => {
+    expect(safeErrorMessage(CHALLENGE_HTML, 'Login failed')).toBe(
+      'Login failed',
+    );
+  });
+
+  it('passes a plain message through', () => {
+    expect(safeErrorMessage('Invalid password', 'Login failed')).toBe(
+      'Invalid password',
+    );
+  });
+
+  it('falls back for empty or non-string bodies', () => {
+    expect(safeErrorMessage('   ', 'Login failed')).toBe('Login failed');
+    expect(safeErrorMessage(undefined, 'Login failed')).toBe('Login failed');
+    expect(safeErrorMessage({a: 1}, 'Login failed')).toBe('Login failed');
+  });
+});
+
+describe('challengeOriginFor', () => {
+  it('reduces an API URL to its origin', () => {
+    expect(
+      challengeOriginFor(
+        'https://bitpay.com/auth/passkey/status?email=a%40b.c',
+      ),
+    ).toBe('https://bitpay.com');
+  });
+
+  it('preserves a non-default port', () => {
+    expect(challengeOriginFor('https://test.bitpay.com:8443/auth/login')).toBe(
+      'https://test.bitpay.com:8443',
+    );
+  });
+
+  it('returns null for a malformed URL', () => {
+    expect(challengeOriginFor('not-a-url')).toBeNull();
+  });
+});

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -1,0 +1,149 @@
+/**
+ * Cloudflare interstitial ("Just a moment...") detection.
+ *
+ * When Cloudflare challenges a request it answers with an HTML page instead of
+ * the JSON our API layer expects. Callers that fall back to "use the response
+ * body as the error message" end up rendering that whole markup blob to the
+ * user, so detection has to happen before any body-to-message coercion.
+ */
+
+// Cloudflare stamps this on anything it mitigated (challenge/jschallenge/block).
+const CF_MITIGATED_HEADER = 'cf-mitigated';
+
+const CHALLENGE_BODY_MARKERS = [
+  'challenges.cloudflare.com',
+  '/cdn-cgi/challenge-platform',
+  'cf-browser-verification',
+  'cf_chl_opt',
+  '__cf_chl',
+];
+
+// Statuses Cloudflare serves interstitials with. 429 is included because a
+// managed challenge can surface as a rate-limit page.
+const CHALLENGE_STATUSES = [403, 429, 503];
+
+export class CloudflareChallengeError extends Error {
+  readonly url: string;
+  readonly status: number;
+
+  constructor(url: string, status: number) {
+    super('Additional verification is required to continue.');
+    this.name = 'CloudflareChallengeError';
+    this.url = url;
+    this.status = status;
+  }
+}
+
+export const isCloudflareChallengeError = (
+  err: any,
+): err is CloudflareChallengeError =>
+  err instanceof CloudflareChallengeError ||
+  err?.name === 'CloudflareChallengeError';
+
+/**
+ * True when a body is an HTML document rather than an API payload. Used to keep
+ * markup out of user-facing error text.
+ */
+export const looksLikeHtml = (body: unknown): body is string => {
+  if (typeof body !== 'string') {
+    return false;
+  }
+  const head = body.trimStart().slice(0, 200).toLowerCase();
+  return head.startsWith('<!doctype html') || head.startsWith('<html');
+};
+
+export const isCloudflareChallengeBody = (body: unknown): boolean => {
+  if (typeof body !== 'string') {
+    return false;
+  }
+  // Markers live in the <head>; cap the scan so a large page isn't lowercased.
+  const sample = body.slice(0, 4000).toLowerCase();
+  return CHALLENGE_BODY_MARKERS.some(marker => sample.includes(marker));
+};
+
+/**
+ * Reads a header from a fetch `Headers`, an axios header object, or a plain map.
+ */
+const readHeader = (headers: any, name: string): string | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+  if (typeof headers.get === 'function') {
+    return headers.get(name) ?? undefined;
+  }
+  const lower = name.toLowerCase();
+  const key = Object.keys(headers).find(k => k.toLowerCase() === lower);
+  return key ? String(headers[key]) : undefined;
+};
+
+export const isCloudflareChallenge = ({
+  status,
+  headers,
+  body,
+}: {
+  status?: number;
+  headers?: any;
+  body?: unknown;
+}): boolean => {
+  // Authoritative when present — no body sniffing needed.
+  if (readHeader(headers, CF_MITIGATED_HEADER)) {
+    return true;
+  }
+  if (status && !CHALLENGE_STATUSES.includes(status)) {
+    return false;
+  }
+  return isCloudflareChallengeBody(body);
+};
+
+/**
+ * Normalizes anything thrown by our fetch or axios layers into a
+ * CloudflareChallengeError, or null when it isn't a challenge.
+ */
+export const asCloudflareChallenge = (
+  err: any,
+): CloudflareChallengeError | null => {
+  if (isCloudflareChallengeError(err)) {
+    return err;
+  }
+
+  const response = err?.response;
+  if (
+    response &&
+    isCloudflareChallenge({
+      status: response.status,
+      headers: response.headers,
+      body: response.data,
+    })
+  ) {
+    return new CloudflareChallengeError(
+      err?.config?.url || '',
+      response.status,
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Returns `body` only when it is safe to show a user, otherwise `fallback`.
+ * Guards against dumping an HTML error page into a notification.
+ */
+export const safeErrorMessage = (body: unknown, fallback: string): string => {
+  if (typeof body === 'string' && body.trim() && !looksLikeHtml(body)) {
+    return body;
+  }
+  return fallback;
+};
+
+/**
+ * The origin to load in the challenge WebView. Cloudflare scopes `cf_clearance`
+ * to the host, and the challenged path is often a POST-only API route, so the
+ * interstitial is solved against the origin root instead.
+ */
+export const challengeOriginFor = (url: string): string | null => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+};

--- a/src/utils/passkey.ts
+++ b/src/utils/passkey.ts
@@ -17,6 +17,11 @@ import {
 import {Network} from '../constants';
 import {PasskeyCredential} from '../store/bitpay-id/bitpay-id.models';
 import BitPayIdApi from '../api/bitpay';
+import {
+  CloudflareChallengeError,
+  isCloudflareChallenge,
+  safeErrorMessage,
+} from './cloudflare';
 
 type Json = Record<string, any>;
 
@@ -25,19 +30,34 @@ async function handleFetchError(res: Response, url: string): Promise<void> {
 
   let message = res.statusText;
   let body: any;
+  let text = '';
 
   try {
-    const text = await res.text();
+    text = await res.text();
     if (text) {
       try {
         body = JSON.parse(text);
-        message = body.message || body.error || text;
+        message = body.message || body.error || safeErrorMessage(text, message);
       } catch {
-        message = text; // plain text
+        // Not JSON. Only surface it if it isn't an HTML error page — otherwise
+        // the whole document ends up rendered as the error message.
+        message = safeErrorMessage(text, message);
       }
     }
   } catch {
     /* ignore body parse errors */
+  }
+
+  // Cloudflare answers a challenged request with an interstitial rather than
+  // our API's JSON, so this has to be checked before treating it as a failure.
+  if (
+    isCloudflareChallenge({
+      status: res.status,
+      headers: res.headers,
+      body: text,
+    })
+  ) {
+    throw new CloudflareChallengeError(url, res.status);
   }
 
   const error = new Error(message);


### PR DESCRIPTION
## Problem

Logging in while Cloudflare is challenging traffic dumps the raw `Just a moment...` interstitial into the "Login failed" notification.

Cloudflare answers a challenged request with an HTML page instead of our API's JSON. `handleFetchError` in `src/utils/passkey.ts` fell back to using the response body as the error message:

```js
body = JSON.parse(text);   // throws on Cloudflare's HTML
} catch {
  message = text;          // <- the entire interstitial
}
const error = new Error(message);
```

`getPasskeyStatus` is the first network call in the login flow and runs outside `checkLoginWithPasskey`'s try/catch, so the whole document propagated to `startLogin`'s catch, hit `errMsg = err.message`, and was dispatched to `failedLogin`.

Two bugs stacked: the challenge was never detected, and an HTML body could become user-facing text.

## Changes

| File | |
|---|---|
| `src/utils/cloudflare.ts` | **new** — detection via the `cf-mitigated` header, with a status + body-marker fallback; `CloudflareChallengeError`; `safeErrorMessage` |
| `src/managers/CloudflareChallengeManager.ts` | **new** — promise-based singleton mirroring `OngoingProcessManager`, so an effect can await a UI outcome |
| `src/components/modal/cloudflare-challenge/CloudflareChallenge.tsx` | **new** — WebView interstitial, resolves once a fresh `cf_clearance` is set |
| `src/utils/passkey.ts` | throws `CloudflareChallengeError`; never uses an HTML body as a message |
| `src/store/bitpay-id/bitpay-id.effects.ts` | detects the challenge (fetch **and** axios paths), presents it, replays login once via `isChallengeRetry` |
| `src/Root.tsx` | mounts the modal |
| specs | 97 tests across 4 suites |

Cookie sharing is what makes the retry work: on Android the WebView and OkHttp already share a jar, and on iOS `sharedCookiesEnabled` puts the WebView on the same `NSHTTPCookieStorage` that `fetch`/axios read, so `CookieManager.get(origin, false)` sees the clearance cookie.

No `Info.plist` change is needed — the `AllowedUrlPrefix` allowlist is an `NSURLProtocol`/OkHttp interceptor on the RN networking stack, not WKWebView.

## Details worth a reviewer's attention

- **Challenge errors are rethrown unwrapped from `checkLoginWithPasskey`.** Its catch rewraps everything as a plain `Error`, which laundered the type and hid the interstitial behind a generic message.
- **The replayed login is awaited, not returned.** `return dispatch(...)` lets the outer frame's `finally` run as soon as the inner thunk starts, and `ongoingProcessManager.hide()` isn't refcounted — so the entire retry ran with no `LOGGING_IN` indicator.
- **A malformed challenge URL can no longer hang login.** `present()` is only awaited when the URL is usable, the modal defensively resolves if handed something unloadable, and the manager has a safety timeout. Previously this could leave login awaiting forever with the spinner already hidden.
- **Only a *new* `cf_clearance` counts as success.** A stale cookie is a plausible reason Cloudflare challenged in the first place; treating its mere presence as cleared would fail the replay instantly and burn the single retry.
- **Follows `RecaptchaModal`**, the sibling bot-challenge sheet in this same flow: `SheetModal` rather than `BaseModal`, `cacheEnabled={false}`, and no backdrop dismiss so a stray tap can't abandon a challenge mid-solve.
- **No `userAgent` override, deliberately.** Cloudflare binds `cf_clearance` to the agent that solved the challenge and scores that agent against the TLS/HTTP2 fingerprint, so spoofing Safari from a WebView earns a cookie the app can't use *and* makes the challenge harder to clear.

## Testing

- 97 tests pass across the four affected suites
- ESLint clean; no new `tsc` errors
- **Not yet exercised against a live Cloudflare challenge**

## Known risk

The WebView solves with its default browser UA while the retried request still goes out as `BitPayApp/<version>` (see `UserAgentInterceptor.java`). If the zone enforces strict UA binding, the replay gets re-challenged and lands on the friendly error rather than succeeding. The fix is to send a matching UA on the retry, which means plumbing a UA override into the axios/fetch layer — worth doing as a follow-up once this is verified against staging.
