### PR TITLE
Performance: feat - token options memoization

### DIFF
--- a/src/components/list/ContactRow.tsx
+++ b/src/components/list/ContactRow.tsx
@@ -52,7 +52,7 @@ interface Props {
 const ContactRow = ({contact, onPress}: Props) => {
   const theme = useTheme();
   const underlayColor = theme.dark ? '#121212' : GhostWhite;
-  const {coin: _coin, name, email, address, chain, tokenAddress} = contact;
+  const {coin: _coin, name, email, address, chain} = contact;
   const coin = getCurrencyAbbreviation(_coin, chain);
   return (
     <ContactContainer underlayColor={underlayColor} onPress={onPress}>
@@ -64,7 +64,6 @@ const ContactRow = ({contact, onPress}: Props) => {
             size={45}
             chain={chain}
             address={address}
-            tokenAddress={tokenAddress}
           />
         </ContactImageContainer>
         <ContactColumn>

--- a/src/navigation/tabs/contacts/components/ContactIcon.tsx
+++ b/src/navigation/tabs/contacts/components/ContactIcon.tsx
@@ -1,16 +1,11 @@
-import React, {ReactElement} from 'react';
+import React from 'react';
 import styled from 'styled-components/native';
 
 import Avatar from '../../../../components/avatar/Avatar';
 
 import {CurrencyListIcons} from '../../../../constants/SupportedCurrencyOptions';
 import {CurrencyImage} from '../../../../components/currency-image/CurrencyImage';
-import {SUPPORTED_CURRENCIES} from '../../../../constants/currencies';
-import {useTokenOptionsByAddress} from '../../../../utils/hooks';
-import {
-  addTokenChainSuffix,
-  getBadgeImg,
-} from '../../../../utils/helper-methods';
+import {getBadgeImg} from '../../../../utils/helper-methods';
 import {IsVMChain, IsOtherChain} from '../../../../store/wallet/utils/currency';
 import Blockie from '../../../../components/blockie/Blockie';
 
@@ -20,14 +15,7 @@ interface ContactIconProps {
   coin?: string;
   chain?: string;
   badge?: JSX.Element;
-  tokenAddress?: string;
   address?: string;
-}
-
-interface BadgeProps {
-  img: string | ((props?: any) => ReactElement);
-  badgeImg: string | ((props?: any) => ReactElement);
-  size?: number;
 }
 
 const ContactIconContainer = styled.View`
@@ -44,31 +32,16 @@ const CoinBadgeContainer = styled.View<{size: number}>`
 const ContactIcon: React.FC<ContactIconProps> = ({
   coin,
   chain,
-  tokenAddress,
   size = 50,
   name,
   badge,
   address,
 }) => {
-  const tokenOptionsByAddress = useTokenOptionsByAddress();
-  const foundToken =
-    tokenAddress &&
-    chain &&
-    tokenOptionsByAddress[
-      // `addTokenChainSuffix` already lowercases non-SVM chains and must
-      // preserve case-sensitive SVM mint addresses.
-      addTokenChainSuffix(tokenAddress.trim(), chain)
-    ];
-
   const img =
     coin &&
     chain &&
     (!IsVMChain(chain) || IsOtherChain(chain)) &&
-    (CurrencyListIcons[coin]
-      ? CurrencyListIcons[coin]
-      : foundToken && foundToken?.logoURI
-      ? (foundToken?.logoURI as string)
-      : '');
+    (CurrencyListIcons[coin] ? CurrencyListIcons[coin] : '');
 
   const coinBadge = img ? (
     <CoinBadgeContainer size={size}>

--- a/src/navigation/tabs/contacts/components/ContactIcon.tsx
+++ b/src/navigation/tabs/contacts/components/ContactIcon.tsx
@@ -6,17 +6,13 @@ import Avatar from '../../../../components/avatar/Avatar';
 import {CurrencyListIcons} from '../../../../constants/SupportedCurrencyOptions';
 import {CurrencyImage} from '../../../../components/currency-image/CurrencyImage';
 import {SUPPORTED_CURRENCIES} from '../../../../constants/currencies';
-import {useAppSelector} from '../../../../utils/hooks';
-import {RootState} from '../../../../store';
-import {BitpaySupportedTokenOptsByAddress} from '../../../../constants/tokens';
-import {Token} from '../../../../store/wallet/wallet.models';
+import {useTokenOptionsByAddress} from '../../../../utils/hooks';
 import {
   addTokenChainSuffix,
   getBadgeImg,
 } from '../../../../utils/helper-methods';
 import {IsVMChain, IsOtherChain} from '../../../../store/wallet/utils/currency';
 import Blockie from '../../../../components/blockie/Blockie';
-import {useTokenContext} from '../../../../contexts';
 
 interface ContactIconProps {
   size?: number;
@@ -54,15 +50,7 @@ const ContactIcon: React.FC<ContactIconProps> = ({
   badge,
   address,
 }) => {
-  const {tokenOptionsByAddress: _tokenOptionsByAddress} = useTokenContext();
-
-  const tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ...tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  }) as {[key in string]: Token};
+  const tokenOptionsByAddress = useTokenOptionsByAddress();
   const foundToken =
     tokenAddress &&
     chain &&
@@ -116,4 +104,4 @@ const ContactIcon: React.FC<ContactIconProps> = ({
   );
 };
 
-export default ContactIcon;
+export default React.memo(ContactIcon);

--- a/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
+++ b/src/navigation/tabs/contacts/screens/ContactsDetails.tsx
@@ -315,7 +315,6 @@ const ContactsDetails = ({
             name={contact.name}
             chain={contact.chain}
             address={contact.address}
-            tokenAddress={contact.tokenAddress}
           />
         </ContactImageHeader>
         <Details>

--- a/src/navigation/wallet/components/AddressCard.tsx
+++ b/src/navigation/wallet/components/AddressCard.tsx
@@ -54,7 +54,6 @@ const AddressCard: React.FC<AddressCardComponentProps> = ({recipient}) => {
                 name={recipient.recipientName || recipient.recipientAddress}
                 coin={recipient.recipientCoin!}
                 chain={recipient.recipientChain || ''}
-                tokenAddress={recipient.recipientTokenAddress}
                 size={30}
               />
             ) : (

--- a/src/navigation/wallet/components/MultipleOutputsTx.tsx
+++ b/src/navigation/wallet/components/MultipleOutputsTx.tsx
@@ -18,7 +18,7 @@ import {
   White,
 } from '../../../styles/colors';
 import Clipboard from '@react-native-clipboard/clipboard';
-import {useAppDispatch} from '../../../utils/hooks';
+import {useAppDispatch, useTokenOptionsByAddress} from '../../../utils/hooks';
 import CopiedSvg from '../../../../assets/img/copied-success.svg';
 import {useTranslation} from 'react-i18next';
 import AddContactIcon from '../../../components/icons/add-contacts/AddContacts';
@@ -31,7 +31,6 @@ import {
   getCurrencyAbbreviation,
 } from '../../../utils/helper-methods';
 import {CurrencyImage} from '../../../components/currency-image/CurrencyImage';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
 import ContactIcon from '../../tabs/contacts/components/ContactIcon';
 import {
   DetailColumn,
@@ -39,10 +38,8 @@ import {
   DetailRow,
   SendToPillContainer,
 } from '../screens/send/confirm/Shared';
-import {RootState} from '../../../store';
 import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import {View} from 'react-native';
-import {useTokenContext} from '../../../contexts';
 
 const MisunderstoodOutputsText = styled(H7)`
   margin-bottom: 5px;
@@ -97,15 +94,7 @@ const MultipleOutputsTx = ({
   let {coin, network, chain} = tx;
   const contactList = useAppSelector(({CONTACT}) => CONTACT.list);
 
-  const {tokenOptionsByAddress: _tokenOptionsByAddress} = useTokenContext();
-
-  const tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ..._tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  });
+  const tokenOptionsByAddress = useTokenOptionsByAddress();
   const foundToken =
     tokenAddress &&
     tokenOptionsByAddress[

--- a/src/navigation/wallet/screens/AccountDetails.tsx
+++ b/src/navigation/wallet/screens/AccountDetails.tsx
@@ -13,7 +13,11 @@ import React, {
 import {RootState} from '../../../store';
 import {useTranslation} from 'react-i18next';
 import {WalletGroupParamList} from '../WalletGroup';
-import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
+import {
+  useAppDispatch,
+  useAppSelector,
+  useTokenOptionsByAddress,
+} from '../../../utils/hooks';
 import {
   Key,
   Wallet,
@@ -174,8 +178,7 @@ import {
   getBaseEVMAccountCreationCoinsAndTokens,
 } from '../../../constants/currencies';
 import {BWCErrorMessage} from '../../../constants/BWCError';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
-import {useOngoingProcess, useTokenContext} from '../../../contexts';
+import {useOngoingProcess} from '../../../contexts';
 import {logManager} from '../../../managers/LogManager';
 import {ExternalServicesScreens} from '../../services/ExternalServicesGroup';
 import {AllocationDonutLegendCard} from '../../tabs/home/components/AllocationSection';
@@ -398,7 +401,6 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  const {tokenOptionsByAddress} = useTokenContext();
   const theme = useTheme();
   const {width: windowWidth} = useWindowDimensions();
   const {defaultAltCurrency, hideAllBalances, showArchaxBanner} =
@@ -582,13 +584,7 @@ const AccountDetails: React.FC<AccountDetailsScreenProps> = ({route}) => {
     ({SHOP}) => SHOP.billPayAccounts[accountItem?.wallets[0]?.network],
   );
 
-  const _tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ...tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  });
+  const _tokenOptionsByAddress = useTokenOptionsByAddress();
 
   const startSyncWallets = async (mnemonic: string) => {
     if (key.isPrivKeyEncrypted) {

--- a/src/navigation/wallet/screens/AddCustomToken.tsx
+++ b/src/navigation/wallet/screens/AddCustomToken.tsx
@@ -53,7 +53,11 @@ import {
 import haptic from '../../../components/haptic-feedback/haptic';
 import Icons from '../components/WalletIcons';
 import {Network} from '../../../constants';
-import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
+import {
+  useAppDispatch,
+  useAppSelector,
+  useTokenOptionsByAddress,
+} from '../../../utils/hooks';
 import {WrongPasswordError} from '../components/ErrorMessages';
 import {
   getTokenContractInfo,
@@ -78,11 +82,9 @@ import {BWCErrorMessage} from '../../../constants/BWCError';
 import {SendToPillContainer} from './send/confirm/Shared';
 import {PillText} from '../components/SendToPill';
 import {ChainSelectionRow} from '../../../components/list/ChainSelectionRow';
-import {RootState} from '../../../store';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
 import {TouchableOpacity} from '@components/base/TouchableOpacity';
 import cloneDeep from 'lodash.clonedeep';
-import {useOngoingProcess, useTokenContext} from '../../../contexts';
+import {useOngoingProcess} from '../../../contexts';
 import {logManager} from '../../../managers/LogManager';
 import {TabsScreens} from '../../../navigation/tabs/TabsStack';
 import {isTSSKey} from '../../../store/wallet/effects/tss-send/tss-send';
@@ -193,16 +195,9 @@ const AddCustomToken = ({
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  const {tokenOptionsByAddress: _tokenOptionsByAddress} = useTokenContext();
   const {key: _key, selectedAccountAddress, selectedChain} = route.params;
 
-  const tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ..._tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  }) as {[key in string]: Token};
+  const tokenOptionsByAddress = useTokenOptionsByAddress();
   const {keys} = useAppSelector(({WALLET}) => WALLET);
   const key = keys[_key.id];
   const [isTestnet, setIsTestnet] = useState(false);

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components/native';
 import {BottomSheetFlashList} from '@gorhom/bottom-sheet';
 import {NavigationProp, RouteProp} from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
-import {useAppDispatch, useAppSelector, useLogger} from '../../../utils/hooks';
+import {
+  useAppDispatch,
+  useAppSelector,
+  useLogger,
+  useTokenOptionsByAddress,
+} from '../../../utils/hooks';
 import {
   BitpaySupportedCoins,
   BitpaySupportedEvmCoins,
@@ -59,7 +64,6 @@ import {
 } from '../../../store/wallet/effects/send/send';
 import {showBottomNotificationModal} from '../../../store/app/app.actions';
 import {Effect} from '../../../store';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
 import Button, {ButtonState} from '../../../components/button/Button';
 import {useTranslation} from 'react-i18next';
 import {
@@ -111,7 +115,7 @@ import {SolanaPayOpts} from './send/confirm/Confirm';
 import cloneDeep from 'lodash.clonedeep';
 import Icons from '../components/WalletIcons';
 import {AppActions} from '../../../store/app';
-import {useOngoingProcess, useTokenContext} from '../../../contexts';
+import {useOngoingProcess} from '../../../contexts';
 import {logManager} from '../../../managers/LogManager';
 
 const ModalHeader = styled.View`
@@ -593,16 +597,12 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
   const logger = useLogger();
   const dispatch = useAppDispatch();
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  const {tokenOptionsByAddress} = useTokenContext();
-  const {keys: _keys, customTokenOptionsByAddress} = useAppSelector(
-    ({WALLET}) => WALLET,
-  );
+  // Was `useAppSelector(({WALLET}) => WALLET)` — the whole slice, so this screen
+  // re-rendered on any wallet-related dispatch. Narrowed to the one field used.
+  const _keys = useAppSelector(({WALLET}) => WALLET.keys);
   const {rates} = useAppSelector(({RATE}) => RATE);
-  const allTokensByAddress = {
-    ...BitpaySupportedTokenOptsByAddress,
-    ...tokenOptionsByAddress,
-    ...customTokenOptionsByAddress,
-  };
+  // Shared memoized merge; previously rebuilt inline on every render.
+  const allTokensByAddress = useTokenOptionsByAddress();
   const [dataToDisplay, setDataToDisplay] = useState<
     GlobalSelectObj[] | KeyWalletsRowProps[]
   >([]);
@@ -652,20 +652,27 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
     mountComponents();
   }, []);
 
-  const NON_BITPAY_SUPPORTED_TOKENS = Array.from(
-    new Set(
-      Object.entries(allTokensByAddress)
-        .flatMap(([address, tokenData]) => {
-          const symbol = tokenData?.symbol?.toLowerCase();
-          const chain = getChainFromTokenByAddressKey(address);
-          const currency = getCurrencyAbbreviation(symbol, chain);
-          return !BitpaySupportedTokens[address] &&
-            !BitpaySupportedCoins[currency]
-            ? currency
-            : undefined;
-        })
-        .filter((currency): currency is string => currency !== undefined),
-    ),
+  // Walks the entire token registry (thousands of entries) with per-token string
+  // work. This used to run bare in the render body, so it re-ran on every search
+  // keystroke and every modal-visibility toggle on the app's most-used picker.
+  const NON_BITPAY_SUPPORTED_TOKENS = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          Object.entries(allTokensByAddress)
+            .flatMap(([address, tokenData]) => {
+              const symbol = tokenData?.symbol?.toLowerCase();
+              const chain = getChainFromTokenByAddressKey(address);
+              const currency = getCurrencyAbbreviation(symbol, chain);
+              return !BitpaySupportedTokens[address] &&
+                !BitpaySupportedCoins[currency]
+                ? currency
+                : undefined;
+            })
+            .filter((currency): currency is string => currency !== undefined),
+        ),
+      ),
+    [allTokensByAddress],
   );
 
   const filterCompleteWallets = (keys: Keys) => {
@@ -1697,7 +1704,9 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
                             | KeyWalletsRowProps
                           )[])
                     }
-                    keyExtractor={(_, index: number) => index.toString()}
+                    keyExtractor={(
+                      item: GlobalSelectObj | KeyWalletsRowProps,
+                    ) => ('id' in item ? item.id : item.key)}
                     renderItem={renderItem}
                     estimatedItemSize={90}
                     onEndReachedThreshold={0.3}
@@ -1743,7 +1752,7 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
                       ? selectedAssetsFromAccount
                       : (searchResults as AssetsByChainData[])
                   }
-                  keyExtractor={(_, index: number) => index.toString()}
+                  keyExtractor={(item: AssetsByChainData) => item.id}
                   renderItem={memoizedRenderAssetsItem}
                 />
               </FlashListCointainer>

--- a/src/navigation/wallet/screens/GlobalSelect.tsx
+++ b/src/navigation/wallet/screens/GlobalSelect.tsx
@@ -36,7 +36,7 @@ import {
   Row,
   ScreenGutter,
 } from '../../../components/styled/Containers';
-import {groupBy, unionBy, uniqueId, isEmpty} from 'lodash';
+import {groupBy, unionBy, isEmpty} from 'lodash';
 import {KeyWalletsRowProps} from '../../../components/list/KeyWalletsRow';
 import {
   Action,
@@ -371,7 +371,7 @@ const buildSelectableCurrenciesList = (
       );
 
       const coinEntry = coins[currencyAbbreviation] || {
-        id: uniqueId('coin_'),
+        id: `coin_${currencyAbbreviation}`,
         currencyName: name,
         currencyAbbreviation,
         chainsImg: {},
@@ -473,7 +473,7 @@ const buildSelectableWalletList = (
           ? 'matic'
           : currencyAbbreviation;
       const coinEntry = coins[key] || {
-        id: uniqueId('coin_'),
+        id: `coin_${key}`,
         currencyName,
         currencyAbbreviation,
         chainsImg: {},
@@ -597,11 +597,8 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
   const logger = useLogger();
   const dispatch = useAppDispatch();
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  // Was `useAppSelector(({WALLET}) => WALLET)` — the whole slice, so this screen
-  // re-rendered on any wallet-related dispatch. Narrowed to the one field used.
   const _keys = useAppSelector(({WALLET}) => WALLET.keys);
   const {rates} = useAppSelector(({RATE}) => RATE);
-  // Shared memoized merge; previously rebuilt inline on every render.
   const allTokensByAddress = useTokenOptionsByAddress();
   const [dataToDisplay, setDataToDisplay] = useState<
     GlobalSelectObj[] | KeyWalletsRowProps[]
@@ -652,9 +649,6 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
     mountComponents();
   }, []);
 
-  // Walks the entire token registry (thousands of entries) with per-token string
-  // work. This used to run bare in the render body, so it re-ran on every search
-  // keystroke and every modal-visibility toggle on the app's most-used picker.
   const NON_BITPAY_SUPPORTED_TOKENS = useMemo(
     () =>
       Array.from(
@@ -686,109 +680,126 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
   };
 
   // Filter keys with only incomplete wallets
-  const keys = filterCompleteWallets(_keys);
+  const keys = useMemo(() => filterCompleteWallets(_keys), [_keys]);
 
   // all wallets
-  let wallets = Object.values(keys).flatMap(key => key.wallets);
-  // Filter hidden wallets
-  wallets = wallets.filter(
-    wallet => !wallet.hideWallet && !wallet.hideWalletByAccount,
-  );
-
-  // only show wallets with funds
-  // only show selected account address wallets if selectedAccountAddress is provided
-  if (
-    [
-      'send',
-      'sell',
-      'swapFrom',
-      'coinbaseDeposit',
-      'contact',
-      'scanner',
-    ].includes(context)
-  ) {
-    wallets = wallets.filter(
-      wallet =>
-        wallet.balance.sat > 0 &&
-        (!selectedAccountAddress ||
-          wallet.receiveAddress === selectedAccountAddress),
+  const wallets = useMemo(() => {
+    let _wallets = Object.values(keys).flatMap(key => key.wallets);
+    // Filter hidden wallets
+    _wallets = _wallets.filter(
+      wallet => !wallet.hideWallet && !wallet.hideWalletByAccount,
     );
-  }
 
-  // only show selected account address wallets if selectedAccountAddress is provided
-  if (['receive'].includes(context) && selectedAccountAddress) {
-    wallets = wallets.filter(wallet =>
-      selectedAccountAddress
-        ? wallet.receiveAddress === selectedAccountAddress
-        : false,
-    );
-  }
-
-  if (
-    recipient &&
-    ['coinbaseDeposit', 'contact', 'scanner'].includes(context)
-  ) {
-    if (recipient.currency && recipient.chain) {
-      wallets = wallets.filter(
+    // only show wallets with funds
+    // only show selected account address wallets if selectedAccountAddress is provided
+    if (
+      [
+        'send',
+        'sell',
+        'swapFrom',
+        'coinbaseDeposit',
+        'contact',
+        'scanner',
+      ].includes(context)
+    ) {
+      _wallets = _wallets.filter(
         wallet =>
-          (wallet.currencyAbbreviation === recipient?.currency &&
-            wallet.chain === recipient?.chain) ||
-          (recipient?.opts?.showEVMWalletsAndTokens &&
-            BitpaySupportedEvmCoins[wallet.chain]) ||
-          (recipient?.opts?.showSVMWalletsAndTokens &&
-            BitpaySupportedSvmCoins[wallet.chain]),
+          wallet.balance.sat > 0 &&
+          (!selectedAccountAddress ||
+            wallet.receiveAddress === selectedAccountAddress),
       );
     }
-    if (recipient?.network) {
-      wallets = wallets.filter(wallet => wallet.network === recipient?.network);
+
+    // only show selected account address wallets if selectedAccountAddress is provided
+    if (['receive'].includes(context) && selectedAccountAddress) {
+      _wallets = _wallets.filter(wallet =>
+        selectedAccountAddress
+          ? wallet.receiveAddress === selectedAccountAddress
+          : false,
+      );
     }
-  }
 
-  if (livenetOnly) {
-    wallets = wallets.filter(wallet => wallet.network === 'livenet');
-  }
-
-  if (assetContext?.currencyAbbreviation && assetContext?.chain) {
-    const filterCurrencyAbbreviation =
-      assetContext.currencyAbbreviation.toLowerCase();
-    const filterChain = assetContext.chain.toLowerCase();
-    const filterNetwork = assetContext.network?.toLowerCase();
-    const filterTokenAddress = assetContext.tokenAddress?.toLowerCase();
-
-    wallets = wallets.filter(wallet => {
-      if (wallet.currencyAbbreviation !== filterCurrencyAbbreviation) {
-        return false;
+    if (
+      recipient &&
+      ['coinbaseDeposit', 'contact', 'scanner'].includes(context)
+    ) {
+      if (recipient.currency && recipient.chain) {
+        _wallets = _wallets.filter(
+          wallet =>
+            (wallet.currencyAbbreviation === recipient?.currency &&
+              wallet.chain === recipient?.chain) ||
+            (recipient?.opts?.showEVMWalletsAndTokens &&
+              BitpaySupportedEvmCoins[wallet.chain]) ||
+            (recipient?.opts?.showSVMWalletsAndTokens &&
+              BitpaySupportedSvmCoins[wallet.chain]),
+        );
       }
-      if (wallet.chain !== filterChain) {
-        return false;
+      if (recipient?.network) {
+        _wallets = _wallets.filter(
+          wallet => wallet.network === recipient?.network,
+        );
       }
-      if (filterNetwork && wallet.network !== filterNetwork) {
-        return false;
-      }
+    }
 
-      if (filterTokenAddress) {
-        const walletTokenAddress = wallet.tokenAddress?.toLowerCase();
-        return walletTokenAddress === filterTokenAddress;
-      }
+    if (livenetOnly) {
+      _wallets = _wallets.filter(wallet => wallet.network === 'livenet');
+    }
 
-      return true;
-    });
-  }
+    if (assetContext?.currencyAbbreviation && assetContext?.chain) {
+      const filterCurrencyAbbreviation =
+        assetContext.currencyAbbreviation.toLowerCase();
+      const filterChain = assetContext.chain.toLowerCase();
+      const filterNetwork = assetContext.network?.toLowerCase();
+      const filterTokenAddress = assetContext.tokenAddress?.toLowerCase();
 
-  if (context === 'coinbase' && useAsModal && customSupportedCurrencies) {
-    const supportedCurrencies = [
-      ...new Set(
-        customSupportedCurrencies.map(item =>
-          item.currencyAbbreviation.toLowerCase(),
+      _wallets = _wallets.filter(wallet => {
+        if (wallet.currencyAbbreviation !== filterCurrencyAbbreviation) {
+          return false;
+        }
+        if (wallet.chain !== filterChain) {
+          return false;
+        }
+        if (filterNetwork && wallet.network !== filterNetwork) {
+          return false;
+        }
+
+        if (filterTokenAddress) {
+          const walletTokenAddress = wallet.tokenAddress?.toLowerCase();
+          return walletTokenAddress === filterTokenAddress;
+        }
+
+        return true;
+      });
+    }
+
+    if (context === 'coinbase' && useAsModal && customSupportedCurrencies) {
+      const supportedCurrencies = [
+        ...new Set(
+          customSupportedCurrencies.map(item =>
+            item.currencyAbbreviation.toLowerCase(),
+          ),
         ),
-      ),
-    ];
-    wallets = wallets.filter(wallet =>
-      supportedCurrencies.includes(wallet.currencyAbbreviation),
-    );
-  }
+      ];
+      _wallets = _wallets.filter(wallet =>
+        supportedCurrencies.includes(wallet.currencyAbbreviation),
+      );
+    }
 
-  const currenciesSupportedList = useMemo(() => {
+    return _wallets;
+  }, [
+    keys,
+    context,
+    selectedAccountAddress,
+    recipient,
+    livenetOnly,
+    assetContext,
+    useAsModal,
+    customSupportedCurrencies,
+  ]);
+
+  const currenciesSupportedList = useMemo<
+    GlobalSelectObj[] | KeyWalletsRowProps[]
+  >(() => {
     const coins = customSupportedCurrencies
       ? customSupportedCurrencies
       : SUPPORTED_COINS;
@@ -872,27 +883,6 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
           };
         })
         .filter(item => item !== null) as KeyWalletsRowProps[];
-      setDataToDisplay(allCurrencyData);
-      const keyWalletsArray = allCurrencyData as KeyWalletsRowProps[];
-      if (
-        keyWalletsArray.length === 1 &&
-        keyWalletsArray[0]?.accounts?.length === 1 &&
-        IsVMChain(keyWalletsArray[0].accounts[0].chains[0])
-      ) {
-        // if only one account and is evm show assets directly
-        const selectedAccount = keyWalletsArray[0].accounts[0];
-        setSelectedEVMAccount({
-          keyId: selectedAccount.keyId,
-          chains: selectedAccount.chains,
-          accountName: selectedAccount.accountName,
-          accountNumber: selectedAccount.accountNumber,
-          receiveAddress: selectedAccount.receiveAddress,
-        });
-        setSelectedAssetsFromAccount(selectedAccount.assetsByChain!);
-        setSearchVal('');
-        setSearchResults([]);
-        setHideCloseButton(true);
-      }
       return allCurrencyData;
     } else if (!customToSelectCurrencies) {
       allCurrencyData = buildSelectableWalletList(
@@ -900,26 +890,74 @@ const GlobalSelect: React.FC<GlobalSelectScreenProps | GlobalSelectProps> = ({
         wallets,
         context,
       );
-      setDataToDisplay(Object.values(allCurrencyData));
-      return Object.values(allCurrencyData);
+      return Object.values(allCurrencyData) as GlobalSelectObj[];
     } else {
       return [];
     }
-  }, []);
+  }, [
+    wallets,
+    keys,
+    context,
+    rates,
+    defaultAltCurrency.isoCode,
+    dispatch,
+    customSupportedCurrencies,
+    customToSelectCurrencies,
+    NON_BITPAY_SUPPORTED_TOKENS,
+  ]);
 
-  const customCurrenciesSupportedList = useMemo(() => {
-    if (customToSelectCurrencies) {
-      const allCurrencyData = buildSelectableCurrenciesList(
+  const customCurrenciesSupportedList = useMemo<GlobalSelectObj[]>(() => {
+    if (!customToSelectCurrencies) {
+      return [];
+    }
+    return Object.values(
+      buildSelectableCurrenciesList(
         customToSelectCurrencies,
         selectedChainFilterOption,
         wallets,
-      );
-      setDataToDisplay(Object.values(allCurrencyData));
-      return Object.values(allCurrencyData);
-    } else {
-      return [];
+      ),
+    );
+  }, [customToSelectCurrencies, selectedChainFilterOption, wallets]);
+
+  useEffect(() => {
+    setDataToDisplay(
+      customToSelectCurrencies
+        ? customCurrenciesSupportedList
+        : currenciesSupportedList,
+    );
+  }, [
+    customToSelectCurrencies,
+    customCurrenciesSupportedList,
+    currenciesSupportedList,
+  ]);
+
+  const autoSelectedSingleAccountRef = useRef(false);
+  useEffect(() => {
+    if (autoSelectedSingleAccountRef.current || customToSelectCurrencies) {
+      return;
     }
-  }, [selectedChainFilterOption]);
+    const keyWalletsArray = currenciesSupportedList as KeyWalletsRowProps[];
+    if (
+      keyWalletsArray.length !== 1 ||
+      keyWalletsArray[0]?.accounts?.length !== 1 ||
+      !IsVMChain(keyWalletsArray[0].accounts[0].chains[0])
+    ) {
+      return;
+    }
+    autoSelectedSingleAccountRef.current = true;
+    const selectedAccount = keyWalletsArray[0].accounts[0];
+    setSelectedEVMAccount({
+      keyId: selectedAccount.keyId,
+      chains: selectedAccount.chains,
+      accountName: selectedAccount.accountName,
+      accountNumber: selectedAccount.accountNumber,
+      receiveAddress: selectedAccount.receiveAddress,
+    });
+    setSelectedAssetsFromAccount(selectedAccount.assetsByChain!);
+    setSearchVal('');
+    setSearchResults([]);
+    setHideCloseButton(true);
+  }, [currenciesSupportedList, customToSelectCurrencies]);
 
   const goToBuyCrypto = async () => {
     if (globalSelectOnDismiss) {

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -46,7 +46,6 @@ import {
   EmptyListContainer,
   ChevronContainer,
 } from '../../../components/styled/Containers';
-import {RootState} from '../../../store';
 import {
   showBottomNotificationModal,
   toggleHideAllBalances,
@@ -84,7 +83,12 @@ import {
 import OptionsSheet, {Option} from '../components/OptionsSheet';
 import Icons from '../components/WalletIcons';
 import {WalletGroupParamList} from '../WalletGroup';
-import {useAppDispatch, useAppSelector, useLogger} from '../../../utils/hooks';
+import {
+  useAppDispatch,
+  useAppSelector,
+  useLogger,
+  useTokenOptionsByAddress,
+} from '../../../utils/hooks';
 import SheetModal from '../../../components/modal/base/sheet/SheetModal';
 import {
   getDecryptPassword,
@@ -125,10 +129,9 @@ import {
   BitpaySupportedEvmCoins,
   getBaseEVMAccountCreationCoinsAndTokens,
 } from '../../../constants/currencies';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
 import {BWCErrorMessage} from '../../../constants/BWCError';
 import ArchaxFooter from '../../../components/archax/archax-footer';
-import {useOngoingProcess, useTokenContext} from '../../../contexts';
+import {useOngoingProcess} from '../../../contexts';
 import BalanceHistoryChart from '../../../components/charts/BalanceHistoryChart';
 import BalanceHeaderSupplement from '../../../components/charts/BalanceHeaderSupplement';
 import FullWidthBalanceChartContainer from '../../../components/charts/FullWidthBalanceChartContainer';
@@ -490,7 +493,6 @@ const KeyOverview = () => {
   const {width: windowWidth} = useWindowDimensions();
   const showArchaxBanner = useAppSelector(({APP}) => APP.showArchaxBanner);
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  const {tokenOptionsByAddress} = useTokenContext();
   const [showKeyOptions, setShowKeyOptions] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const {keys}: {keys: {[key: string]: Key}} = useAppSelector(
@@ -809,13 +811,7 @@ const KeyOverview = () => {
     [maybeActivateAllocationGainLoss],
   );
 
-  const _tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ...tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  });
+  const _tokenOptionsByAddress = useTokenOptionsByAddress();
 
   const startSyncWallets = async (mnemonic: string) => {
     if (key.isPrivKeyEncrypted) {

--- a/src/navigation/wallet/screens/KeyOverview.tsx
+++ b/src/navigation/wallet/screens/KeyOverview.tsx
@@ -495,9 +495,7 @@ const KeyOverview = () => {
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
   const [showKeyOptions, setShowKeyOptions] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const {keys}: {keys: {[key: string]: Key}} = useAppSelector(
-    ({WALLET}) => WALLET,
-  );
+  const keys: {[key: string]: Key} = useAppSelector(({WALLET}) => WALLET.keys);
   const {rates} = useAppSelector(({RATE}) => RATE);
   const {defaultAltCurrency, hideAllBalances} = useAppSelector(({APP}) => APP);
   const showPortfolioValue = useAppSelector(selectShowPortfolioValue);

--- a/src/navigation/wallet/screens/KeySettings.tsx
+++ b/src/navigation/wallet/screens/KeySettings.tsx
@@ -38,7 +38,11 @@ import {openUrlWithInAppBrowser} from '../../../store/app/app.effects';
 import InfoIcon from '../../../components/icons/info/Info';
 import RequestEncryptPasswordToggle from '../components/RequestEncryptPasswordToggle';
 import {URL} from '../../../constants';
-import {useAppDispatch, useAppSelector} from '../../../utils/hooks';
+import {
+  useAppDispatch,
+  useAppSelector,
+  useTokenOptionsByAddress,
+} from '../../../utils/hooks';
 import {AppActions} from '../../../store/app';
 import {
   checkEncryptedKeysForEddsaMigration,
@@ -64,15 +68,13 @@ import {
 import merge from 'lodash.merge';
 import {syncWallets} from '../../../store/wallet/wallet.actions';
 import {BWCErrorMessage} from '../../../constants/BWCError';
-import {RootState} from '../../../store';
-import {BitpaySupportedTokenOptsByAddress} from '../../../constants/tokens';
 import {useTranslation} from 'react-i18next';
 import SearchComponent from '../../../components/chain-search/ChainSearch';
 import {AccountRowProps} from '../../../components/list/AccountListRow';
 import AccountSettingsRow from '../../../components/list/AccountSettingsRow';
 import {useTheme} from 'styled-components/native';
 import {IsSVMChain, IsVMChain} from '../../../store/wallet/utils/currency';
-import {useOngoingProcess, useTokenContext} from '../../../contexts';
+import {useOngoingProcess} from '../../../contexts';
 import {isTSSKey} from '../../../store/wallet/effects/tss-send/tss-send';
 import {logManager} from '../../../managers/LogManager';
 
@@ -134,7 +136,6 @@ const KeySettings = () => {
   const {defaultAltCurrency} = useAppSelector(({APP}) => APP);
   const {rates} = useAppSelector(({RATE}) => RATE);
   const {showOngoingProcess, hideOngoingProcess} = useOngoingProcess();
-  const {tokenOptionsByAddress} = useTokenContext();
   const [searchVal, setSearchVal] = useState('');
   const [searchResults, setSearchResults] = useState([] as AccountRowProps[]);
   const selectedChainFilterOption = useAppSelector(
@@ -193,13 +194,7 @@ const KeySettings = () => {
     };
   };
 
-  const _tokenOptionsByAddress = useAppSelector(({WALLET}: RootState) => {
-    return {
-      ...BitpaySupportedTokenOptsByAddress,
-      ...tokenOptionsByAddress,
-      ...WALLET.customTokenOptionsByAddress,
-    };
-  });
+  const _tokenOptionsByAddress = useTokenOptionsByAddress();
 
   const startSyncWallets = async (mnemonic: string) => {
     if (_key.isPrivKeyEncrypted) {

--- a/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
+++ b/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
@@ -267,6 +267,11 @@ jest.mock('../../../utils/hooks', () => ({
     debug: jest.fn(),
     error: jest.fn(),
   }),
+  // Screens now read the merged token map through this shared memoized hook
+  // instead of spreading the whole registry inside useAppSelector on every
+  // dispatch. These screens only need it to resolve token metadata, which these
+  // chart-visibility assertions do not exercise.
+  useTokenOptionsByAddress: () => ({}),
 }));
 
 jest.mock('../../../contexts', () => ({

--- a/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
+++ b/src/navigation/wallet/screens/portfolioChartVisibility.spec.tsx
@@ -267,10 +267,6 @@ jest.mock('../../../utils/hooks', () => ({
     debug: jest.fn(),
     error: jest.fn(),
   }),
-  // Screens now read the merged token map through this shared memoized hook
-  // instead of spreading the whole registry inside useAppSelector on every
-  // dispatch. These screens only need it to resolve token metadata, which these
-  // chart-visibility assertions do not exercise.
   useTokenOptionsByAddress: () => ({}),
 }));
 

--- a/src/store/wallet/utils/wallet.ts
+++ b/src/store/wallet/utils/wallet.ts
@@ -56,7 +56,7 @@ import {
 } from '../../../components/list/KeyWalletsRow';
 import {AppDispatch} from '../../../utils/hooks';
 import {toStringOrEmpty} from '../../../utils/text';
-import _, {find, isEqual} from 'lodash';
+import {find, isEqual} from 'lodash';
 import {Invoice} from '../../../store/shop/shop.models';
 import {AccountRowProps} from '../../../components/list/AccountListRow';
 import {
@@ -1326,7 +1326,7 @@ export const buildAccountList = (
 
     if (!existingAccount) {
       accountMap[accountKey] = {
-        id: _.uniqueId('account_'),
+        id: `account_${keyId}_${accountKey}`,
         keyId,
         chains: [chain],
         accountName: isTokensSupportedChain
@@ -1473,7 +1473,7 @@ const buildUIFormattedAssetsList = (
       chains: [wallet.chain], // useful only for chain selector
       data: [
         {
-          id: _.uniqueId('chain_'),
+          id: `chain_${wallet.chain}_${wallet.receiveAddress ?? ''}`,
           chain: wallet.chain,
           chainImg: wallet.badgeImg || wallet.img,
           chainName: wallet.chainName,
@@ -1587,7 +1587,7 @@ const buildUIFormattedAssets = (
     });
   } else {
     const newChainData: AssetsByChainData = {
-      id: _.uniqueId('chain_'),
+      id: `chain_${wallet.chain}_${wallet.receiveAddress ?? ''}`,
       chain: wallet.chain,
       chainImg: wallet.badgeImg || wallet.img,
       chainName: wallet.chainName,

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useDeeplinks';
 export * from './useLogger';
 export * from './useMount';
 export * from './useSensitiveRefClear';
+export * from './useTokenOptionsByAddress';

--- a/src/utils/hooks/useTokenOptionsByAddress.ts
+++ b/src/utils/hooks/useTokenOptionsByAddress.ts
@@ -1,0 +1,45 @@
+import {useMemo} from 'react';
+import {useAppSelector} from './useAppSelector';
+import {useTokenContext} from '../../contexts/TokenContext';
+import {BitpaySupportedTokenOptsByAddress} from '../../constants/tokens';
+import {Token} from '../../store/wallet/wallet.models';
+
+/**
+ * The merged token map every token-resolving screen needs: static BitPay
+ * tokens, the 1inch lists held in TokenContext, and the user's custom tokens
+ * from the store.
+ *
+ * Previously each call site built this inline *inside* `useAppSelector`:
+ *
+ *   useAppSelector(({WALLET}) => ({
+ *     ...BitpaySupportedTokenOptsByAddress,
+ *     ...tokenOptionsByAddress,
+ *     ...WALLET.customTokenOptionsByAddress,
+ *   }))
+ *
+ * `useSelector` runs on every store dispatch, so that spread a multi-thousand
+ * key object on every dispatch, for every mounted instance — and because the
+ * result was always a fresh reference the equality check could never bail, so
+ * the component re-rendered on every dispatch too. On 1,500-1,900 line screens
+ * (KeyOverview, AccountDetails) and per-row components (ContactIcon,
+ * MultipleOutputsTx) that dominated render cost during balance/portfolio sync.
+ *
+ * Selecting only the custom-token map (a stable reference that changes just when
+ * the user adds a token) and merging in `useMemo` keeps the identity stable
+ * until the inputs genuinely change.
+ */
+export const useTokenOptionsByAddress = (): {[key in string]: Token} => {
+  const {tokenOptionsByAddress} = useTokenContext();
+  const customTokenOptionsByAddress = useAppSelector(
+    ({WALLET}) => WALLET.customTokenOptionsByAddress,
+  );
+
+  return useMemo(
+    () => ({
+      ...BitpaySupportedTokenOptsByAddress,
+      ...tokenOptionsByAddress,
+      ...customTokenOptionsByAddress,
+    }),
+    [tokenOptionsByAddress, customTokenOptionsByAddress],
+  );
+};

--- a/src/utils/hooks/useTokenOptionsByAddress.ts
+++ b/src/utils/hooks/useTokenOptionsByAddress.ts
@@ -4,30 +4,6 @@ import {useTokenContext} from '../../contexts/TokenContext';
 import {BitpaySupportedTokenOptsByAddress} from '../../constants/tokens';
 import {Token} from '../../store/wallet/wallet.models';
 
-/**
- * The merged token map every token-resolving screen needs: static BitPay
- * tokens, the 1inch lists held in TokenContext, and the user's custom tokens
- * from the store.
- *
- * Previously each call site built this inline *inside* `useAppSelector`:
- *
- *   useAppSelector(({WALLET}) => ({
- *     ...BitpaySupportedTokenOptsByAddress,
- *     ...tokenOptionsByAddress,
- *     ...WALLET.customTokenOptionsByAddress,
- *   }))
- *
- * `useSelector` runs on every store dispatch, so that spread a multi-thousand
- * key object on every dispatch, for every mounted instance — and because the
- * result was always a fresh reference the equality check could never bail, so
- * the component re-rendered on every dispatch too. On 1,500-1,900 line screens
- * (KeyOverview, AccountDetails) and per-row components (ContactIcon,
- * MultipleOutputsTx) that dominated render cost during balance/portfolio sync.
- *
- * Selecting only the custom-token map (a stable reference that changes just when
- * the user adds a token) and merging in `useMemo` keeps the identity stable
- * until the inputs genuinely change.
- */
 export const useTokenOptionsByAddress = (): {[key in string]: Token} => {
   const {tokenOptionsByAddress} = useTokenContext();
   const customTokenOptionsByAddress = useAppSelector(


### PR DESCRIPTION
### Issue

  Seven screens each built the merged token map inline **inside** `useAppSelector`:

  ```js
  useAppSelector(({WALLET}) => ({
    ...BitpaySupportedTokenOptsByAddress,
    ...tokenOptionsByAddress,
    ...WALLET.customTokenOptionsByAddress,
  }))
  ```

  `useSelector` runs on every store dispatch, so this spread a multi-thousand-key object on every dispatch, for every mounted instance. And because the result was always a fresh reference, the equality check could never bail — so the component
  re-rendered on every dispatch too. Worst on the 1,500–1,900 line KeyOverview/AccountDetails screens and on per-row components (`ContactIcon`, `MultipleOutputsTx`).

  A shared `useTokenOptionsByAddress` hook now selects only the custom-token map (a stable reference) and merges in `useMemo`, so the identity stays stable until the inputs actually change.

  **Also fixes a bug:** `ContactIcon` spread the const it was declaring instead of the context value, so the 1inch token map was silently dropped there. eslint had been flagging the unused binding.

  **Second commit** applies the hook to `GlobalSelect` and cleans up its render path: it walked the entire token registry and ran ~8 sequential wallet filter passes bare in the render body, so all of it re-ran on every search keystroke and every
  modal toggle. That's now memoized, it selects one WALLET field instead of the whole slice, and its two FlashLists key on stable ids instead of array indices (index keys over filtered, changing data break recycling and can reuse a row for the
  wrong wallet).

  ### How to test

  1. Token icons and names resolve correctly on KeyOverview, AccountDetails, KeySettings, Add Custom Token, transaction detail with multiple outputs, and the contacts list. Some icons may now appear where a generic fallback showed before —
  that's the ContactIcon fix, not a regression.
  2. Open the wallet/coin picker: type quickly in search, toggle chain filters, scroll. Rows must show the **correct** wallet — a wrong-row or duplicated row would indicate a list-key problem.
  3. Add a custom token and confirm it still appears everywhere it should.
  4. Send and swap flows still resolve token metadata correctly.