### PR TITLE
Performance: feat - skip no-op portfolio populate updates and narrow slice selectors

### DIFF
--- a/src/navigation/tabs/home/HomeRoot.tsx
+++ b/src/navigation/tabs/home/HomeRoot.tsx
@@ -105,7 +105,13 @@ const HomeRoot: React.FC<HomeScreenProps> = ({route, navigation}) => {
   const pendingTxps = wallets.flatMap(w => w.pendingTxps);
   const appIsLoading = useAppSelector(({APP}) => APP.appIsLoading);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
-  const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
+  // Narrowed from `useAppSelector(({PORTFOLIO}) => PORTFOLIO)`. The whole slice
+  // gets a new object identity on every populate-progress tick, which
+  // re-rendered this component ~1-2x/second for the duration of every
+  // portfolio populate.
+  const portfolioQuoteCurrency = useAppSelector(
+    ({PORTFOLIO}) => PORTFOLIO.quoteCurrency,
+  );
   const rates = useAppSelector(({RATE}) => RATE.rates) as Rates;
   const keyMigrationFailure = useAppSelector(
     ({APP}) => APP.keyMigrationFailure,
@@ -171,7 +177,7 @@ const HomeRoot: React.FC<HomeScreenProps> = ({route, navigation}) => {
   // Exchange Rates
   const lastDayRates = useAppSelector(({RATE}) => RATE.lastDayRates) as Rates;
   const quoteCurrency = getQuoteCurrency({
-    portfolioQuoteCurrency: portfolio.quoteCurrency,
+    portfolioQuoteCurrency,
     defaultAltCurrencyIsoCode: defaultAltCurrency?.isoCode,
   }).toUpperCase();
   const exchangeRateHistoricalRequests = useMemo(

--- a/src/navigation/tabs/home/components/AssetsSection.tsx
+++ b/src/navigation/tabs/home/components/AssetsSection.tsx
@@ -87,7 +87,15 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
   const theme = useTheme();
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [gainLossMode, setGainLossMode] = useState<GainLossMode>('1D');
-  const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
+  // Narrowed from `useAppSelector(({PORTFOLIO}) => PORTFOLIO)`. The whole slice
+  // gets a new object identity on every populate-progress tick, which
+  // re-rendered this component ~1-2x/second for the duration of every
+  // portfolio populate.
+  // Only the boolean is read here, so select the primitive: this component then
+  // re-renders when populate starts/stops rather than on every progress tick.
+  const populateInProgress = useAppSelector(
+    ({PORTFOLIO}) => !!PORTFOLIO.populateStatus?.inProgress,
+  );
   const rates = useAppSelector(({RATE}) => RATE.rates);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
   const showPortfolioValue = useAppSelector(selectShowPortfolioValue);
@@ -239,7 +247,7 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
     portfolioChartsEnabled &&
     hasAnyVisibleWalletBalance &&
     !items.length &&
-    (!!visibleWallets.length || !!portfolio.populateStatus?.inProgress);
+    (!!visibleWallets.length || populateInProgress);
 
   if (shouldShowActivationPlaceholder) {
     return (
@@ -267,11 +275,7 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
     );
   }
 
-  if (
-    !portfolio.populateStatus?.inProgress &&
-    !hasAnyPortfolioData &&
-    !previewItems.length
-  ) {
+  if (!populateInProgress && !hasAnyPortfolioData && !previewItems.length) {
     return null;
   }
 
@@ -294,9 +298,7 @@ const AssetsSection: React.FC<AssetsSectionProps> = ({enabled = true}) => {
       <AssetsList
         items={items}
         isPnlLoading={isPnlLoading}
-        populateInProgress={
-          portfolioChartsEnabled && !!portfolio.populateStatus?.inProgress
-        }
+        populateInProgress={portfolioChartsEnabled && populateInProgress}
         isPopulateLoadingByKey={isPopulateLoadingByKey}
         presentationResetToken={presentationResetToken}
       />

--- a/src/navigation/tabs/home/components/Crypto.tsx
+++ b/src/navigation/tabs/home/components/Crypto.tsx
@@ -411,7 +411,13 @@ const Crypto = () => {
   const linkedCoinbase = useAppSelector(
     ({COINBASE}) => !!COINBASE.token[COINBASE_ENV],
   );
-  const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
+  // Narrowed from `useAppSelector(({PORTFOLIO}) => PORTFOLIO)`. The whole slice
+  // gets a new object identity on every populate-progress tick, which
+  // re-rendered this component ~1-2x/second for the duration of every
+  // portfolio populate.
+  const populateStatus = useAppSelector(
+    ({PORTFOLIO}) => PORTFOLIO.populateStatus,
+  );
   const homeCarouselLayoutType = useAppSelector(
     ({APP}) => APP.homeCarouselLayoutType,
   );
@@ -488,7 +494,7 @@ const Crypto = () => {
     ? portfolioPercentageDifferenceByKey
     : undefined;
   const portfolioPopulateStatus = portfolioChartsEnabled
-    ? portfolio?.populateStatus
+    ? populateStatus
     : undefined;
   const [cardsList, setCardsList] = useState(
     createHomeCardList({

--- a/src/navigation/tabs/home/screens/AllAssets.tsx
+++ b/src/navigation/tabs/home/screens/AllAssets.tsx
@@ -106,7 +106,16 @@ const AllAssets: React.FC<Props> = ({navigation, route}) => {
   const {t} = useTranslation();
   const theme = useTheme();
   const commonOptions = useStackScreenOptions(theme);
-  const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
+  // Narrowed from `useAppSelector(({PORTFOLIO}) => PORTFOLIO)`. The whole slice
+  // gets a new object identity on every populate-progress tick, which
+  // re-rendered this component ~1-2x/second for the duration of every
+  // portfolio populate.
+  const portfolioPopulateInProgress = useAppSelector(
+    ({PORTFOLIO}) => !!PORTFOLIO.populateStatus?.inProgress,
+  );
+  const portfolioQuoteCurrency = useAppSelector(
+    ({PORTFOLIO}) => PORTFOLIO.quoteCurrency,
+  );
   const rates = useAppSelector(({RATE}) => RATE.rates);
   const defaultAltCurrency = useAppSelector(({APP}) => APP.defaultAltCurrency);
   const showPortfolioValue = useAppSelector(selectShowPortfolioValue);
@@ -114,7 +123,7 @@ const AllAssets: React.FC<Props> = ({navigation, route}) => {
   const keys = useAppSelector(({WALLET}) => WALLET.keys) as Record<string, Key>;
   const portfolioChartsEnabled = showPortfolioValue === true;
   const populateInProgress =
-    portfolioChartsEnabled && !!portfolio.populateStatus?.inProgress;
+    portfolioChartsEnabled && portfolioPopulateInProgress;
   const {getAssetIconData, getSupportedOption} = useAssetIconResolver();
   const focusRefreshToken = useScreenFocusRefreshToken();
   const keyId = route.params?.keyId;
@@ -131,7 +140,7 @@ const AllAssets: React.FC<Props> = ({navigation, route}) => {
     return getVisibleWalletsFromKeys(keys, homeCarouselConfig);
   }, [homeCarouselConfig, keyId, keys]);
   const quoteCurrency = getQuoteCurrency({
-    portfolioQuoteCurrency: portfolio.quoteCurrency,
+    portfolioQuoteCurrency,
     defaultAltCurrencyIsoCode: defaultAltCurrency?.isoCode,
   }).toUpperCase();
   const legacyAssetRowsEnabled = !portfolioChartsEnabled;

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -499,7 +499,14 @@ const KeyOverview = () => {
   const {rates} = useAppSelector(({RATE}) => RATE);
   const {defaultAltCurrency, hideAllBalances} = useAppSelector(({APP}) => APP);
   const showPortfolioValue = useAppSelector(selectShowPortfolioValue);
-  const portfolio = useAppSelector(({PORTFOLIO}) => PORTFOLIO);
+  // Narrowed from the whole PORTFOLIO slice, which gets a new object identity on
+  // every populate-progress tick.
+  const portfolioQuoteCurrency = useAppSelector(
+    ({PORTFOLIO}) => PORTFOLIO.quoteCurrency,
+  );
+  const portfolioPopulateStatus = useAppSelector(
+    ({PORTFOLIO}) => PORTFOLIO.populateStatus,
+  );
   const linkedCoinbase = useAppSelector(
     ({COINBASE}) => !!COINBASE.token[COINBASE_ENV],
   );
@@ -531,7 +538,7 @@ const KeyOverview = () => {
     ({APP}) => APP.selectedChainFilterOption,
   );
   const quoteCurrency = getQuoteCurrency({
-    portfolioQuoteCurrency: portfolio.quoteCurrency,
+    portfolioQuoteCurrency,
     defaultAltCurrencyIsoCode: defaultAltCurrency?.isoCode,
   });
 
@@ -742,7 +749,7 @@ const KeyOverview = () => {
   }, [allocationWalletRows, defaultAltCurrency.isoCode]);
 
   const isKeyPopulateLoading = isPopulateLoadingForWallets({
-    populateStatus: portfolio.populateStatus,
+    populateStatus: portfolioPopulateStatus,
     wallets: visibleKeyWallets,
   });
 

--- a/src/store/portfolio/portfolio.reducer.spec.ts
+++ b/src/store/portfolio/portfolio.reducer.spec.ts
@@ -12,6 +12,7 @@ import {
   setQuarantinesByWalletIdUpdates,
   setSnapshotBalanceMismatchesByWalletIdUpdates,
   startPopulatePortfolio,
+  updatePopulateProgress,
 } from './portfolio.actions';
 import {selectCanRenderPortfolioBalanceCharts} from './portfolio.selectors';
 
@@ -97,7 +98,7 @@ describe('portfolioReducer', () => {
         finishedAt: 200,
         lastFullPopulateCompletedAt: 200,
         quoteCurrency: 'USD',
-        reason: 'completed',
+        reason: 'done',
       }),
     );
 
@@ -113,7 +114,7 @@ describe('portfolioReducer', () => {
       finishPopulatePortfolio({
         finishedAt: 200,
         quoteCurrency: 'USD',
-        reason: 'completed',
+        reason: 'done',
       }),
     );
 
@@ -354,5 +355,110 @@ describe('portfolioReducer', () => {
     expect(
       portfolioReducer(state, markPopulateResumeSettled({settledAt: 300})),
     ).toBe(state);
+  });
+
+  // UPDATE_POPULATE_PROGRESS is dispatched from a 200ms poll loop, so the
+  // identity of the returned slice decides whether every whole-slice subscriber
+  // re-renders 5x/second. These guard the bailout.
+  describe('UPDATE_POPULATE_PROGRESS', () => {
+    it('returns the SAME state object when nothing changed', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({
+          currentWalletId: state.populateStatus.currentWalletId,
+          walletsTotal: state.populateStatus.walletsTotal,
+          walletsCompleted: state.populateStatus.walletsCompleted,
+          txRequestsMade: state.populateStatus.txRequestsMade,
+          txsProcessed: state.populateStatus.txsProcessed,
+        }),
+      );
+      expect(next).toBe(state);
+    });
+
+    it('returns the SAME state when walletStatusByIdUpdates repeats current values', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({
+          walletStatusByIdUpdates: {'wallet-1': 'in_progress'},
+        }),
+      );
+      expect(next).toBe(state);
+    });
+
+    it('propagates a changed progress counter', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({txsProcessed: 42}),
+      );
+      expect(next).not.toBe(state);
+      expect(next.populateStatus.txsProcessed).toBe(42);
+      // untouched fields are preserved
+      expect(next.populateStatus.currentWalletId).toBe(
+        state.populateStatus.currentWalletId,
+      );
+    });
+
+    it('propagates a changed walletsCompleted', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({walletsCompleted: 1}),
+      );
+      expect(next).not.toBe(state);
+      expect(next.populateStatus.walletsCompleted).toBe(1);
+    });
+
+    it('propagates a genuinely changed walletStatusById value', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({
+          walletStatusByIdUpdates: {'wallet-1': 'done'},
+        }),
+      );
+      expect(next).not.toBe(state);
+      expect(next.populateStatus.walletStatusById?.['wallet-1']).toBe('done');
+    });
+
+    it('propagates a new wallet id in walletStatusById', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({
+          walletStatusByIdUpdates: {'wallet-2': 'in_progress'},
+        }),
+      );
+      expect(next).not.toBe(state);
+      expect(next.populateStatus.walletStatusById).toEqual({
+        'wallet-1': 'in_progress',
+        'wallet-2': 'in_progress',
+      });
+    });
+
+    it('propagates appended errors', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({
+          errorsToAdd: [{walletId: 'wallet-1', message: 'boom'}],
+        }),
+      );
+      expect(next).not.toBe(state);
+      expect(next.populateStatus.errors).toEqual([
+        {walletId: 'wallet-1', message: 'boom'},
+      ]);
+    });
+
+    it('does not treat an empty errorsToAdd array as a change', () => {
+      const state = makeState();
+      const next = portfolioReducer(
+        state,
+        updatePopulateProgress({errorsToAdd: []}),
+      );
+      expect(next).toBe(state);
+    });
   });
 });

--- a/src/store/portfolio/portfolio.reducer.ts
+++ b/src/store/portfolio/portfolio.reducer.ts
@@ -143,27 +143,55 @@ export const portfolioReducer = (
         ? state.populateStatus.errors.concat(action.payload.errorsToAdd)
         : state.populateStatus.errors;
 
-      const nextWalletStatusById = action.payload.walletStatusByIdUpdates
+      // Only allocate a new map when an incoming status actually differs, so an
+      // unchanged tick can bail out below.
+      const statusUpdates = action.payload.walletStatusByIdUpdates;
+      const currentStatusById = state.populateStatus.walletStatusById;
+      const statusChanged =
+        !!statusUpdates &&
+        Object.keys(statusUpdates).some(
+          walletId =>
+            (currentStatusById || {})[walletId] !== statusUpdates[walletId],
+        );
+      const nextWalletStatusById = statusChanged
         ? {
-            ...(state.populateStatus.walletStatusById || {}),
-            ...action.payload.walletStatusByIdUpdates,
+            ...(currentStatusById || {}),
+            ...statusUpdates,
           }
-        : state.populateStatus.walletStatusById;
+        : currentStatusById;
       const nextProgressValue = <K extends keyof typeof state.populateStatus>(
         key: K,
       ) => pickDefinedUpdate(action.payload, state.populateStatus, key);
+
+      const nextPopulateStatus = {
+        ...state.populateStatus,
+        currentWalletId: nextProgressValue('currentWalletId'),
+        walletsTotal: nextProgressValue('walletsTotal'),
+        walletsCompleted: nextProgressValue('walletsCompleted'),
+        txRequestsMade: nextProgressValue('txRequestsMade'),
+        txsProcessed: nextProgressValue('txsProcessed'),
+        errors: nextErrors,
+        walletStatusById: nextWalletStatusById,
+      };
+
+      // This action is dispatched from a 200ms poll loop. Without a bailout it
+      // returned a brand-new slice object on every tick even when every field
+      // was identical, re-rendering every whole-slice PORTFOLIO subscriber
+      // (HomeRoot, Crypto, AssetsSection, AllAssets, KeyOverview,
+      // usePortfolioAssetRows) 5x/second and driving a persist flush each time.
+      const populateStatusUnchanged = (
+        Object.keys(nextPopulateStatus) as Array<
+          keyof typeof nextPopulateStatus
+        >
+      ).every(key => nextPopulateStatus[key] === state.populateStatus[key]);
+
+      if (populateStatusUnchanged) {
+        return state;
+      }
+
       return {
         ...state,
-        populateStatus: {
-          ...state.populateStatus,
-          currentWalletId: nextProgressValue('currentWalletId'),
-          walletsTotal: nextProgressValue('walletsTotal'),
-          walletsCompleted: nextProgressValue('walletsCompleted'),
-          txRequestsMade: nextProgressValue('txRequestsMade'),
-          txsProcessed: nextProgressValue('txsProcessed'),
-          errors: nextErrors,
-          walletStatusById: nextWalletStatusById,
-        },
+        populateStatus: nextPopulateStatus,
       };
     }
 


### PR DESCRIPTION
UPDATE_POPULATE_PROGRESS is dispatched from a 200ms poll and returned a brand-new slice object on every tick even when every field was identical, re-rendering every component that subscribed to the whole PORTFOLIO slice. The reducer now bails out when nothing changed, and the five whole-slice subscribers select only the fields they read - three of them just a boolean, so they re-render when populate starts and stops rather than on every tick.