### PR TITLE
Info.plist: fix - NSLocationWhenInUseUsageDescription

### DIFF
--- a/ios/BitPayApp/Info.plist
+++ b/ios/BitPayApp/Info.plist
@@ -74,6 +74,8 @@
 	<string>This app requires access to Bluetooth for establishing secure connections with Ledger Nano devices, enabling seamless interaction and management of cryptocurrency transactions.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>We need permission to access your camera to scan QR codes and verify your identity.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Your location is used to deliver relevant offers and notifications while you use the app.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>We need permission to access your microphone for identity verification.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
App Store Connect returned **ITMS-90683: Missing purpose string in Info.plist** for version 14.46.1 (build 1):

> The Info.plist file for the "BitPayApp.app" bundle should contain a NSLocationWhenInUseUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data.
