### PR TITLE
Performance: feat - resolve BwcProvider lazily instead of at module scope

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -170,8 +170,20 @@ import {maybePopulatePortfolioOnAppLaunch} from './store/portfolio';
 import {MoonpayEmbeddedCredentialManager} from './navigation/services/components/MoonpayEmbeddedCredentialManager';
 import {isUnitedKingdomCountry} from './store/location/location.effects';
 
-const BWC = BwcProvider.getInstance();
-const Logger = BWC.getLogger();
+// Resolve BWC lazily. `BwcProvider.getInstance()` at module scope forced
+// src/lib/bwc.ts to evaluate during bundle evaluation, and that module's
+// `static API = BWC` pulls in the whole bitcore-wallet-client graph (4
+// bitcore-lib variants + crypto-wallet-core, whose elliptic-curve precompute
+// tables run real work at module init). Metro's inlineRequires would otherwise
+// defer all of it until first use, so the module-scope call was putting several
+// hundred ms of JS on the critical path to first paint.
+let _bwc: ReturnType<typeof BwcProvider.getInstance> | null = null;
+const getBWC = () => {
+  if (!_bwc) {
+    _bwc = BwcProvider.getInstance();
+  }
+  return _bwc;
+};
 
 const {Timer, SilentPushEvent, InAppMessageModule} = NativeModules;
 
@@ -695,7 +707,7 @@ export default () => {
         };
       });
     };
-    patchLogger(Logger);
+    patchLogger(getBWC().getLogger());
   }, []);
 
   const scheme =
@@ -894,8 +906,9 @@ export default () => {
                         continue;
                       }
                       const xPrivKeyHex = key.properties!.xPrivKeyEDDSA;
-                      const derivedAddress =
-                        BWC.getCore().Deriver.derivePrivateKeyWithPath(
+                      const derivedAddress = getBWC()
+                        .getCore()
+                        .Deriver.derivePrivateKeyWithPath(
                           'SOL',
                           wallet.network,
                           xPrivKeyHex,

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -25,7 +25,17 @@ import {
 } from './encrypt';
 import {logManager} from '../../managers/LogManager';
 
-const BWCProvider = BwcProvider.getInstance();
+// Resolve BWC lazily. Calling getInstance() at module scope forced src/lib/bwc.ts
+// to evaluate during bundle evaluation, and that module's static API field pulls
+// in the whole bitcore-wallet-client graph. Metro inlineRequires would otherwise
+// defer it until first use.
+let _bwcProvider: ReturnType<typeof BwcProvider.getInstance> | null = null;
+const getBWCProvider = () => {
+  if (!_bwcProvider) {
+    _bwcProvider = BwcProvider.getInstance();
+  }
+  return _bwcProvider;
+};
 
 // Helper for logging transform failures before the store exists
 const logTransformFailure = (
@@ -55,7 +65,7 @@ export const bootstrapWallets = (wallets: Wallet[]) => {
           loadMore: true,
           hasConfirmingTxs: false,
         };
-        const walletClient = BWCProvider.getClient(
+        const walletClient = getBWCProvider().getClient(
           JSON.stringify(wallet.credentials),
         );
         const successLog = `bindWalletClient - ${wallet.id}`;
@@ -104,7 +114,7 @@ export const bootstrapKey = (key: Key, id: string) => {
           reducedPrivateKeyShare.data,
         );
       }
-      const tssKey = BWCProvider.createTssKey(properties);
+      const tssKey = getBWCProvider().createTssKey(properties);
       const _key = merge(key, {
         methods: tssKey,
       });
@@ -120,7 +130,7 @@ export const bootstrapKey = (key: Key, id: string) => {
   } else {
     try {
       const _key = merge(key, {
-        methods: BWCProvider.createKey({
+        methods: getBWCProvider().createKey({
           seedType: 'object',
           seedData: key.properties,
         }),


### PR DESCRIPTION
Root.tsx and the persist transforms both called BwcProvider.getInstance() at module scope, which forced the whole bitcore-wallet-client graph - four bitcore-lib variants plus crypto-wallet-core, whose elliptic-curve precompute tables run real work at module init - to load during bundle evaluation, on the critical path to first paint. Metro inlineRequires already defers this when the only references are inside functions.