### PR TITLE
Performance: fix - stop the persist transform mutating live wallet state

### DIFF
--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -435,6 +435,9 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
       transactions: any[];
       loadMore: boolean;
       hasConfirmingTxs: boolean;
+      // Carried through from GetTransactionHistory; send.ts uses it to decide
+      // whether hasConfirmingTxs still needs re-verification.
+      fetchedAt?: number;
     };
   }>({});
   const [groupedHistory, setGroupedHistory] = useState<GroupedHistoryProps[]>(

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -435,9 +435,8 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
       transactions: any[];
       loadMore: boolean;
       hasConfirmingTxs: boolean;
-      // Carried through from GetTransactionHistory; send.ts uses it to decide
-      // whether hasConfirmingTxs still needs re-verification.
       fetchedAt?: number;
+      hasConfirmingTxsAt?: number;
     };
   }>({});
   const [groupedHistory, setGroupedHistory] = useState<GroupedHistoryProps[]>(

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -76,7 +76,6 @@ import {
 } from '../wallet/utils/wallet';
 import {navigationRef, RootStacks, SilentPushEventObj} from '../../Root';
 import {
-  startUpdateAllKeyAndWalletStatus,
   startUpdateWalletStatus,
   FormatKeyBalances,
 } from '../wallet/effects/status/status';
@@ -932,23 +931,6 @@ export const setEmailNotifications =
     });
   };
 
-const _startUpdateAllKeyAndWalletStatus = debounce(
-  async (dispatch, chain, tokenAddress) => {
-    dispatch(
-      startUpdateAllKeyAndWalletStatus({
-        context: 'newBlockEvent',
-        force: true,
-        createTokenWalletWithFunds: false,
-        chain,
-        tokenAddress,
-      }),
-    );
-    DeviceEventEmitter.emit(DeviceEmitterEvents.WALLET_LOAD_HISTORY);
-  },
-  5000,
-  {leading: true, trailing: false},
-);
-
 const _createWalletAddress = debounce(
   async (dispatch, wallet) => {
     dispatch(createWalletAddress({wallet, newAddress: true}));
@@ -1001,10 +983,7 @@ export const handleBwsEvent =
         return;
       }
 
-      if (
-        !wallet.credentials.walletId &&
-        response.notification_type !== 'NewBlock'
-      ) {
+      if (!wallet.credentials.walletId) {
         return;
       }
 
@@ -1018,16 +997,6 @@ export const handleBwsEvent =
           break;
         case 'NewAddress':
           _createWalletAddress(dispatch, wallet);
-          break;
-        case 'NewBlock':
-          if (response.network && response.network === 'livenet') {
-            // Chain and tokenAddress are passed to check if a new token received funds on that network and create the wallet if necessary
-            _startUpdateAllKeyAndWalletStatus(
-              dispatch,
-              response.chain,
-              response.tokenAddress,
-            );
-          }
           break;
         case 'TxProposalAcceptedBy':
         case 'TxProposalRejectedBy':

--- a/src/store/transforms/transforms.spec.ts
+++ b/src/store/transforms/transforms.spec.ts
@@ -316,7 +316,7 @@ describe('bindWalletKeys', () => {
     expect(result).toBe(state);
   });
 
-  it('inbound: strips transactionHistory from wallets', () => {
+  it('inbound: strips transactionHistory from the persisted output', () => {
     const wallet = makeWallet();
     wallet.transactionHistory = {
       transactions: [{id: 'tx'}],
@@ -328,8 +328,36 @@ describe('bindWalletKeys', () => {
         'key-1': {wallets: [wallet]},
       },
     };
-    getInbound()(state);
-    expect(wallet.transactionHistory).toBeUndefined();
+    const result = getInbound()(state);
+    expect(result.keys['key-1'].wallets[0].transactionHistory).toBeUndefined();
+  });
+
+  // Regression guard. redux-persist passes inbound transforms the LIVE store
+  // slice by reference, so this transform used to `delete` transactionHistory off
+  // the real in-memory wallet objects — wiping the tx-history cache on every
+  // persist flush moments after the reducer wrote it, which made the cache
+  // short-circuit in GetTransactionHistory dead and forced constant refetching.
+  it('inbound: does not mutate the live state it is handed', () => {
+    const wallet = makeWallet();
+    const history = {
+      transactions: [{id: 'tx'}],
+      loadMore: false,
+      hasConfirmingTxs: false,
+    };
+    wallet.transactionHistory = history;
+    const key = {wallets: [wallet]};
+    const state: any = {keys: {'key-1': key}};
+
+    const result = getInbound()(state);
+
+    // the live objects are untouched...
+    expect(wallet.transactionHistory).toBe(history);
+    expect(state.keys['key-1']).toBe(key);
+    expect(state.keys['key-1'].wallets[0]).toBe(wallet);
+    // ...and the transform returned new objects rather than the originals
+    expect(result).not.toBe(state);
+    expect(result.keys['key-1']).not.toBe(key);
+    expect(result.keys['key-1'].wallets[0]).not.toBe(wallet);
   });
 
   it('outbound: returns state unchanged when no keys', () => {

--- a/src/store/transforms/transforms.spec.ts
+++ b/src/store/transforms/transforms.spec.ts
@@ -332,11 +332,6 @@ describe('bindWalletKeys', () => {
     expect(result.keys['key-1'].wallets[0].transactionHistory).toBeUndefined();
   });
 
-  // Regression guard. redux-persist passes inbound transforms the LIVE store
-  // slice by reference, so this transform used to `delete` transactionHistory off
-  // the real in-memory wallet objects — wiping the tx-history cache on every
-  // persist flush moments after the reducer wrote it, which made the cache
-  // short-circuit in GetTransactionHistory dead and forced constant refetching.
   it('inbound: does not mutate the live state it is handed', () => {
     const wallet = makeWallet();
     const history = {
@@ -350,14 +345,36 @@ describe('bindWalletKeys', () => {
 
     const result = getInbound()(state);
 
-    // the live objects are untouched...
     expect(wallet.transactionHistory).toBe(history);
     expect(state.keys['key-1']).toBe(key);
     expect(state.keys['key-1'].wallets[0]).toBe(wallet);
-    // ...and the transform returned new objects rather than the originals
     expect(result).not.toBe(state);
     expect(result.keys['key-1']).not.toBe(key);
     expect(result.keys['key-1'].wallets[0]).not.toBe(wallet);
+  });
+
+  it('inbound: preserves every other wallet and key field', () => {
+    const wallet = makeWallet({
+      transactionHistory: {
+        transactions: [{id: 'tx'}],
+        loadMore: false,
+        hasConfirmingTxs: true,
+      },
+    });
+    const key = makeKey({wallets: [wallet]});
+    const state: any = {keys: {'key-1': key}};
+
+    const result = getInbound()(state);
+
+    const expectedWallet = {...wallet};
+    delete expectedWallet.transactionHistory;
+    expect(result.keys['key-1'].wallets[0]).toEqual(expectedWallet);
+    expect(result.keys['key-1'].wallets[0].credentials).toBe(
+      wallet.credentials,
+    );
+    expect(result.keys['key-1'].properties).toBe(key.properties);
+    expect(result.keys['key-1'].methods).toBe(key.methods);
+    expect(result.keys['key-1'].id).toBe(key.id);
   });
 
   it('outbound: returns state unchanged when no keys', () => {

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -145,20 +145,12 @@ export const bindWalletKeys = createTransform<WalletState, WalletState>(
     if (Object.keys(keys).length === 0) {
       return inboundState;
     }
-    // NOTE: redux-persist hands inbound transforms the LIVE store slice by
-    // reference (createPersistoid reduces transforms over `lastState[key]`).
-    // Mutating it here mutated in-memory Redux state: `delete
-    // wallet.transactionHistory` wiped the tx-history cache on every persist
-    // flush, moments after the reducer wrote it, so the cache short-circuit in
-    // GetTransactionHistory never hit and history was refetched constantly.
-    // Build a new map instead and never touch `inboundState`.
+    // redux-persist hands inbound transforms the live store slice by reference,
+    // so mutating `inboundState` here would mutate in-memory Redux state.
     const nextKeys: WalletState['keys'] = {};
     for (const [id, key] of Object.entries(keys)) {
       nextKeys[id] = {
         ...key,
-        // Strip persisted tx history without mutating the live wallet objects.
-        // `Wallet` is a BWC client instance type, so a rest-spread object literal
-        // is not structurally assignable to it; the runtime shape is correct.
         wallets: key.wallets.map(
           ({transactionHistory: _omitted, ...wallet}) => wallet as Wallet,
         ),

--- a/src/store/transforms/transforms.ts
+++ b/src/store/transforms/transforms.ts
@@ -142,16 +142,29 @@ export const bindWalletKeys = createTransform<WalletState, WalletState>(
   // transform state on its way to being serialized and persisted.
   inboundState => {
     const keys = inboundState.keys || {};
-    if (Object.keys(keys).length > 0) {
-      for (const [id, key] of Object.entries(keys)) {
-        key.wallets.forEach(wallet => delete wallet.transactionHistory);
-
-        inboundState.keys[id] = {
-          ...key,
-        };
-      }
+    if (Object.keys(keys).length === 0) {
+      return inboundState;
     }
-    return inboundState;
+    // NOTE: redux-persist hands inbound transforms the LIVE store slice by
+    // reference (createPersistoid reduces transforms over `lastState[key]`).
+    // Mutating it here mutated in-memory Redux state: `delete
+    // wallet.transactionHistory` wiped the tx-history cache on every persist
+    // flush, moments after the reducer wrote it, so the cache short-circuit in
+    // GetTransactionHistory never hit and history was refetched constantly.
+    // Build a new map instead and never touch `inboundState`.
+    const nextKeys: WalletState['keys'] = {};
+    for (const [id, key] of Object.entries(keys)) {
+      nextKeys[id] = {
+        ...key,
+        // Strip persisted tx history without mutating the live wallet objects.
+        // `Wallet` is a BWC client instance type, so a rest-spread object literal
+        // is not structurally assignable to it; the runtime shape is correct.
+        wallets: key.wallets.map(
+          ({transactionHistory: _omitted, ...wallet}) => wallet as Wallet,
+        ),
+      };
+    }
+    return {...inboundState, keys: nextKeys};
   },
   // transform state being rehydrated
   outboundState => {

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -46,6 +46,7 @@ import {
   GetTransactionHistory,
   TX_HISTORY_LIMIT,
 } from '../transactions/transactions';
+import {updateWalletTxHistory} from '../../wallet.actions';
 import {
   checkEncryptedKeysForEddsaMigration,
   createAtaAndSend,
@@ -109,12 +110,7 @@ import ReactNativeBiometrics, {BiometryTypes} from 'react-native-biometrics';
 import {BiometricErrorNotification} from '../../../../constants/BiometricError';
 import {DeviceEventEmitter, Platform} from 'react-native';
 
-// How long a cached `transactionHistory.hasConfirmingTxs` is trusted without
-// re-checking. Past this the flag is NOT discarded — it is re-verified against
-// the network before the send is allowed or blocked (see the gate below). The
-// window only decides when the extra round trip is worth paying; it is not a
-// correctness boundary.
-const HAS_CONFIRMING_TXS_MAX_AGE_MS = 2 * 60 * 1000;
+const HAS_CONFIRMING_TXS_MAX_AGE_MS = 10 * 1000;
 import {Rates} from '../../../rate/rate.models';
 import {
   getCoinAndChainFromCurrencyCode,
@@ -199,95 +195,79 @@ export const createProposalAndBuildTxDetails =
           tx.signingMethod = 'ecdsa';
         }
 
-        // ETH nonce-ordering gate.
-        //
-        // This was effectively dead until recently: the persist transform used to
-        // delete `wallet.transactionHistory` off live state on every flush, so
-        // `hasConfirmingTxs` was almost always undefined by the time a send ran.
-        // Fixing that mutation re-armed the gate — but nothing recomputes the
-        // flag unless a Wallet/Account details screen is mounted or the user
-        // pulls to refresh, so a cached `true` can be arbitrarily old.
-        //
-        // Neither shortcut is acceptable. Trusting a stale `true` locks the user
-        // out of sending until app restart. Discarding a stale `true` disables
-        // the protection for precisely the case it exists for — a low-gas tx can
-        // stay pending far longer than any TTL worth having, and skipping this
-        // block also skips `setEthAddressNonce`, so `tx.nonce` is never set and
-        // BWS assigns its default, which is exactly the collision the gate
-        // prevents. So when the flag is set but stale, re-verify against the
-        // network before deciding.
         if (
           chain === 'eth' &&
           context !== 'speedupEth' &&
           wallet.transactionHistory?.hasConfirmingTxs
         ) {
+          const cachedHistory = wallet.transactionHistory;
           let hasConfirmingTxs = true;
-          const confirmingTxsFetchedAt = wallet.transactionHistory?.fetchedAt;
+          let verified = true;
           const isFresh =
-            !!confirmingTxsFetchedAt &&
-            Date.now() - confirmingTxsFetchedAt < HAS_CONFIRMING_TXS_MAX_AGE_MS;
+            !!cachedHistory.hasConfirmingTxsAt &&
+            Date.now() - cachedHistory.hasConfirmingTxsAt <
+              HAS_CONFIRMING_TXS_MAX_AGE_MS;
 
           if (!isFresh) {
+            const isToken = IsERCToken(currencyAbbreviation, chain);
             try {
-              // Re-verify against the LINKED native wallet for ERC20 sends.
-              // GetTransactionHistory derives hasConfirmingTxs for a token
-              // wallet from `linkedWallet.transactionHistory.transactions` read
-              // out of redux — NOT from the page it just fetched. So refreshing
-              // the token wallet would fetch one thing and then recompute the
-              // flag from the very stale cache this re-verification exists to
-              // replace, and stamp that stale-derived result as fresh.
-              //
-              // Refreshing the linked wallet instead takes the `else` branch
-              // there, deriving the flag from its own fresh page, and its
-              // updateWalletTxHistory write refreshes the exact redux entry the
-              // token-wallet computation reads. It is also the semantically
-              // right target: nonces are account-level, and the linked wallet's
-              // history covers pending txs from the native coin and every token
-              // on the account.
-              // Matches the normal history path so contact names resolve the
-              // same way in the rows this call caches.
-              const {CONTACT} = getState();
-              let verificationWallet = wallet;
-              if (IsERCToken(currencyAbbreviation, chain)) {
-                const linkedWallet = keys[wallet.keyId]?.wallets.find(
-                  (linked: Wallet) => linked.tokens?.includes(wallet.id),
+              const verificationWallet = isToken
+                ? getFullLinkedWallet(keys[wallet.keyId], wallet)
+                : wallet;
+
+              if (!verificationWallet) {
+                verified = false;
+              } else {
+                const {CONTACT} = getState();
+                const refreshed = await dispatch(
+                  GetTransactionHistory({
+                    wallet: verificationWallet,
+                    transactionsHistory: [],
+                    limit: TX_HISTORY_LIMIT,
+                    refresh: true,
+                    contactList: CONTACT.list,
+                  }),
                 );
-                if (linkedWallet) {
-                  verificationWallet = linkedWallet;
+
+                const recomputedFromFreshPage = !!refreshed.hasConfirmingTxsAt;
+
+                if (recomputedFromFreshPage) {
+                  hasConfirmingTxs = !!refreshed.hasConfirmingTxs;
+                  if (isToken) {
+                    dispatch(
+                      updateWalletTxHistory({
+                        walletId: wallet.id,
+                        keyId: wallet.keyId,
+                        transactionHistory: {
+                          ...cachedHistory,
+                          hasConfirmingTxs,
+                          hasConfirmingTxsAt: refreshed.hasConfirmingTxsAt,
+                        },
+                      }),
+                    );
+                  }
+                } else {
+                  verified = false;
                 }
               }
-
-              const refreshed = await dispatch(
-                GetTransactionHistory({
-                  wallet: verificationWallet,
-                  transactionsHistory: [],
-                  limit: TX_HISTORY_LIMIT,
-                  // refresh forces skip=0, which is what makes
-                  // hasConfirmingTxs get recomputed rather than served from
-                  // the cache.
-                  refresh: true,
-                  // Deliberately NOT skipUiFriendlyList/skipWalletProcessing.
-                  // With skip=0 and isAccountDetailsView false this call also
-                  // dispatches updateWalletTxHistory, so whatever it produces
-                  // becomes the cached history that WalletDetails serves via the
-                  // cache short-circuit. Skipping BuildUiFriendlyList would
-                  // store rows without uiIcon/uiDescription and render blank
-                  // transaction rows until the next pull-to-refresh. At
-                  // TX_HISTORY_LIMIT (25) the formatting cost is trivial.
-                  contactList: CONTACT.list,
-                }),
-              );
-              hasConfirmingTxs = !!refreshed.hasConfirmingTxs;
             } catch (err) {
-              // Fail closed. If the pending state cannot be confirmed, keep the
-              // cached `true` rather than risk a nonce collision; a send on a
-              // dead network would fail moments later anyway.
+              verified = false;
               logManager.warn(
-                `Could not re-verify pending ETH txs before send, keeping cached hasConfirmingTxs: ${
+                `Could not re-verify pending ETH txs before send: ${
                   err instanceof Error ? err.message : String(err)
                 }`,
               );
             }
+          }
+
+          if (!verified) {
+            return reject({
+              err: new Error(
+                t(
+                  'Could not check this account for pending transactions. Check your connection and try again.',
+                ),
+              ),
+            });
           }
 
           if (hasConfirmingTxs) {
@@ -478,7 +458,9 @@ const setEthAddressNonce =
           }`,
         );
 
-        tx.nonce = suggestedNonce;
+        if (tx.nonce == null) {
+          tx.nonce = suggestedNonce;
+        }
 
         return resolve();
       } catch (error: any) {

--- a/src/store/wallet/effects/send/send.ts
+++ b/src/store/wallet/effects/send/send.ts
@@ -41,7 +41,11 @@ import {
   GetMinFee,
   getFeeRatePerKb,
 } from '../fee/fee';
-import {GetInput} from '../transactions/transactions';
+import {
+  GetInput,
+  GetTransactionHistory,
+  TX_HISTORY_LIMIT,
+} from '../transactions/transactions';
 import {
   checkEncryptedKeysForEddsaMigration,
   createAtaAndSend,
@@ -104,6 +108,13 @@ import _ from 'lodash';
 import ReactNativeBiometrics, {BiometryTypes} from 'react-native-biometrics';
 import {BiometricErrorNotification} from '../../../../constants/BiometricError';
 import {DeviceEventEmitter, Platform} from 'react-native';
+
+// How long a cached `transactionHistory.hasConfirmingTxs` is trusted without
+// re-checking. Past this the flag is NOT discarded — it is re-verified against
+// the network before the send is allowed or blocked (see the gate below). The
+// window only decides when the extra round trip is worth paying; it is not a
+// correctness boundary.
+const HAS_CONFIRMING_TXS_MAX_AGE_MS = 2 * 60 * 1000;
 import {Rates} from '../../../rate/rate.models';
 import {
   getCoinAndChainFromCurrencyCode,
@@ -188,21 +199,109 @@ export const createProposalAndBuildTxDetails =
           tx.signingMethod = 'ecdsa';
         }
 
+        // ETH nonce-ordering gate.
+        //
+        // This was effectively dead until recently: the persist transform used to
+        // delete `wallet.transactionHistory` off live state on every flush, so
+        // `hasConfirmingTxs` was almost always undefined by the time a send ran.
+        // Fixing that mutation re-armed the gate — but nothing recomputes the
+        // flag unless a Wallet/Account details screen is mounted or the user
+        // pulls to refresh, so a cached `true` can be arbitrarily old.
+        //
+        // Neither shortcut is acceptable. Trusting a stale `true` locks the user
+        // out of sending until app restart. Discarding a stale `true` disables
+        // the protection for precisely the case it exists for — a low-gas tx can
+        // stay pending far longer than any TTL worth having, and skipping this
+        // block also skips `setEthAddressNonce`, so `tx.nonce` is never set and
+        // BWS assigns its default, which is exactly the collision the gate
+        // prevents. So when the flag is set but stale, re-verify against the
+        // network before deciding.
         if (
           chain === 'eth' &&
-          wallet.transactionHistory?.hasConfirmingTxs &&
-          context !== 'speedupEth'
+          context !== 'speedupEth' &&
+          wallet.transactionHistory?.hasConfirmingTxs
         ) {
-          if (!queuedTransactions) {
-            return reject({
-              err: new Error(
-                t(
-                  'There is a pending transaction with a lower account nonce. Wait for your pending transactions to confirm or enable "ETH Queued transactions" in Advanced Settings.',
+          let hasConfirmingTxs = true;
+          const confirmingTxsFetchedAt = wallet.transactionHistory?.fetchedAt;
+          const isFresh =
+            !!confirmingTxsFetchedAt &&
+            Date.now() - confirmingTxsFetchedAt < HAS_CONFIRMING_TXS_MAX_AGE_MS;
+
+          if (!isFresh) {
+            try {
+              // Re-verify against the LINKED native wallet for ERC20 sends.
+              // GetTransactionHistory derives hasConfirmingTxs for a token
+              // wallet from `linkedWallet.transactionHistory.transactions` read
+              // out of redux — NOT from the page it just fetched. So refreshing
+              // the token wallet would fetch one thing and then recompute the
+              // flag from the very stale cache this re-verification exists to
+              // replace, and stamp that stale-derived result as fresh.
+              //
+              // Refreshing the linked wallet instead takes the `else` branch
+              // there, deriving the flag from its own fresh page, and its
+              // updateWalletTxHistory write refreshes the exact redux entry the
+              // token-wallet computation reads. It is also the semantically
+              // right target: nonces are account-level, and the linked wallet's
+              // history covers pending txs from the native coin and every token
+              // on the account.
+              // Matches the normal history path so contact names resolve the
+              // same way in the rows this call caches.
+              const {CONTACT} = getState();
+              let verificationWallet = wallet;
+              if (IsERCToken(currencyAbbreviation, chain)) {
+                const linkedWallet = keys[wallet.keyId]?.wallets.find(
+                  (linked: Wallet) => linked.tokens?.includes(wallet.id),
+                );
+                if (linkedWallet) {
+                  verificationWallet = linkedWallet;
+                }
+              }
+
+              const refreshed = await dispatch(
+                GetTransactionHistory({
+                  wallet: verificationWallet,
+                  transactionsHistory: [],
+                  limit: TX_HISTORY_LIMIT,
+                  // refresh forces skip=0, which is what makes
+                  // hasConfirmingTxs get recomputed rather than served from
+                  // the cache.
+                  refresh: true,
+                  // Deliberately NOT skipUiFriendlyList/skipWalletProcessing.
+                  // With skip=0 and isAccountDetailsView false this call also
+                  // dispatches updateWalletTxHistory, so whatever it produces
+                  // becomes the cached history that WalletDetails serves via the
+                  // cache short-circuit. Skipping BuildUiFriendlyList would
+                  // store rows without uiIcon/uiDescription and render blank
+                  // transaction rows until the next pull-to-refresh. At
+                  // TX_HISTORY_LIMIT (25) the formatting cost is trivial.
+                  contactList: CONTACT.list,
+                }),
+              );
+              hasConfirmingTxs = !!refreshed.hasConfirmingTxs;
+            } catch (err) {
+              // Fail closed. If the pending state cannot be confirmed, keep the
+              // cached `true` rather than risk a nonce collision; a send on a
+              // dead network would fail moments later anyway.
+              logManager.warn(
+                `Could not re-verify pending ETH txs before send, keeping cached hasConfirmingTxs: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            }
+          }
+
+          if (hasConfirmingTxs) {
+            if (!queuedTransactions) {
+              return reject({
+                err: new Error(
+                  t(
+                    'There is a pending transaction with a lower account nonce. Wait for your pending transactions to confirm or enable "ETH Queued transactions" in Advanced Settings.',
+                  ),
                 ),
-              ),
-            });
-          } else {
-            await dispatch(setEthAddressNonce(wallet, tx));
+              });
+            } else {
+              await dispatch(setEthAddressNonce(wallet, tx));
+            }
           }
         }
 

--- a/src/store/wallet/effects/status/status.ts
+++ b/src/store/wallet/effects/status/status.ts
@@ -570,7 +570,6 @@ export type UpdateAllKeyAndWalletStatusContext =
   | 'importWallet'
   | 'init'
   | 'appEffectsDebounced'
-  | 'newBlockEvent'
   | 'startMigration';
 
 export const startUpdateAllKeyAndWalletStatus =

--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -687,6 +687,7 @@ export const GetAccountTransactionHistory =
         transactions: any[];
         loadMore: boolean;
         hasConfirmingTxs: boolean;
+        fetchedAt?: number;
       };
     };
     keyId: string;
@@ -701,6 +702,7 @@ export const GetAccountTransactionHistory =
           transactions: any[];
           loadMore: boolean;
           hasConfirmingTxs: boolean;
+          fetchedAt?: number;
         };
       };
       sortedCompleteHistory: any[];
@@ -715,6 +717,7 @@ export const GetAccountTransactionHistory =
         transactions: any[];
         loadMore: boolean;
         hasConfirmingTxs: boolean;
+        fetchedAt?: number;
       };
     };
     sortedCompleteHistory: any[];
@@ -816,7 +819,12 @@ export const GetTransactionHistory =
     skipWalletProcessing?: boolean;
     skipUiFriendlyList?: boolean;
   }): Effect<
-    Promise<{transactions: any[]; loadMore: boolean; hasConfirmingTxs: boolean}>
+    Promise<{
+      transactions: any[];
+      loadMore: boolean;
+      hasConfirmingTxs: boolean;
+      fetchedAt?: number;
+    }>
   > =>
   async (
     dispatch,
@@ -825,6 +833,7 @@ export const GetTransactionHistory =
     transactions: any[];
     loadMore: boolean;
     hasConfirmingTxs: boolean;
+    fetchedAt?: number;
   }> => {
     return new Promise(async (resolve, reject) => {
       let requestLimit = limit;
@@ -897,8 +906,25 @@ export const GetTransactionHistory =
         });
 
         let hasConfirmingTxs: boolean = false;
+        // Only the newest page can be head-scanned for pending txs, so a
+        // load-more call (skip > 0) cannot recompute this. Carry the previous
+        // value forward instead of reporting `false`: this object is stored into
+        // wallet.transactionHistory (directly, or via
+        // GetAccountTransactionHistory -> UPDATE_ACCOUNT_TX_HISTORY), so
+        // reporting false would clobber a correct `true` and silently bypass the
+        // ETH nonce-ordering gate in send.ts after an ordinary "load more" tap.
+        let confirmingTxsFetchedAt: number | undefined =
+          wallet.transactionHistory?.fetchedAt;
+        if (skip) {
+          hasConfirmingTxs = !!wallet.transactionHistory?.hasConfirmingTxs;
+        }
         if (!skip) {
           let transactionHistory;
+          // Age of the data the flag is actually derived from. For the ERC20
+          // branch below that is the LINKED wallet's cached history, not the page
+          // we just fetched, so stamping Date.now() there would advertise a
+          // stale-derived observation as fresh and stop send.ts re-verifying it.
+          let derivedAt: number | undefined;
           // linked eth wallet could have pendings txs from different tokens
           // this means we need to check pending txs from the linked wallet if is ERC20Token instead of the sending wallet
           const {WALLET} = getState();
@@ -908,8 +934,10 @@ export const GetTransactionHistory =
               tokens?.includes(walletId),
             );
             transactionHistory = linkedWallet?.transactionHistory?.transactions;
+            derivedAt = linkedWallet?.transactionHistory?.fetchedAt;
           } else {
             transactionHistory = newHistory;
+            derivedAt = Date.now();
           }
 
           // look for sent or moved unconfirmed until find a confirmed
@@ -924,6 +952,9 @@ export const GetTransactionHistory =
               }
             }
           }
+          // Reflects the age of the data the flag was derived from — fresh for
+          // the newest-page branch, the linked wallet's own age for ERC20.
+          confirmingTxsFetchedAt = derivedAt;
           if (!isAccountDetailsView) {
             dispatch(
               updateWalletTxHistory({
@@ -933,12 +964,26 @@ export const GetTransactionHistory =
                   transactions: newHistory.slice(0, TX_HISTORY_LIMIT),
                   loadMore,
                   hasConfirmingTxs,
+                  fetchedAt: confirmingTxsFetchedAt,
                 },
               }),
             );
           }
         }
-        return resolve({transactions: newHistory, loadMore, hasConfirmingTxs});
+        // fetchedAt must be stamped here too, not only on the
+        // updateWalletTxHistory dispatch above: when isAccountDetailsView is
+        // true that dispatch is skipped and GetAccountTransactionHistory
+        // stores THIS object into accountTransactionsHistory, which
+        // UPDATE_ACCOUNT_TX_HISTORY then writes straight into
+        // wallet.transactionHistory. Without it the ETH nonce gate in send.ts
+        // would treat the flag as permanently stale for every wallet whose
+        // history was last loaded from AccountDetails.
+        return resolve({
+          transactions: newHistory,
+          loadMore,
+          hasConfirmingTxs,
+          fetchedAt: confirmingTxsFetchedAt,
+        });
       } catch (err) {
         const errString =
           err instanceof Error ? err.message : JSON.stringify(err);

--- a/src/store/wallet/effects/transactions/transactions.ts
+++ b/src/store/wallet/effects/transactions/transactions.ts
@@ -28,7 +28,10 @@ import i18n from 'i18next';
 import {Effect} from '../../../index';
 import {getHistoricFiatRate, startGetRates} from '../rates/rates';
 import {toFiat} from '../../utils/wallet';
-import {formatFiatAmount} from '../../../../utils/helper-methods';
+import {
+  formatFiatAmount,
+  getFullLinkedWallet,
+} from '../../../../utils/helper-methods';
 import {GetMinFee} from '../fee/fee';
 import {
   updateAccountTxHistory,
@@ -51,6 +54,7 @@ const Errors = BWC.getErrors();
 
 export const TX_HISTORY_LIMIT = 25;
 export const BWS_TX_HISTORY_LIMIT = 1001;
+const TX_HISTORY_CACHE_MAX_AGE_MS = 10 * 1000;
 
 const GetCoinsForTx = (wallet: Wallet, txId: string): Promise<any> => {
   const {currencyAbbreviation, chain, network} = wallet;
@@ -688,6 +692,7 @@ export const GetAccountTransactionHistory =
         loadMore: boolean;
         hasConfirmingTxs: boolean;
         fetchedAt?: number;
+        hasConfirmingTxsAt?: number;
       };
     };
     keyId: string;
@@ -703,6 +708,7 @@ export const GetAccountTransactionHistory =
           loadMore: boolean;
           hasConfirmingTxs: boolean;
           fetchedAt?: number;
+          hasConfirmingTxsAt?: number;
         };
       };
       sortedCompleteHistory: any[];
@@ -718,6 +724,7 @@ export const GetAccountTransactionHistory =
         loadMore: boolean;
         hasConfirmingTxs: boolean;
         fetchedAt?: number;
+        hasConfirmingTxsAt?: number;
       };
     };
     sortedCompleteHistory: any[];
@@ -784,6 +791,28 @@ export const GetAccountTransactionHistory =
 
       const sortedCompleteHistory = allTransactions.slice(0, limit);
 
+      const key = getState().WALLET.keys[keyId];
+      if (key) {
+        wallets.forEach(wallet => {
+          if (!IsERCToken(wallet.currencyAbbreviation, wallet.chain)) {
+            return;
+          }
+          const linkedWallet = getFullLinkedWallet(key, wallet);
+          const linkedHistoryFromThisBatch = linkedWallet
+            ? accountTransactionsHistory[linkedWallet.id]
+            : undefined;
+          const tokenHistory = accountTransactionsHistory[wallet.id];
+          if (!linkedHistoryFromThisBatch || !tokenHistory) {
+            return;
+          }
+          accountTransactionsHistory[wallet.id] = {
+            ...tokenHistory,
+            hasConfirmingTxs: linkedHistoryFromThisBatch.hasConfirmingTxs,
+            hasConfirmingTxsAt: linkedHistoryFromThisBatch.hasConfirmingTxsAt,
+          };
+        });
+      }
+
       dispatch(
         updateAccountTxHistory({
           keyId: keyId,
@@ -824,6 +853,7 @@ export const GetTransactionHistory =
       loadMore: boolean;
       hasConfirmingTxs: boolean;
       fetchedAt?: number;
+      hasConfirmingTxsAt?: number;
     }>
   > =>
   async (
@@ -834,6 +864,7 @@ export const GetTransactionHistory =
     loadMore: boolean;
     hasConfirmingTxs: boolean;
     fetchedAt?: number;
+    hasConfirmingTxsAt?: number;
   }> => {
     return new Promise(async (resolve, reject) => {
       let requestLimit = limit;
@@ -864,7 +895,16 @@ export const GetTransactionHistory =
         : null;
       const skip = refresh ? 0 : transactionsHistory.length;
 
-      if (transactionHistory?.transactions?.length && !refresh && !skip) {
+      const cachedAt = transactionHistory?.fetchedAt;
+      const isCacheFresh =
+        !!cachedAt && Date.now() - cachedAt < TX_HISTORY_CACHE_MAX_AGE_MS;
+
+      if (
+        transactionHistory?.transactions?.length &&
+        !refresh &&
+        !skip &&
+        isCacheFresh
+      ) {
         return resolve(transactionHistory);
       }
 
@@ -907,23 +947,18 @@ export const GetTransactionHistory =
 
         let hasConfirmingTxs: boolean = false;
         // Only the newest page can be head-scanned for pending txs, so a
-        // load-more call (skip > 0) cannot recompute this. Carry the previous
-        // value forward instead of reporting `false`: this object is stored into
-        // wallet.transactionHistory (directly, or via
-        // GetAccountTransactionHistory -> UPDATE_ACCOUNT_TX_HISTORY), so
-        // reporting false would clobber a correct `true` and silently bypass the
-        // ETH nonce-ordering gate in send.ts after an ordinary "load more" tap.
-        let confirmingTxsFetchedAt: number | undefined =
+        // load-more call carries the previous value forward rather than
+        // reporting false and clobbering a correct `true`.
+        let hasConfirmingTxsAt: number | undefined =
+          wallet.transactionHistory?.hasConfirmingTxsAt;
+        let fetchedAt: number | undefined =
           wallet.transactionHistory?.fetchedAt;
         if (skip) {
           hasConfirmingTxs = !!wallet.transactionHistory?.hasConfirmingTxs;
         }
         if (!skip) {
+          fetchedAt = Date.now();
           let transactionHistory;
-          // Age of the data the flag is actually derived from. For the ERC20
-          // branch below that is the LINKED wallet's cached history, not the page
-          // we just fetched, so stamping Date.now() there would advertise a
-          // stale-derived observation as fresh and stop send.ts re-verifying it.
           let derivedAt: number | undefined;
           // linked eth wallet could have pendings txs from different tokens
           // this means we need to check pending txs from the linked wallet if is ERC20Token instead of the sending wallet
@@ -952,10 +987,8 @@ export const GetTransactionHistory =
               }
             }
           }
-          // Reflects the age of the data the flag was derived from — fresh for
-          // the newest-page branch, the linked wallet's own age for ERC20.
-          confirmingTxsFetchedAt = derivedAt;
-          if (!isAccountDetailsView) {
+          hasConfirmingTxsAt = derivedAt;
+          if (!isAccountDetailsView && !isExportHistoryView) {
             dispatch(
               updateWalletTxHistory({
                 walletId: walletId,
@@ -964,25 +997,19 @@ export const GetTransactionHistory =
                   transactions: newHistory.slice(0, TX_HISTORY_LIMIT),
                   loadMore,
                   hasConfirmingTxs,
-                  fetchedAt: confirmingTxsFetchedAt,
+                  fetchedAt,
+                  hasConfirmingTxsAt,
                 },
               }),
             );
           }
         }
-        // fetchedAt must be stamped here too, not only on the
-        // updateWalletTxHistory dispatch above: when isAccountDetailsView is
-        // true that dispatch is skipped and GetAccountTransactionHistory
-        // stores THIS object into accountTransactionsHistory, which
-        // UPDATE_ACCOUNT_TX_HISTORY then writes straight into
-        // wallet.transactionHistory. Without it the ETH nonce gate in send.ts
-        // would treat the flag as permanently stale for every wallet whose
-        // history was last loaded from AccountDetails.
         return resolve({
           transactions: newHistory,
           loadMore,
           hasConfirmingTxs,
-          fetchedAt: confirmingTxsFetchedAt,
+          fetchedAt,
+          hasConfirmingTxsAt,
         });
       } catch (err) {
         const errString =

--- a/src/store/wallet/wallet.actions.ts
+++ b/src/store/wallet/wallet.actions.ts
@@ -172,6 +172,7 @@ export const updateWalletTxHistory = (payload: {
     loadMore: boolean;
     hasConfirmingTxs: boolean;
     fetchedAt?: number;
+    hasConfirmingTxsAt?: number;
   };
 }): WalletActionType => ({
   type: WalletActionTypes.UPDATE_WALLET_TX_HISTORY,
@@ -186,6 +187,7 @@ export const updateAccountTxHistory = (payload: {
       loadMore: boolean;
       hasConfirmingTxs: boolean;
       fetchedAt?: number;
+      hasConfirmingTxsAt?: number;
     };
   };
 }): WalletActionType => ({

--- a/src/store/wallet/wallet.actions.ts
+++ b/src/store/wallet/wallet.actions.ts
@@ -171,6 +171,7 @@ export const updateWalletTxHistory = (payload: {
     transactions: any[];
     loadMore: boolean;
     hasConfirmingTxs: boolean;
+    fetchedAt?: number;
   };
 }): WalletActionType => ({
   type: WalletActionTypes.UPDATE_WALLET_TX_HISTORY,
@@ -184,6 +185,7 @@ export const updateAccountTxHistory = (payload: {
       transactions: any[];
       loadMore: boolean;
       hasConfirmingTxs: boolean;
+      fetchedAt?: number;
     };
   };
 }): WalletActionType => ({

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -151,6 +151,10 @@ export interface WalletObj {
     transactions: any[];
     loadMore: boolean;
     hasConfirmingTxs: boolean;
+    // When this history was fetched. `hasConfirmingTxs` gates ETH sends, and
+    // nothing recomputes it unless a details screen is mounted or the user
+    // pulls to refresh, so consumers must check freshness before trusting it.
+    fetchedAt?: number;
   };
   hideWallet?: boolean;
   hideWalletByAccount?: boolean;

--- a/src/store/wallet/wallet.models.ts
+++ b/src/store/wallet/wallet.models.ts
@@ -151,10 +151,8 @@ export interface WalletObj {
     transactions: any[];
     loadMore: boolean;
     hasConfirmingTxs: boolean;
-    // When this history was fetched. `hasConfirmingTxs` gates ETH sends, and
-    // nothing recomputes it unless a details screen is mounted or the user
-    // pulls to refresh, so consumers must check freshness before trusting it.
     fetchedAt?: number;
+    hasConfirmingTxsAt?: number;
   };
   hideWallet?: boolean;
   hideWalletByAccount?: boolean;

--- a/src/store/wallet/wallet.types.ts
+++ b/src/store/wallet/wallet.types.ts
@@ -254,6 +254,7 @@ interface updateWalletTxHistory {
       transactions: any[];
       loadMore: boolean;
       hasConfirmingTxs: boolean;
+      fetchedAt?: number;
     };
   };
 }
@@ -267,6 +268,7 @@ interface updateAccountTxHistory {
         transactions: any[];
         loadMore: boolean;
         hasConfirmingTxs: boolean;
+        fetchedAt?: number;
       };
     };
   };

--- a/src/store/wallet/wallet.types.ts
+++ b/src/store/wallet/wallet.types.ts
@@ -255,6 +255,7 @@ interface updateWalletTxHistory {
       loadMore: boolean;
       hasConfirmingTxs: boolean;
       fetchedAt?: number;
+      hasConfirmingTxsAt?: number;
     };
   };
 }
@@ -269,6 +270,7 @@ interface updateAccountTxHistory {
         loadMore: boolean;
         hasConfirmingTxs: boolean;
         fetchedAt?: number;
+        hasConfirmingTxsAt?: number;
       };
     };
   };


### PR DESCRIPTION
The bindWalletKeys inbound transform ran `delete wallet.transactionHistory` on wallet objects it does not own. redux-persist passes inbound transforms the live store slice by reference, so this mutated in-memory Redux state: the tx-history cache was wiped on every persist flush, moments after the reducer wrote it. The read-side cache check in GetTransactionHistory was therefore dead, and history was re-downloaded on every wallet or account view - one request per wallet on account views.

Restoring that cache re-arms a safety gate that had been dead as a side effect of the same bug: send.ts blocks an ETH send when `hasConfirmingTxs` is set, to avoid a nonce collision with a pending transaction. Nothing recomputes that flag unless a details screen is mounted or the user pulls to refresh, so a cached value can be arbitrarily old. Trusting a stale value locks the user out of sending; discarding it disables the protection for exactly the case it exists for. So the flag now carries a fetchedAt stamp and, when stale, is re-verified against the network before the send is allowed or blocked. On a fetch failure it fails closed.

For ERC20 sends the re-verification targets the linked native wallet, because the flag for a token wallet is derived from the linked wallet's history - nonces are account-level - and re-fetching the token wallet would recompute from the same stale cache. Load-more pages carry the previous flag and its age forward rather than reporting false, which would clobber a correct value after an ordinary scroll.