### PR TITLE
Performance: feat - parallelize launch and refresh network requests

### DIFF
--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -10,3 +10,4 @@ export const HIGH_FEE_LIMIT: {[key in string]: number} = {
   btc: 100, // sat/byte
   eth: 200, // Gwei
 };
+export const WALLET_REQUEST_CONCURRENCY = 5;

--- a/src/store/wallet/effects/create/create.ts
+++ b/src/store/wallet/effects/create/create.ts
@@ -4,6 +4,8 @@ import {
   SupportedChains,
 } from '../../../../constants/currencies';
 import {Effect} from '../../../index';
+import {mapWithConcurrency} from '../../../../utils/concurrency';
+import {WALLET_REQUEST_CONCURRENCY} from '../../../../constants/wallet';
 import {Credentials} from '@bitpay-labs/bitcore-wallet-client';
 import {BwcProvider} from '../../../../lib/bwc';
 import merge from 'lodash.merge';
@@ -931,8 +933,13 @@ export const detectAndCreateTokensForEachEvmWallet =
         'Number of VM wallets to check: ' + vmWalletsToCheck?.length,
       );
 
-      for (const [index, w] of vmWalletsToCheck.entries()) {
-        if (w.chain && w.receiveAddress) {
+      const detectedTokensByWallet = await mapWithConcurrency(
+        vmWalletsToCheck,
+        WALLET_REQUEST_CONCURRENCY,
+        async (w, index) => {
+          if (!w.chain || !w.receiveAddress) {
+            return {w, filteredTokens: []};
+          }
           logManager.debug(
             `Checking tokens for wallet[${index}]: ${w.id} - ${w.receiveAddress}`,
           );
@@ -947,22 +954,24 @@ export const detectAndCreateTokensForEachEvmWallet =
                 }),
               );
 
-            filteredTokens = moralisSVMWithBalanceData.filter(svmToken => {
-              return (
-                (!w.tokens ||
-                  !cloneDeep(w.tokens).some(token =>
-                    token.includes(svmToken.mint),
-                  )) &&
-                svmToken.amount &&
-                svmToken.decimals &&
-                parseFloat(svmToken.amount) / Math.pow(10, svmToken.decimals) >=
-                  1e-7
-              );
-            });
-            filteredTokens = filteredTokens.map(token => ({
-              ...token,
-              token_address: token.mint,
-            }));
+            filteredTokens = moralisSVMWithBalanceData
+              .filter(svmToken => {
+                return (
+                  (!w.tokens ||
+                    !cloneDeep(w.tokens).some(token =>
+                      token.includes(svmToken.mint),
+                    )) &&
+                  svmToken.amount &&
+                  svmToken.decimals &&
+                  parseFloat(svmToken.amount) /
+                    Math.pow(10, svmToken.decimals) >=
+                    1e-7
+                );
+              })
+              .map(token => ({
+                ...token,
+                token_address: token.mint,
+              }));
           } else {
             const erc20WithBalanceData: MoralisErc20TokenBalanceByWalletData[] =
               await dispatch(
@@ -994,69 +1003,73 @@ export const detectAndCreateTokensForEachEvmWallet =
             'Number of tokens to create: ' + filteredTokens?.length,
           );
 
-          let account: number | undefined;
-          let customAccount = false;
-          if (w.credentials.rootPath) {
-            account = getAccount(w.credentials.rootPath);
-            customAccount = true;
-          }
+          return {w, filteredTokens};
+        },
+      );
 
-          for (const [index, tokenToAdd] of filteredTokens.entries()) {
-            const existingTokenWallet = key.wallets.filter(wallet => {
-              return (
-                wallet.id ===
-                `${w.id}-${cloneDeep(tokenToAdd.token_address).toLowerCase()}`
-              );
-            });
-            if (existingTokenWallet[0]) {
-              // workaround for cases where the token was already created but for some reason was not included in the list of tokens in the associated wallet
-              logManager.debug(
-                `Token ${tokenToAdd.symbol} (${tokenToAdd.token_address}) already created for this wallet. Adding to tokens list in the associated wallet`,
-              );
+      for (const {w, filteredTokens} of detectedTokensByWallet) {
+        let account: number | undefined;
+        let customAccount = false;
+        if (w.credentials.rootPath) {
+          account = getAccount(w.credentials.rootPath);
+          customAccount = true;
+        }
 
-              (w.tokens || []).push(existingTokenWallet[0].id);
-              w.tokens = uniq(w.tokens);
+        for (const [index, tokenToAdd] of filteredTokens.entries()) {
+          const existingTokenWallet = key.wallets.filter(wallet => {
+            return (
+              wallet.id ===
+              `${w.id}-${cloneDeep(tokenToAdd.token_address).toLowerCase()}`
+            );
+          });
+          if (existingTokenWallet[0]) {
+            // workaround for cases where the token was already created but for some reason was not included in the list of tokens in the associated wallet
+            logManager.debug(
+              `Token ${tokenToAdd.symbol} (${tokenToAdd.token_address}) already created for this wallet. Adding to tokens list in the associated wallet`,
+            );
 
-              await dispatch(
-                successUpdateKey({
-                  key,
-                }),
-              );
-            } else {
-              try {
-                const newTokenWallet: AddWalletData = {
-                  key,
-                  associatedWallet: w,
-                  currency: {
-                    chain: w.chain,
-                    currencyAbbreviation: tokenToAdd.symbol.toLowerCase(),
-                    isToken: true,
-                    tokenAddress: tokenToAdd.token_address,
-                    decimals: tokenToAdd.decimals,
-                  },
-                  options: {
-                    network: Network.mainnet,
-                    ...(account !== undefined && {
-                      account,
-                      customAccount,
-                    }),
-                  },
-                };
-                const newWallet = await dispatch(addWallet(newTokenWallet));
-                if (newWallet) {
-                  await dispatch(
-                    startUpdateWalletStatus({
-                      key,
-                      wallet: newWallet,
-                      force: true,
-                    }),
-                  );
-                }
-              } catch (err) {
-                logManager.debug(
-                  `Error[${index}] adding Token: ${tokenToAdd?.symbol} (${tokenToAdd.token_address}). Continue anyway...`,
+            (w.tokens || []).push(existingTokenWallet[0].id);
+            w.tokens = uniq(w.tokens);
+
+            await dispatch(
+              successUpdateKey({
+                key,
+              }),
+            );
+          } else {
+            try {
+              const newTokenWallet: AddWalletData = {
+                key,
+                associatedWallet: w,
+                currency: {
+                  chain: w.chain,
+                  currencyAbbreviation: tokenToAdd.symbol.toLowerCase(),
+                  isToken: true,
+                  tokenAddress: tokenToAdd.token_address,
+                  decimals: tokenToAdd.decimals,
+                },
+                options: {
+                  network: Network.mainnet,
+                  ...(account !== undefined && {
+                    account,
+                    customAccount,
+                  }),
+                },
+              };
+              const newWallet = await dispatch(addWallet(newTokenWallet));
+              if (newWallet) {
+                await dispatch(
+                  startUpdateWalletStatus({
+                    key,
+                    wallet: newWallet,
+                    force: true,
+                  }),
                 );
               }
+            } catch (err) {
+              logManager.debug(
+                `Error[${index}] adding Token: ${tokenToAdd?.symbol} (${tokenToAdd.token_address}). Continue anyway...`,
+              );
             }
           }
         }

--- a/src/store/wallet/effects/currencies/currencies.spec.ts
+++ b/src/store/wallet/effects/currencies/currencies.spec.ts
@@ -29,12 +29,11 @@ jest.mock('../../../../managers/TokenManager', () => ({
   },
 }));
 
-// Provide a minimal constant set so the loop only runs over 'eth'
 jest.mock('../../../../constants/currencies', () => {
   const actual = jest.requireActual('../../../../constants/currencies');
   return {
     ...actual,
-    SUPPORTED_VM_TOKENS: ['eth'],
+    SUPPORTED_VM_TOKENS: ['eth', 'matic'],
     // Keep BitpaySupportedTokens empty so custom tokens aren't filtered
     BitpaySupportedTokens: {},
   };
@@ -109,7 +108,7 @@ describe('startGetTokenOptions', () => {
 
   it('calls tokenManager.setTokenOptions after a successful response with an array of tokens', async () => {
     const token = makeToken();
-    mockedAxios.get.mockResolvedValueOnce({data: [token]});
+    mockedAxios.get.mockResolvedValue({data: [token]});
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
@@ -119,7 +118,7 @@ describe('startGetTokenOptions', () => {
 
   it('dispatches APP_TOKENS_DATA_LOADED on success', async () => {
     const token = makeToken();
-    mockedAxios.get.mockResolvedValueOnce({data: [token]});
+    mockedAxios.get.mockResolvedValue({data: [token]});
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
@@ -127,38 +126,59 @@ describe('startGetTokenOptions', () => {
     expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
   });
 
-  // BEHAVIOUR CHANGE: these two cases used to `return` out of the whole effect on
-  // the first bad chain response, skipping BOTH tokenManager.setTokenOptions and
-  // the appTokensDataLoaded dispatch — even though the per-chain catch logs
-  // "continue anyway", and even though balances are awaited behind this effect in
-  // runWalletStoreInit. A single failing chain could therefore stall token data
-  // for every chain. Per-chain failures are now isolated.
-  it('isolates a non-array response for one chain and still completes', async () => {
-    mockedAxios.get.mockResolvedValueOnce({data: {someKey: 'someValue'}});
-
-    const store = configureTestStore({});
-    await store.dispatch(startGetTokenOptions());
-
-    expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
-    expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
-  });
-
-  it('isolates a per-chain network error and still completes', async () => {
-    mockedAxios.get.mockRejectedValueOnce(new Error('network error'));
+  it('keeps tokens from a healthy chain when another chain returns a non-array', async () => {
+    const token = makeToken({address: '0xhealthy', symbol: 'OK'});
+    mockedAxios.get.mockImplementation((url: string) =>
+      url.endsWith('/eth')
+        ? Promise.resolve({data: {someKey: 'someValue'}})
+        : Promise.resolve({data: [token]}),
+    );
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
 
     expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
+    const {tokenOptionsByAddress} = mockedSetTokenOptions.mock.calls[0][0];
+    expect(Object.keys(tokenOptionsByAddress)).toHaveLength(1);
     expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
   });
 
+  it('keeps tokens from a healthy chain when another chain request fails', async () => {
+    const token = makeToken({address: '0xhealthy', symbol: 'OK'});
+    mockedAxios.get.mockImplementation((url: string) =>
+      url.endsWith('/eth')
+        ? Promise.reject(new Error('network error'))
+        : Promise.resolve({data: [token]}),
+    );
+
+    const store = configureTestStore({});
+    await store.dispatch(startGetTokenOptions());
+
+    expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
+    const {tokenOptionsByAddress} = mockedSetTokenOptions.mock.calls[0][0];
+    expect(Object.keys(tokenOptionsByAddress)).toHaveLength(1);
+    expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
+  });
+
+  it('passes empty token maps when every chain fails', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('network error'));
+
+    const store = configureTestStore({});
+    await store.dispatch(startGetTokenOptions());
+
+    expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
+    const {tokenOptionsByAddress, tokenDataByAddress} =
+      mockedSetTokenOptions.mock.calls[0][0];
+    expect(tokenOptionsByAddress).toEqual({});
+    expect(tokenDataByAddress).toEqual({});
+    expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
+  });
 
   it('dispatches failedGetTokenOptions when tokenManager.setTokenOptions throws', async () => {
     // The outer catch is triggered by something outside the inner axios try/catch.
     // Make setTokenOptions throw to simulate an unexpected outer error.
     const token = makeToken();
-    mockedAxios.get.mockResolvedValueOnce({data: [token]});
+    mockedAxios.get.mockResolvedValue({data: [token]});
     mockedSetTokenOptions.mockImplementationOnce(() => {
       throw new Error('storage failure');
     });
@@ -173,7 +193,7 @@ describe('startGetTokenOptions', () => {
 
   it('includes the token in setTokenOptions when it is not a BitpaySupported token', async () => {
     const token = makeToken({address: '0xdeadbeef', symbol: 'TEST'});
-    mockedAxios.get.mockResolvedValueOnce({data: [token]});
+    mockedAxios.get.mockResolvedValue({data: [token]});
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
@@ -190,7 +210,7 @@ describe('startGetTokenOptions', () => {
       symbol: 'MYT',
       decimals: 8,
     });
-    mockedAxios.get.mockResolvedValueOnce({data: [token]});
+    mockedAxios.get.mockResolvedValue({data: [token]});
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
@@ -198,7 +218,8 @@ describe('startGetTokenOptions', () => {
     expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
     const {tokenDataByAddress} = mockedSetTokenOptions.mock.calls[0][0];
     const values = Object.values(tokenDataByAddress) as any[];
-    expect(values.length).toBe(1);
+    expect(values.length).toBe(2);
+    expect(values.map(v => v.chain)).toEqual(['eth', 'matic']);
     expect(values[0].coin).toBe('myt');
     expect(values[0].unitInfo.unitDecimals).toBe(8);
     expect(values[0].properties.isCustom).toBe(true);

--- a/src/store/wallet/effects/currencies/currencies.spec.ts
+++ b/src/store/wallet/effects/currencies/currencies.spec.ts
@@ -127,25 +127,32 @@ describe('startGetTokenOptions', () => {
     expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
   });
 
-  it('returns early (no setTokenOptions) when the API response is not an array', async () => {
-    // The function checks !Array.isArray(tokens) and returns early
+  // BEHAVIOUR CHANGE: these two cases used to `return` out of the whole effect on
+  // the first bad chain response, skipping BOTH tokenManager.setTokenOptions and
+  // the appTokensDataLoaded dispatch — even though the per-chain catch logs
+  // "continue anyway", and even though balances are awaited behind this effect in
+  // runWalletStoreInit. A single failing chain could therefore stall token data
+  // for every chain. Per-chain failures are now isolated.
+  it('isolates a non-array response for one chain and still completes', async () => {
     mockedAxios.get.mockResolvedValueOnce({data: {someKey: 'someValue'}});
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
 
-    expect(mockedSetTokenOptions).not.toHaveBeenCalled();
+    expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
+    expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
   });
 
-  it('catches per-chain network error; tokens stays as non-array so returns early', async () => {
+  it('isolates a per-chain network error and still completes', async () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('network error'));
 
     const store = configureTestStore({});
     await store.dispatch(startGetTokenOptions());
 
-    // tokens was never reassigned → stays as {} (not array) → early return
-    expect(mockedSetTokenOptions).not.toHaveBeenCalled();
+    expect(mockedSetTokenOptions).toHaveBeenCalledTimes(1);
+    expect(AppActions.appTokensDataLoaded).toHaveBeenCalled();
   });
+
 
   it('dispatches failedGetTokenOptions when tokenManager.setTokenOptions throws', async () => {
     // The outer catch is triggered by something outside the inner axios try/catch.

--- a/src/store/wallet/effects/currencies/currencies.ts
+++ b/src/store/wallet/effects/currencies/currencies.ts
@@ -31,20 +31,10 @@ export const startGetTokenOptions =
       let tokenOptionsByAddress: {[key in string]: Token} = {};
       let tokenDataByAddress: {[key in string]: CurrencyOpts} = {};
 
-      // These requests were previously serial (`for await`), so balances — which
-      // are awaited behind this effect in runWalletStoreInit — queued behind one
-      // round trip per supported chain. They are independent, so fetch them
-      // together and merge afterwards.
-      //
-      // Per-chain failures are also isolated now. Previously a single failed
-      // request left `tokens` as `{}`, failed the `Array.isArray` guard and
-      // `return`ed out of the whole effect, skipping both
-      // `tokenManager.setTokenOptions` and the `appTokensDataLoaded` dispatch —
-      // despite the log message stating "continue anyway".
       const chainResults = await Promise.all(
         SUPPORTED_VM_TOKENS.map(async chain => {
           try {
-            const {data} = await axios.get<{[key in string]: Token}>(
+            const {data} = await axios.get<Token[]>(
               `${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain}`,
             );
             if (!Array.isArray(data)) {
@@ -53,7 +43,7 @@ export const startGetTokenOptions =
               );
               return {chain, tokens: [] as Token[]};
             }
-            return {chain, tokens: data as unknown as Token[]};
+            return {chain, tokens: data};
           } catch (error) {
             logManager.info(
               `request: ${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain} failed - continue anyway [startGetTokenOptions]`,
@@ -63,8 +53,6 @@ export const startGetTokenOptions =
         }),
       );
 
-      // Merge in SUPPORTED_VM_TOKENS order so key-collision precedence matches
-      // the previous serial behaviour.
       for (const {chain, tokens} of chainResults) {
         tokens.forEach(token => {
           if (

--- a/src/store/wallet/effects/currencies/currencies.ts
+++ b/src/store/wallet/effects/currencies/currencies.ts
@@ -30,25 +30,42 @@ export const startGetTokenOptions =
       logManager.info('starting [startGetTokenOptions]');
       let tokenOptionsByAddress: {[key in string]: Token} = {};
       let tokenDataByAddress: {[key in string]: CurrencyOpts} = {};
-      for await (const chain of SUPPORTED_VM_TOKENS) {
-        let tokens = {} as {[key in string]: Token};
-        try {
-          const {data} = await axios.get<{[key in string]: Token}>(
-            `${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain}`,
-          );
-          tokens = data;
-        } catch (error) {
-          logManager.info(
-            `request: ${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain} failed - continue anyway [startGetTokenOptions]`,
-          );
-        }
-        if (!Array.isArray(tokens)) {
-          logManager.error(
-            `Unexpected response [startGetTokenOptions]: ${tokens}`,
-          );
-          return;
-        }
 
+      // These requests were previously serial (`for await`), so balances — which
+      // are awaited behind this effect in runWalletStoreInit — queued behind one
+      // round trip per supported chain. They are independent, so fetch them
+      // together and merge afterwards.
+      //
+      // Per-chain failures are also isolated now. Previously a single failed
+      // request left `tokens` as `{}`, failed the `Array.isArray` guard and
+      // `return`ed out of the whole effect, skipping both
+      // `tokenManager.setTokenOptions` and the `appTokensDataLoaded` dispatch —
+      // despite the log message stating "continue anyway".
+      const chainResults = await Promise.all(
+        SUPPORTED_VM_TOKENS.map(async chain => {
+          try {
+            const {data} = await axios.get<{[key in string]: Token}>(
+              `${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain}`,
+            );
+            if (!Array.isArray(data)) {
+              logManager.error(
+                `Unexpected response for ${chain} [startGetTokenOptions]: ${data}`,
+              );
+              return {chain, tokens: [] as Token[]};
+            }
+            return {chain, tokens: data as unknown as Token[]};
+          } catch (error) {
+            logManager.info(
+              `request: ${BASE_BWS_URL}/v1/service/oneInch/getTokens/${chain} failed - continue anyway [startGetTokenOptions]`,
+            );
+            return {chain, tokens: [] as Token[]};
+          }
+        }),
+      );
+
+      // Merge in SUPPORTED_VM_TOKENS order so key-collision precedence matches
+      // the previous serial behaviour.
+      for (const {chain, tokens} of chainResults) {
         tokens.forEach(token => {
           if (
             BitpaySupportedTokens[getCurrencyAbbreviation(token.address, chain)]

--- a/src/store/wallet/effects/rates/rates.spec.ts
+++ b/src/store/wallet/effects/rates/rates.spec.ts
@@ -501,6 +501,185 @@ describe('startGetRates – init context', () => {
 });
 
 // ---------------------------------------------------------------------------
+// startGetRates – carries forward rates this cycle did not produce
+// ---------------------------------------------------------------------------
+describe('startGetRates – carry forward', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+  const {getMultipleTokenPrices} = jest.requireMock(
+    '../../../../store/moralis/moralis.effects',
+  );
+
+  const freshRates = {
+    btc: [{code: 'USD', rate: 60000, name: 'Bitcoin', fetchedOn: NOW, ts: NOW}],
+  };
+  const knownTokenRate = [
+    {code: 'USD', rate: 1, name: 'USDC', fetchedOn: NOW, ts: NOW},
+  ];
+
+  const stateWithKnownTokenRate = {
+    RATE: {
+      rates: {btc: [], '0xusdc_e.eth': knownTokenRate},
+      lastDayRates: {'0xusdc_e.eth': knownTokenRate},
+      fiatRateSeriesCache: {},
+      ratesCacheKey: {},
+    },
+    APP: {altCurrencyList: [{isoCode: 'USD', name: 'US Dollar'}]},
+    WALLET: {
+      keys: {
+        key1: {
+          wallets: [
+            {
+              id: 'wallet-eth-1',
+              chain: 'eth',
+              currencyAbbreviation: 'eth',
+              tokens: ['wallet-eth-1-0xusdc'],
+            },
+          ],
+        },
+      },
+      customTokenOptionsByAddress: {},
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMultipleTokenPrices.mockImplementation(() => () => Promise.resolve([]));
+  });
+
+  it('keeps a known token rate when this cycle produced none', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({data: freshRates})
+      .mockResolvedValueOnce({data: freshRates});
+
+    const store = configureTestStore(stateWithKnownTokenRate as any);
+    const result = await store.dispatch(startGetRates({force: true}));
+
+    expect(result['0xusdc_e.eth']).toEqual(knownTokenRate);
+    expect(result).toHaveProperty('btc');
+  });
+
+  it('keeps a known token rate when the token price chunk rejects', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({data: freshRates})
+      .mockResolvedValueOnce({data: freshRates});
+    getMultipleTokenPrices.mockImplementation(
+      () => () => Promise.reject(new Error('moralis down')),
+    );
+
+    const store = configureTestStore(stateWithKnownTokenRate as any);
+    const result = await store.dispatch(startGetRates({force: true}));
+
+    expect(result['0xusdc_e.eth']).toEqual(knownTokenRate);
+    expect(result).toHaveProperty('btc');
+  });
+
+  it('keeps a healthy chain token rate when another chain chunk rejects', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({data: freshRates})
+      .mockResolvedValueOnce({data: freshRates});
+    getMultipleTokenPrices.mockImplementation(
+      ({chain}: {chain: string}) =>
+        () =>
+          chain === 'eth'
+            ? Promise.reject(new Error('moralis down'))
+            : Promise.resolve([
+                {
+                  usdPrice: 2,
+                  tokenAddress: '0xhealthy',
+                  '24hrPercentChange': '1',
+                },
+              ]),
+    );
+
+    const store = configureTestStore({
+      RATE: {
+        rates: {},
+        lastDayRates: {},
+        fiatRateSeriesCache: {},
+        ratesCacheKey: {},
+      },
+      APP: {altCurrencyList: [{isoCode: 'USD', name: 'US Dollar'}]},
+      WALLET: {
+        keys: {
+          key1: {
+            wallets: [
+              {
+                id: 'wallet-eth-1',
+                chain: 'eth',
+                currencyAbbreviation: 'eth',
+                tokens: ['wallet-eth-1-0xusdc'],
+              },
+              {
+                id: 'wallet-matic-1',
+                chain: 'matic',
+                currencyAbbreviation: 'matic',
+                tokens: ['wallet-matic-1-0xhealthy'],
+              },
+            ],
+          },
+        },
+        customTokenOptionsByAddress: {
+          '0xhealthy_e.matic': {symbol: 'HEALTHY'},
+        },
+      },
+    } as any);
+    const result = await store.dispatch(startGetRates({force: true}));
+
+    expect(result['0xhealthy_e.matic']).toHaveLength(1);
+  });
+
+  it('keeps a known token rate when this cycle produced an empty rate array', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({data: {btc: []}})
+      .mockResolvedValueOnce({data: {btc: []}});
+    getMultipleTokenPrices.mockImplementation(
+      () => () =>
+        Promise.resolve([
+          {usdPrice: 1, tokenAddress: '0xusdc', '24hrPercentChange': '0'},
+        ]),
+    );
+
+    const store = configureTestStore({
+      ...stateWithKnownTokenRate,
+      APP: {altCurrencyList: []},
+      WALLET: {
+        ...stateWithKnownTokenRate.WALLET,
+        customTokenOptionsByAddress: {'0xusdc_e.eth': {symbol: 'USDC'}},
+      },
+    } as any);
+    const result = await store.dispatch(startGetRates({force: true}));
+
+    expect(result['0xusdc_e.eth']).toEqual(knownTokenRate);
+  });
+
+  it('does not keep a stale rate when this cycle produced a fresh one', async () => {
+    const updatedRates = {
+      btc: [
+        {code: 'USD', rate: 70000, name: 'Bitcoin', fetchedOn: NOW, ts: NOW},
+      ],
+    };
+    mockedAxios.get
+      .mockResolvedValueOnce({data: updatedRates})
+      .mockResolvedValueOnce({data: updatedRates});
+
+    const store = configureTestStore({
+      ...stateWithKnownTokenRate,
+      RATE: {
+        ...stateWithKnownTokenRate.RATE,
+        rates: {
+          btc: [
+            {code: 'USD', rate: 1, name: 'Bitcoin', fetchedOn: NOW, ts: NOW},
+          ],
+        },
+      },
+    } as any);
+    const result = await store.dispatch(startGetRates({force: true}));
+
+    expect(result.btc).toEqual(updatedRates.btc);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getContractAddresses – extracts token addresses from wallets
 // ---------------------------------------------------------------------------
 describe('getContractAddresses', () => {

--- a/src/store/wallet/effects/rates/rates.ts
+++ b/src/store/wallet/effects/rates/rates.ts
@@ -4,7 +4,10 @@ import {BASE_BWS_URL} from '../../../../constants/config';
 import {SUPPORTED_VM_TOKENS} from '../../../../constants/currencies';
 import {HistoricRate, Rate, Rates} from '../../../rate/rate.models';
 import {isCacheKeyStale} from '../../utils/wallet';
-import {RATES_CACHE_DURATION} from '../../../../constants/wallet';
+import {
+  RATES_CACHE_DURATION,
+  WALLET_REQUEST_CONCURRENCY,
+} from '../../../../constants/wallet';
 import {DEFAULT_DATE_RANGE} from '../../../../constants/rate';
 import {
   failedGetRates,
@@ -21,6 +24,7 @@ import {
   getLastDayTimestampStartOfHourMs,
   getErrorString,
 } from '../../../../utils/helper-methods';
+import {mapWithConcurrency} from '../../../../utils/concurrency';
 import {
   getMultipleTokenPrices,
   UnifiedTokenPriceObj,
@@ -65,8 +69,6 @@ export const startGetRates =
         logManager.info('startGetRates: fetching new rates...');
         const yesterday = getLastDayTimestampStartOfHourMs();
 
-        // Today's and yesterday's tables are independent; fetching them serially
-        // doubled rate-refresh latency at launch and on every pull-to-refresh.
         logManager.info(
           `startGetRates: get requests to: ${BASE_BWS_URL}/v3/fiatrates/ (today + ts=${yesterday})`,
         );
@@ -99,13 +101,6 @@ export const startGetRates =
           getTokenRates(),
         )) as any;
 
-        // A failed token-price chunk yields no entries for those tokens, and
-        // SUCCESS_GET_RATES replaces rather than merges
-        // (`{...initialState.rates, ...rates}`), so anything missing here loses
-        // its last-known rate app-wide — and ratesCacheKey is bumped regardless,
-        // so nothing retries for the cache window. There is no good reason to
-        // discard a known-good rate because one HTTP call failed, so carry
-        // forward whatever this cycle did not produce.
         const previousRates = getState().RATE.rates;
         const previousLastDayRates = getState().RATE.lastDayRates;
         const allRates: Rates = {...rates, ...tokenRates};
@@ -114,12 +109,12 @@ export const startGetRates =
           ...tokenLastDayRates,
         };
         Object.keys(previousRates).forEach(key => {
-          if (!allRates[key]) {
+          if (!allRates[key]?.length) {
             allRates[key] = previousRates[key];
           }
         });
         Object.keys(previousLastDayRates).forEach(key => {
-          if (!allLastDayRates[key]) {
+          if (!allLastDayRates[key]?.length) {
             allLastDayRates[key] = previousLastDayRates[key];
           }
         });
@@ -224,11 +219,6 @@ export const getTokenRates =
           return chunked_arr;
         };
 
-        // Previously: for chain -> for chunk -> await, so every price chunk on
-        // every chain was its own serial round trip. This runs on each 5-minute
-        // cache expiry AND on every forced refresh (Home pull-to-refresh always
-        // forces). Collect the tasks, fetch them with bounded concurrency, then
-        // process results in order so accumulator precedence is unchanged.
         const priceTasks: {chain: string; chunk: string[]}[] = [];
         for (const chain of SUPPORTED_VM_TOKENS) {
           const contractAddresses = dispatch(getContractAddresses(chain));
@@ -243,47 +233,26 @@ export const getTokenRates =
           }
         }
 
-        const TOKEN_PRICE_FETCH_CONCURRENCY = 5;
-        const priceResults: {chain: string; data: UnifiedTokenPriceObj[]}[] =
-          [];
-        for (
-          let i = 0;
-          i < priceTasks.length;
-          i += TOKEN_PRICE_FETCH_CONCURRENCY
-        ) {
-          const batch = priceTasks.slice(i, i + TOKEN_PRICE_FETCH_CONCURRENCY);
-          const settled = await Promise.all(
-            // Catch per chunk. getMultipleTokenPrices rethrows, and because
-            // results are now processed after all batches complete, an
-            // uncaught rejection here would skip the processing loop entirely
-            // and hand the outer catch EMPTY accumulators — and
-            // SUCCESS_GET_RATES replaces rather than merges
-            // (`{...initialState.rates, ...rates}`), so one transient Moralis
-            // error would wipe every known token rate app-wide. Isolating the
-            // chunk is also strictly better than the original serial code,
-            // which abandoned all remaining chunks on the first failure.
-            batch.map(async ({chain, chunk}) => {
-              try {
-                return {
-                  chain,
-                  data: (await dispatch(
-                    getMultipleTokenPrices({addresses: chunk, chain}),
-                  )) as UnifiedTokenPriceObj[],
-                };
-              } catch (err) {
-                // String(err), not JSON.stringify: a circular non-Error
-                // throwable would make the stringify throw and reject the
-                // batch, defeating the isolation this catch exists for.
-                const errStr = err instanceof Error ? err.message : String(err);
-                logManager.error(
-                  `getTokenRates: token price chunk failed for ${chain} (continue anyway): ${errStr}`,
-                );
-                return {chain, data: [] as UnifiedTokenPriceObj[]};
-              }
-            }),
-          );
-          priceResults.push(...settled);
-        }
+        const priceResults = await mapWithConcurrency(
+          priceTasks,
+          WALLET_REQUEST_CONCURRENCY,
+          async ({chain, chunk}) => {
+            try {
+              return {
+                chain,
+                data: (await dispatch(
+                  getMultipleTokenPrices({addresses: chunk, chain}),
+                )) as UnifiedTokenPriceObj[],
+              };
+            } catch (err) {
+              const errStr = err instanceof Error ? err.message : String(err);
+              logManager.error(
+                `getTokenRates: token price chunk failed for ${chain} (continue anyway): ${errStr}`,
+              );
+              return {chain, data: [] as UnifiedTokenPriceObj[]};
+            }
+          },
+        );
 
         for (const {chain, data} of priceResults) {
           data.forEach((tokenInfo: UnifiedTokenPriceObj) => {

--- a/src/store/wallet/effects/rates/rates.ts
+++ b/src/store/wallet/effects/rates/rates.ts
@@ -65,19 +65,18 @@ export const startGetRates =
         logManager.info('startGetRates: fetching new rates...');
         const yesterday = getLastDayTimestampStartOfHourMs();
 
+        // Today's and yesterday's tables are independent; fetching them serially
+        // doubled rate-refresh latency at launch and on every pull-to-refresh.
         logManager.info(
-          `startGetRates: get request to: ${BASE_BWS_URL}/v3/fiatrates/`,
+          `startGetRates: get requests to: ${BASE_BWS_URL}/v3/fiatrates/ (today + ts=${yesterday})`,
         );
-        const {data: rates} = await axios.get(`${BASE_BWS_URL}/v3/fiatrates/`);
-        logManager.info('startGetRates: success get request');
-
+        const [{data: rates}, {data: lastDayRates}] = await Promise.all([
+          axios.get(`${BASE_BWS_URL}/v3/fiatrates/`),
+          axios.get(`${BASE_BWS_URL}/v3/fiatrates?ts=${yesterday}`),
+        ]);
         logManager.info(
-          `startGetRates: get request (yesterday) to: ${BASE_BWS_URL}/v3/fiatrates?ts=${yesterday}`,
+          'startGetRates: success get requests (today + yesterday)',
         );
-        const {data: lastDayRates} = await axios.get(
-          `${BASE_BWS_URL}/v3/fiatrates?ts=${yesterday}`,
-        );
-        logManager.info('startGetRates: success get request (yesterday)');
 
         if (context === 'init' || altCurrencyList.length === 0) {
           logManager.info('startGetRates: setting alternative currency list');
@@ -100,8 +99,30 @@ export const startGetRates =
           getTokenRates(),
         )) as any;
 
-        const allRates = {...rates, ...tokenRates};
-        const allLastDayRates = {...lastDayRates, ...tokenLastDayRates};
+        // A failed token-price chunk yields no entries for those tokens, and
+        // SUCCESS_GET_RATES replaces rather than merges
+        // (`{...initialState.rates, ...rates}`), so anything missing here loses
+        // its last-known rate app-wide — and ratesCacheKey is bumped regardless,
+        // so nothing retries for the cache window. There is no good reason to
+        // discard a known-good rate because one HTTP call failed, so carry
+        // forward whatever this cycle did not produce.
+        const previousRates = getState().RATE.rates;
+        const previousLastDayRates = getState().RATE.lastDayRates;
+        const allRates: Rates = {...rates, ...tokenRates};
+        const allLastDayRates: Rates = {
+          ...lastDayRates,
+          ...tokenLastDayRates,
+        };
+        Object.keys(previousRates).forEach(key => {
+          if (!allRates[key]) {
+            allRates[key] = previousRates[key];
+          }
+        });
+        Object.keys(previousLastDayRates).forEach(key => {
+          if (!allLastDayRates[key]) {
+            allLastDayRates[key] = previousLastDayRates[key];
+          }
+        });
 
         dispatch(
           successGetRates({
@@ -203,75 +224,122 @@ export const getTokenRates =
           return chunked_arr;
         };
 
+        // Previously: for chain -> for chunk -> await, so every price chunk on
+        // every chain was its own serial round trip. This runs on each 5-minute
+        // cache expiry AND on every forced refresh (Home pull-to-refresh always
+        // forces). Collect the tasks, fetch them with bounded concurrency, then
+        // process results in order so accumulator precedence is unchanged.
+        const priceTasks: {chain: string; chunk: string[]}[] = [];
         for (const chain of SUPPORTED_VM_TOKENS) {
           const contractAddresses = dispatch(getContractAddresses(chain));
           if (contractAddresses?.length > 0) {
-            const chunks = chunkArray(contractAddresses, 25);
-            for (const chunk of chunks) {
-              const data = await dispatch(
-                getMultipleTokenPrices({addresses: chunk, chain}),
-              );
-              data.forEach((tokenInfo: UnifiedTokenPriceObj) => {
-                const {
-                  usdPrice,
-                  tokenAddress,
-                  '24hrPercentChange': percentChange,
-                } = tokenInfo;
-                const lastUpdate = Date.now();
-
-                if (!usdPrice || !tokenAddress || percentChange == null) {
-                  return;
-                }
-                const formattedTokenAddress = addTokenChainSuffix(
-                  tokenAddress,
-                  chain,
-                );
-                // only save token rates if exist in tokens list
-                if (tokensOptsByAddress[formattedTokenAddress]) {
-                  tokenRates[formattedTokenAddress] = [];
-                  tokenLastDayRates[formattedTokenAddress] = [];
-
-                  altCurrencies.forEach((altCurrency: string) => {
-                    const rate =
-                      dispatch(
-                        calculateUsdToAltFiat(
-                          usdPrice,
-                          altCurrency,
-                          decimalPrecision,
-                          shouldSkipLogging,
-                        ),
-                      ) || 0;
-                    tokenRates[formattedTokenAddress].push({
-                      code: altCurrency.toUpperCase(),
-                      fetchedOn: lastUpdate,
-                      name: tokensOptsByAddress[formattedTokenAddress]?.symbol,
-                      rate,
-                      ts: lastUpdate,
-                    });
-                    const sign = Number(percentChange) >= 0 ? 1 : -1;
-                    const lastDayRate =
-                      rate /
-                      (1 + (sign * Math.abs(Number(percentChange))) / 100);
-                    const yesterday = moment
-                      .unix(lastUpdate)
-                      .subtract(1, 'days')
-                      .unix();
-                    tokenLastDayRates[formattedTokenAddress].push({
-                      code: altCurrency.toUpperCase(),
-                      fetchedOn: yesterday,
-                      name: tokensOptsByAddress[formattedTokenAddress]?.symbol,
-                      rate: lastDayRate,
-                      ts: yesterday,
-                    });
-                  });
-                }
-              });
+            for (const chunk of chunkArray(contractAddresses, 25)) {
+              priceTasks.push({chain, chunk});
             }
           } else {
             logManager.info(
               `No tokens wallets for ${chain} found. Skipping getTokenRates...`,
             );
           }
+        }
+
+        const TOKEN_PRICE_FETCH_CONCURRENCY = 5;
+        const priceResults: {chain: string; data: UnifiedTokenPriceObj[]}[] =
+          [];
+        for (
+          let i = 0;
+          i < priceTasks.length;
+          i += TOKEN_PRICE_FETCH_CONCURRENCY
+        ) {
+          const batch = priceTasks.slice(i, i + TOKEN_PRICE_FETCH_CONCURRENCY);
+          const settled = await Promise.all(
+            // Catch per chunk. getMultipleTokenPrices rethrows, and because
+            // results are now processed after all batches complete, an
+            // uncaught rejection here would skip the processing loop entirely
+            // and hand the outer catch EMPTY accumulators — and
+            // SUCCESS_GET_RATES replaces rather than merges
+            // (`{...initialState.rates, ...rates}`), so one transient Moralis
+            // error would wipe every known token rate app-wide. Isolating the
+            // chunk is also strictly better than the original serial code,
+            // which abandoned all remaining chunks on the first failure.
+            batch.map(async ({chain, chunk}) => {
+              try {
+                return {
+                  chain,
+                  data: (await dispatch(
+                    getMultipleTokenPrices({addresses: chunk, chain}),
+                  )) as UnifiedTokenPriceObj[],
+                };
+              } catch (err) {
+                // String(err), not JSON.stringify: a circular non-Error
+                // throwable would make the stringify throw and reject the
+                // batch, defeating the isolation this catch exists for.
+                const errStr = err instanceof Error ? err.message : String(err);
+                logManager.error(
+                  `getTokenRates: token price chunk failed for ${chain} (continue anyway): ${errStr}`,
+                );
+                return {chain, data: [] as UnifiedTokenPriceObj[]};
+              }
+            }),
+          );
+          priceResults.push(...settled);
+        }
+
+        for (const {chain, data} of priceResults) {
+          data.forEach((tokenInfo: UnifiedTokenPriceObj) => {
+            const {
+              usdPrice,
+              tokenAddress,
+              '24hrPercentChange': percentChange,
+            } = tokenInfo;
+            const lastUpdate = Date.now();
+
+            if (!usdPrice || !tokenAddress || percentChange == null) {
+              return;
+            }
+            const formattedTokenAddress = addTokenChainSuffix(
+              tokenAddress,
+              chain,
+            );
+            // only save token rates if exist in tokens list
+            if (tokensOptsByAddress[formattedTokenAddress]) {
+              tokenRates[formattedTokenAddress] = [];
+              tokenLastDayRates[formattedTokenAddress] = [];
+
+              altCurrencies.forEach((altCurrency: string) => {
+                const rate =
+                  dispatch(
+                    calculateUsdToAltFiat(
+                      usdPrice,
+                      altCurrency,
+                      decimalPrecision,
+                      shouldSkipLogging,
+                    ),
+                  ) || 0;
+                tokenRates[formattedTokenAddress].push({
+                  code: altCurrency.toUpperCase(),
+                  fetchedOn: lastUpdate,
+                  name: tokensOptsByAddress[formattedTokenAddress]?.symbol,
+                  rate,
+                  ts: lastUpdate,
+                });
+                const sign = Number(percentChange) >= 0 ? 1 : -1;
+                const lastDayRate =
+                  rate / (1 + (sign * Math.abs(Number(percentChange))) / 100);
+                const yesterday = moment
+                  .unix(lastUpdate)
+                  .subtract(1, 'days')
+                  .unix();
+                tokenLastDayRates[formattedTokenAddress].push({
+                  code: altCurrency.toUpperCase(),
+                  fetchedOn: yesterday,
+                  name: tokensOptsByAddress[formattedTokenAddress]?.symbol,
+                  rate: lastDayRate,
+                  ts: yesterday,
+                });
+              });
+            }
+          });
         }
 
         logManager.info('getTokenRates: success');

--- a/src/store/wallet/effects/status/statusv2.ts
+++ b/src/store/wallet/effects/status/statusv2.ts
@@ -1,5 +1,5 @@
 import {Effect} from '../../../index';
-import {Wallet, WalletStatus} from '../../wallet.models';
+import {Key, Wallet, WalletStatus} from '../../wallet.models';
 import {successUpdateWalletBalancesAndStatus} from '../../wallet.actions';
 import _ from 'lodash';
 import {detectAndCreateTokensForEachEvmWallet} from '../create/create';
@@ -11,6 +11,8 @@ import {
   updateKeyStatus,
 } from './status';
 import {logManager} from '../../../../managers/LogManager';
+import {mapWithConcurrency} from '../../../../utils/concurrency';
+import {WALLET_REQUEST_CONCURRENCY} from '../../../../constants/wallet';
 
 export const clearWalletBalances =
   (): Effect<Promise<void>> => async (dispatch, getState) => {
@@ -135,30 +137,21 @@ export const getUpdatedWalletBalances =
       }
     }
 
-    // Process regular keys.
-    //
-    // Previously a serial `for (const key of keys) await …`, so time-to-balances
-    // grew linearly with key count — the one place this path is used is Home
-    // pull-to-refresh and asset-screen refresh. The v1 equivalent in status.ts
-    // already uses Promise.all; this brings v2 in line.
-    //
-    // Rejection semantics are preserved: no per-key catch is added, so the first
-    // failure still propagates out of getUpdatedWalletBalances exactly as the
-    // serial loop did. (One difference: the remaining keys' requests are now
-    // already in flight when that happens, rather than never being issued.)
-    const keyStatusResults = await Promise.all(
-      keys.map(key =>
-        dispatch(
+    const keyStatusResults = await mapWithConcurrency(
+      keys,
+      WALLET_REQUEST_CONCURRENCY,
+      async key => ({
+        key,
+        keyBalance: await dispatch(
           updateKeyStatus({
             key,
             force,
             dataOnly: true,
           }),
-        ).then((keyBalance: any) => ({key, keyBalance})),
-      ),
+        ),
+      }),
     );
 
-    // Accumulate in the original key order so downstream ordering is unchanged.
     for (const {key, keyBalance} of keyStatusResults) {
       if (keyBalance) {
         keyBalances.push({
@@ -166,7 +159,7 @@ export const getUpdatedWalletBalances =
           totalBalance: keyBalance.totalBalance,
           totalBalanceLastDay: keyBalance.totalBalanceLastDay,
         });
-        keyBalance.walletUpdates.forEach((walletUpdate: any) => {
+        keyBalance.walletUpdates.forEach(walletUpdate => {
           walletBalances.push({
             keyId: key.id,
             walletId: walletUpdate.walletId,
@@ -180,31 +173,30 @@ export const getUpdatedWalletBalances =
       }
     }
 
-    // Process read-only keys — previously serial per key AND per wallet, so a
-    // user with a handful of read-only wallets paid one full round trip each.
-    // The per-wallet catch is kept, so a single failing wallet is still isolated
-    // rather than failing the whole refresh.
-    const readOnlyResults = await Promise.all(
-      readOnlyKeys.flatMap(key =>
-        key.wallets.map((wallet: Wallet) =>
-          dispatch(
+    const readOnlyWallets = readOnlyKeys.flatMap((key: Key) =>
+      key.wallets.map((wallet: Wallet) => ({key, wallet})),
+    );
+    const readOnlyResults = await mapWithConcurrency(
+      readOnlyWallets,
+      WALLET_REQUEST_CONCURRENCY,
+      async ({key, wallet}) => {
+        try {
+          const status = await dispatch(
             updateWalletStatus({
               wallet,
               defaultAltCurrencyIsoCode: defaultAltCurrency.isoCode,
               rates,
               lastDayRates,
             }),
-          ).then(
-            (status: any) => ({keyId: key.id, walletId: wallet.id, status}),
-            (error: unknown) => {
-              logManager.error(
-                `Error updating wallet status for read-only wallet ${wallet.id}: ${error}`,
-              );
-              return undefined;
-            },
-          ),
-        ),
-      ),
+          );
+          return {keyId: key.id, walletId: wallet.id, status};
+        } catch (error) {
+          logManager.error(
+            `Error updating wallet status for read-only wallet ${wallet.id}: ${error}`,
+          );
+          return undefined;
+        }
+      },
     );
 
     for (const result of readOnlyResults) {

--- a/src/store/wallet/effects/status/statusv2.ts
+++ b/src/store/wallet/effects/status/statusv2.ts
@@ -1,5 +1,5 @@
 import {Effect} from '../../../index';
-import {WalletStatus} from '../../wallet.models';
+import {Wallet, WalletStatus} from '../../wallet.models';
 import {successUpdateWalletBalancesAndStatus} from '../../wallet.actions';
 import _ from 'lodash';
 import {detectAndCreateTokensForEachEvmWallet} from '../create/create';
@@ -135,22 +135,38 @@ export const getUpdatedWalletBalances =
       }
     }
 
-    // Process regular keys
-    for (const key of keys) {
-      const keyBalance = await dispatch(
-        updateKeyStatus({
-          key,
-          force,
-          dataOnly: true,
-        }),
-      );
+    // Process regular keys.
+    //
+    // Previously a serial `for (const key of keys) await …`, so time-to-balances
+    // grew linearly with key count — the one place this path is used is Home
+    // pull-to-refresh and asset-screen refresh. The v1 equivalent in status.ts
+    // already uses Promise.all; this brings v2 in line.
+    //
+    // Rejection semantics are preserved: no per-key catch is added, so the first
+    // failure still propagates out of getUpdatedWalletBalances exactly as the
+    // serial loop did. (One difference: the remaining keys' requests are now
+    // already in flight when that happens, rather than never being issued.)
+    const keyStatusResults = await Promise.all(
+      keys.map(key =>
+        dispatch(
+          updateKeyStatus({
+            key,
+            force,
+            dataOnly: true,
+          }),
+        ).then((keyBalance: any) => ({key, keyBalance})),
+      ),
+    );
+
+    // Accumulate in the original key order so downstream ordering is unchanged.
+    for (const {key, keyBalance} of keyStatusResults) {
       if (keyBalance) {
         keyBalances.push({
           keyId: keyBalance.keyId,
           totalBalance: keyBalance.totalBalance,
           totalBalanceLastDay: keyBalance.totalBalanceLastDay,
         });
-        keyBalance.walletUpdates.forEach(walletUpdate => {
+        keyBalance.walletUpdates.forEach((walletUpdate: any) => {
           walletBalances.push({
             keyId: key.id,
             walletId: walletUpdate.walletId,
@@ -164,28 +180,36 @@ export const getUpdatedWalletBalances =
       }
     }
 
-    // Process read-only keys
-    for (const key of readOnlyKeys) {
-      for (const wallet of key.wallets) {
-        try {
-          const status = await dispatch(
+    // Process read-only keys — previously serial per key AND per wallet, so a
+    // user with a handful of read-only wallets paid one full round trip each.
+    // The per-wallet catch is kept, so a single failing wallet is still isolated
+    // rather than failing the whole refresh.
+    const readOnlyResults = await Promise.all(
+      readOnlyKeys.flatMap(key =>
+        key.wallets.map((wallet: Wallet) =>
+          dispatch(
             updateWalletStatus({
               wallet,
               defaultAltCurrencyIsoCode: defaultAltCurrency.isoCode,
               rates,
               lastDayRates,
             }),
-          );
-          walletBalances.push({
-            keyId: key.id,
-            walletId: wallet.id,
-            status,
-          });
-        } catch (error) {
-          logManager.error(
-            `Error updating wallet status for read-only wallet ${wallet.id}: ${error}`,
-          );
-        }
+          ).then(
+            (status: any) => ({keyId: key.id, walletId: wallet.id, status}),
+            (error: unknown) => {
+              logManager.error(
+                `Error updating wallet status for read-only wallet ${wallet.id}: ${error}`,
+              );
+              return undefined;
+            },
+          ),
+        ),
+      ),
+    );
+
+    for (const result of readOnlyResults) {
+      if (result) {
+        walletBalances.push(result);
       }
     }
 

--- a/src/utils/concurrency.spec.ts
+++ b/src/utils/concurrency.spec.ts
@@ -1,0 +1,82 @@
+import {mapWithConcurrency} from './concurrency';
+
+const flushMicrotasks = () => new Promise(resolve => setImmediate(resolve));
+
+describe('mapWithConcurrency', () => {
+  it('returns an empty array for an empty input', async () => {
+    const task = jest.fn();
+    await expect(mapWithConcurrency([], 5, task)).resolves.toEqual([]);
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it('resolves results in input order regardless of completion order', async () => {
+    const delays = [40, 10, 30, 0, 20];
+    const result = await mapWithConcurrency(
+      delays,
+      2,
+      (delay, index) =>
+        new Promise<number>(resolve => setTimeout(() => resolve(index), delay)),
+    );
+    expect(result).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('runs every item when there are more items than the limit', async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7];
+    const result = await mapWithConcurrency(items, 3, async item => item * 2);
+    expect(result).toEqual([2, 4, 6, 8, 10, 12, 14]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const resolvers: Array<() => void> = [];
+
+    const pending = mapWithConcurrency(
+      Array.from({length: 9}, (_, i) => i),
+      3,
+      () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise<void>(resolve => {
+          resolvers.push(() => {
+            inFlight--;
+            resolve();
+          });
+        });
+      },
+    );
+
+    await flushMicrotasks();
+    expect(maxInFlight).toBe(3);
+
+    while (resolvers.length) {
+      resolvers.shift()!();
+      await flushMicrotasks();
+    }
+    await pending;
+    expect(maxInFlight).toBe(3);
+  });
+
+  it('uses a single worker when the limit is below one', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await mapWithConcurrency([1, 2, 3], 0, async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await flushMicrotasks();
+      inFlight--;
+    });
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('rejects when a task rejects', async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async item => {
+        if (item === 2) {
+          throw new Error('boom');
+        }
+        return item;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,17 @@
+export const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const runWorker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await task(items[index], index);
+    }
+  };
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({length: workerCount}, runWorker));
+  return results;
+};


### PR DESCRIPTION
Balances were awaited behind roughly nine serial round trips: one token-list GET per supported chain, two fiat-rate GETs, then per-key and per-read-only-wallet status calls. These are independent, so they now run together. Per-chain and per-chunk failures are isolated rather than aborting the whole effect, and rates this cycle did not produce are carried forward instead of erased.