### PR TITLE
chore: drop 32-bit x86 ABI from Android builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,7 +89,7 @@ def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
  */
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
-    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+    return value ? value.split(",") : ["armeabi-v7a", "x86_64", "arm64-v8a"]
 }
 
 apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
@@ -108,7 +108,7 @@ android {
         versionName "14.46.0"
         missingDimensionStrategy 'react-native-camera', 'mlkit'
         ndk {
-            abiFilters "armeabi-v7a", "x86", "x86_64", "arm64-v8a"
+            abiFilters "armeabi-v7a", "x86_64", "arm64-v8a"
         }
     }
     splits {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,7 +27,7 @@ android.enableJetifier=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in


### PR DESCRIPTION
No consumer Android device ships 32-bit-only x86 (the Atom phone line ended in 2016) and Play has required 64-bit since Aug 2019, so the x86 slice is dead weight in every AAB. x86_64 stays for ChromeOS, Intel-Mac emulators, and Play pre-launch test devices.