### PR TITLE
KYC: Fix - Mark the verification attempt as started when the SDK opens

### DIFF
--- a/src/api/sumsub/index.spec.ts
+++ b/src/api/sumsub/index.spec.ts
@@ -1,11 +1,12 @@
 /**
- * Tests for src/api/sumsub/index.ts (SumSubApi.fetchAccessToken)
+ * Tests for src/api/sumsub/index.ts (the signed /api/v2 RPC wrappers)
  */
 
 import {
   SumSubApi,
   GET_KYC_ACCESS_TOKEN_METHOD,
   GET_KYC_STATUS_METHOD,
+  START_KYC_ATTEMPT_METHOD,
 } from './index';
 import BitPayIdApi from '../bitpay';
 
@@ -81,5 +82,28 @@ describe('SumSubApi.fetchKycStatus', () => {
       {},
     );
     expect(result).toEqual(payload);
+  });
+});
+
+describe('SumSubApi.startKycAttempt', () => {
+  it('marks the attempt as started via the signed /api/v2 RPC', async () => {
+    mockApiCall.mockResolvedValue({success: true});
+
+    await expect(SumSubApi.startKycAttempt(API_TOKEN)).resolves.toBeUndefined();
+
+    expect(mockApiCall).toHaveBeenCalledTimes(1);
+    expect(mockApiCall).toHaveBeenCalledWith(
+      API_TOKEN,
+      START_KYC_ATTEMPT_METHOD,
+      {platform: 'mobile'},
+    );
+  });
+
+  it('does not swallow errors from the RPC', async () => {
+    mockApiCall.mockRejectedValue(new Error('attempt endpoint down'));
+
+    await expect(SumSubApi.startKycAttempt(API_TOKEN)).rejects.toThrow(
+      'attempt endpoint down',
+    );
   });
 });

--- a/src/api/sumsub/index.ts
+++ b/src/api/sumsub/index.ts
@@ -3,6 +3,7 @@ import BitPayIdApi from '../bitpay';
 // Signed /api/v2 RPC methods (map to BitPayUser.* server-side, same channel DI uses).
 export const GET_KYC_ACCESS_TOKEN_METHOD = 'getKycAccessToken';
 export const GET_KYC_STATUS_METHOD = 'getKycStatus';
+export const START_KYC_ATTEMPT_METHOD = 'startKycAttempt';
 
 export interface KycActiveAttempt {
   targetTier?: number;
@@ -51,7 +52,15 @@ const fetchKycStatus = async (apiToken: string): Promise<KycStatusResponse> => {
   return result;
 };
 
+const startKycAttempt = async (apiToken: string): Promise<void> => {
+  const result = await BitPayIdApi.apiCall(apiToken, START_KYC_ATTEMPT_METHOD, {
+    platform: 'mobile',
+  });
+  console.log('[SumSub] startKycAttempt →', JSON.stringify(result));
+};
+
 export const SumSubApi = {
   fetchAccessToken,
   fetchKycStatus,
+  startKycAttempt,
 };

--- a/src/navigation/bitpay-id/screens/ProfileSettings.tsx
+++ b/src/navigation/bitpay-id/screens/ProfileSettings.tsx
@@ -111,6 +111,12 @@ function getStatusPillConfig(
       navigable: true,
     };
   }
+  if (kycUiState === 'inProgress') {
+    return {
+      label: t('Continue Verification'),
+      navigable: true,
+    };
+  }
   if (kycUiState === 'actionRequired') {
     return {
       label: t('Action Required'),

--- a/src/navigation/bitpay-id/screens/VerifyIdentity.tsx
+++ b/src/navigation/bitpay-id/screens/VerifyIdentity.tsx
@@ -82,6 +82,13 @@ const STATE_CONFIG: Record<
   Exclude<KycUiState, 'notStarted'>,
   KycStateConfig
 > = {
+  inProgress: {
+    icon: IconKycStatusPending,
+    iconBg: Warning25,
+    titleKey: 'Finish verifying your identity',
+    bodyKey:
+      'You have a verification in progress. Click the button below to pick up where you left off.',
+  },
   actionRequired: {
     icon: IconKycStatusDenied,
     iconBg: Caution25,
@@ -165,7 +172,9 @@ export const VerifyIdentityScreen: React.FC = () => {
       </Content>
 
       <ButtonContainer>
-        {state === 'actionRequired' ? (
+        {state === 'inProgress' ? (
+          <Button onPress={handleResume}>{t('Continue Verification')}</Button>
+        ) : state === 'actionRequired' ? (
           <Button onPress={handleResume}>{t('Resume Application')}</Button>
         ) : (
           <Button onPress={goHome}>{t('Go Home')}</Button>

--- a/src/navigation/tabs/home/components/GetVerifiedModal.tsx
+++ b/src/navigation/tabs/home/components/GetVerifiedModal.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {Pressable, TouchableOpacity} from 'react-native';
 import styled from 'styled-components/native';
 import {useTranslation} from 'react-i18next';
@@ -14,6 +14,7 @@ import {
 } from '../../../../styles/colors';
 import {useAppDispatch, useAppSelector} from '../../../../utils/hooks';
 import {setShowKycGetVerifiedModal} from '../../../../store/app/app.actions';
+import {SumSubSelectors} from '../../../../store/sumsub';
 import {BitpayIdScreens} from '../../../bitpay-id/BitpayIdGroup';
 import {navigationRef} from '../../../../Root';
 import IconKycGetVerified from '../../../../../assets/img/kyc_get_verified.svg';
@@ -72,12 +73,19 @@ const GetVerifiedModal: React.FC = () => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const isVisible = useAppSelector(({APP}) => APP.showKycGetVerifiedModal);
+  const canStartKyc = useAppSelector(SumSubSelectors.selectCanStartKyc);
 
   // Navigate after the sheet dismisses, via navigationRef (VerifyIdentity is a
   // root-navigator screen).
   const pendingVerifyRef = useRef(false);
 
   const dismiss = () => dispatch(setShowKycGetVerifiedModal(false));
+
+  useEffect(() => {
+    if (isVisible && !canStartKyc) {
+      dispatch(setShowKycGetVerifiedModal(false));
+    }
+  }, [dispatch, isVisible, canStartKyc]);
 
   const onVerify = () => {
     pendingVerifyRef.current = true;

--- a/src/navigation/tabs/home/components/KycBannerGate.spec.tsx
+++ b/src/navigation/tabs/home/components/KycBannerGate.spec.tsx
@@ -3,12 +3,21 @@ import {Provider} from 'react-redux';
 import {cleanup, fireEvent, render} from '@test/render';
 import configureTestStore from '@test/store';
 import {Network} from '../../../../constants';
+import {BitpayIdScreens} from '../../../bitpay-id/BitpayIdGroup';
 import KycBannerGate from './KycBannerGate';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({navigate: mockNavigate}),
+}));
 
 const EID = 'user-eid-123';
 const CONGRATS = 'Congratulations! Your identity was verified.';
 const IN_REVIEW = 'Identity verification in review.';
 const ACTION_REQUIRED = 'Action required on your application.';
+const IN_PROGRESS = 'Continue your identity verification.';
 
 const buildStore = ({
   status,
@@ -39,6 +48,8 @@ const renderWithStore = (store: ReturnType<typeof buildStore>) =>
 
 describe('KycBannerGate', () => {
   afterEach(cleanup);
+
+  beforeEach(() => mockNavigate.mockClear());
 
   it('does not congratulate a user approved in a previous session', () => {
     const {queryByText} = renderWithStore(
@@ -90,6 +101,20 @@ describe('KycBannerGate', () => {
 
     fireEvent.press(getByLabelText('Dismiss KYC notification'));
     expect(queryByText(CONGRATS)).toBeNull();
+  });
+
+  it('offers the resume entry point while verification is in progress', () => {
+    const {getByText, queryByLabelText} = renderWithStore(
+      buildStore({status: 'inProgress', ack: {eid: EID, state: 'success'}}),
+    );
+
+    const banner = getByText(IN_PROGRESS);
+    expect(banner).toBeTruthy();
+    // Standing state: no dismiss affordance, and a stale ack must not hide it.
+    expect(queryByLabelText('Dismiss KYC notification')).toBeNull();
+
+    fireEvent.press(banner);
+    expect(mockNavigate).toHaveBeenCalledWith(BitpayIdScreens.VERIFY_IDENTITY);
   });
 
   it('shows the non-dismissible banners regardless of any acknowledgement', () => {

--- a/src/navigation/tabs/home/components/KycBannerGate.tsx
+++ b/src/navigation/tabs/home/components/KycBannerGate.tsx
@@ -84,6 +84,14 @@ function getHomeBannerConfig(
       icon: IconPersonIdentifyVerification,
     };
   }
+  if (kycUiState === 'inProgress') {
+    return {
+      message: t('Continue your identity verification.'),
+      showDot: true,
+      dismissible: false,
+      icon: IconPersonIdentifyVerification,
+    };
+  }
   if (kycUiState === 'actionRequired') {
     return {
       message: t('Action required on your application.'),

--- a/src/store/sumsub/sumsub.effects.spec.ts
+++ b/src/store/sumsub/sumsub.effects.spec.ts
@@ -25,6 +25,7 @@ jest.mock('../../api/sumsub', () => ({
   SumSubApi: {
     fetchAccessToken: jest.fn(),
     fetchKycStatus: jest.fn(),
+    startKycAttempt: jest.fn(),
   },
 }));
 
@@ -34,6 +35,7 @@ jest.mock('../../lib/sumsub', () => ({
 
 const mockFetchAccessToken = SumSubApi.fetchAccessToken as jest.Mock;
 const mockFetchKycStatus = SumSubApi.fetchKycStatus as jest.Mock;
+const mockStartKycAttempt = SumSubApi.startKycAttempt as jest.Mock;
 const mockLaunchSumSubSdk = launchSumSubSdk as jest.Mock;
 
 // ---------------------------------------------------------------------------
@@ -64,6 +66,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockFetchAccessToken.mockResolvedValue(ACCESS_TOKEN);
   mockFetchKycStatus.mockResolvedValue(NOT_STARTED);
+  mockStartKycAttempt.mockResolvedValue(undefined);
   mockLaunchSumSubSdk.mockResolvedValue({success: true, status: 'Approved'});
 });
 
@@ -155,6 +158,42 @@ describe('startKycVerification — happy path', () => {
 
     expect(refreshed).toBe(ACCESS_TOKEN);
     expect(mockFetchAccessToken).toHaveBeenCalledWith(API_TOKEN);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server-side attempt
+// ---------------------------------------------------------------------------
+describe('startKycVerification — startKycAttempt', () => {
+  it('opens the attempt before launching the SDK', async () => {
+    const store = makeLoggedInStore();
+
+    await store.dispatch(startKycVerification());
+
+    expect(mockStartKycAttempt).toHaveBeenCalledWith(API_TOKEN);
+    expect(mockStartKycAttempt.mock.invocationCallOrder[0]).toBeLessThan(
+      mockLaunchSumSubSdk.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('never opens an attempt when the user is not eligible for a token', async () => {
+    const store = makeLoggedInStore();
+    mockFetchAccessToken.mockResolvedValue(null);
+
+    await store.dispatch(startKycVerification());
+
+    expect(mockStartKycAttempt).not.toHaveBeenCalled();
+    expect(mockLaunchSumSubSdk).not.toHaveBeenCalled();
+  });
+
+  it('still launches the SDK when opening the attempt fails', async () => {
+    const store = makeLoggedInStore();
+    mockStartKycAttempt.mockRejectedValue(new Error('boom'));
+
+    await store.dispatch(startKycVerification());
+
+    // Bookkeeping must never lock the user out of verification.
+    expect(mockLaunchSumSubSdk).toHaveBeenCalled();
   });
 });
 

--- a/src/store/sumsub/sumsub.effects.ts
+++ b/src/store/sumsub/sumsub.effects.ts
@@ -82,6 +82,13 @@ export const startKycVerification =
 
       const locale = (APP.defaultLanguage || 'en').split('-')[0];
 
+      try {
+        await SumSubApi.startKycAttempt(apiToken);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : JSON.stringify(err);
+        dispatch(LogActions.error(`[SumSub] startKycAttempt failed: ${msg}`));
+      }
+
       const result = await launchSumSubSdk(accessToken, onTokenExpired, locale);
 
       dispatch(

--- a/src/store/sumsub/sumsub.reducer.spec.ts
+++ b/src/store/sumsub/sumsub.reducer.spec.ts
@@ -23,10 +23,17 @@ const notStarted: KycInfo = {
 
 const approved: KycInfo = {path: 'sumsub', tier: 0, status: 'approved'};
 
+const unfetchedMap = {
+  [Network.mainnet]: false,
+  [Network.testnet]: false,
+  [Network.regtest]: false,
+};
+
 const seed = (partial: Partial<SumSubState>): SumSubState => ({
   kyc: {...emptyMap},
   sdkStatus: {...emptyMap},
   bannerAck: {...emptyMap},
+  statusFetched: {...unfetchedMap},
   ...partial,
 });
 
@@ -66,6 +73,12 @@ describe('sumSubReducer', () => {
     expect(state.kyc[Network.testnet]).toBeNull();
   });
 
+  it('SET_KYC marks the status as fetched for that network only', () => {
+    const state = sumSubReducer(undefined, setKyc(Network.mainnet, notStarted));
+    expect(state.statusFetched[Network.mainnet]).toBe(true);
+    expect(state.statusFetched[Network.testnet]).toBe(false);
+  });
+
   it('SET_SDK_STATUS stores the raw SDK status for the given network', () => {
     const state = sumSubReducer(
       undefined,
@@ -94,10 +107,12 @@ describe('sumSubReducer', () => {
         [Network.mainnet]: 'Incomplete',
         [Network.testnet]: 'Pending',
       },
+      statusFetched: {...unfetchedMap, [Network.mainnet]: true},
     });
     const state = sumSubReducer(seeded, resetKyc(Network.mainnet));
     expect(state.kyc[Network.mainnet]).toBeNull();
     expect(state.sdkStatus[Network.mainnet]).toBeNull();
+    expect(state.statusFetched[Network.mainnet]).toBe(false);
     expect(state.kyc[Network.testnet]).toBe(notStarted);
     expect(state.sdkStatus[Network.testnet]).toBe('Pending');
   });
@@ -108,6 +123,7 @@ describe('sumSubReducer', () => {
     const state = sumSubReducer(legacy, setKyc(Network.mainnet, approved));
     expect(state.kyc[Network.mainnet]).toBe(approved);
     expect(state.sdkStatus[Network.mainnet]).toBeNull();
+    expect(state.statusFetched[Network.mainnet]).toBe(true);
   });
 
   it('does not mutate the previous state', () => {

--- a/src/store/sumsub/sumsub.reducer.ts
+++ b/src/store/sumsub/sumsub.reducer.ts
@@ -25,6 +25,13 @@ export interface SumSubState {
   bannerAck: {
     [key in Network]: KycBannerAck | null;
   };
+  // Whether `getKycStatus` has answered since the app started. Not persisted:
+  // a rehydrated `kyc` can be stale (the status may have moved on server-side
+  // while the app was closed), and prompting to start KYC off a stale
+  // notStarted is what re-shows the Get Verified modal.
+  statusFetched: {
+    [key in Network]: boolean;
+  };
 }
 
 const initialState: SumSubState = {
@@ -43,9 +50,16 @@ const initialState: SumSubState = {
     [Network.testnet]: null,
     [Network.regtest]: null,
   },
+  statusFetched: {
+    [Network.mainnet]: false,
+    [Network.testnet]: false,
+    [Network.regtest]: false,
+  },
 };
 
-export const sumSubReduxPersistBlackList: (keyof SumSubState)[] = [];
+export const sumSubReduxPersistBlackList: (keyof SumSubState)[] = [
+  'statusFetched',
+];
 
 export const sumSubReducer = (
   state: SumSubState = initialState,
@@ -60,6 +74,9 @@ export const sumSubReducer = (
   if (!state.bannerAck) {
     state = {...state, bannerAck: initialState.bannerAck};
   }
+  if (!state.statusFetched) {
+    state = {...state, statusFetched: initialState.statusFetched};
+  }
   switch (action.type) {
     case SumSubActionTypes.SET_KYC:
       return {
@@ -67,6 +84,10 @@ export const sumSubReducer = (
         kyc: {
           ...state.kyc,
           [action.payload.network]: action.payload.kyc,
+        },
+        statusFetched: {
+          ...state.statusFetched,
+          [action.payload.network]: true,
         },
       };
 
@@ -98,6 +119,10 @@ export const sumSubReducer = (
         sdkStatus: {
           ...state.sdkStatus,
           [action.payload.network]: null,
+        },
+        statusFetched: {
+          ...state.statusFetched,
+          [action.payload.network]: false,
         },
       };
 

--- a/src/store/sumsub/sumsub.selectors.spec.ts
+++ b/src/store/sumsub/sumsub.selectors.spec.ts
@@ -10,6 +10,7 @@ import {
   selectCanStartKyc,
   selectKycBannerState,
   selectKycInfo,
+  selectKycStatusFetched,
   selectKycUiState,
   selectSdkStatus,
 } from './sumsub.selectors';
@@ -28,6 +29,7 @@ describe('deriveKycUiState — backend precedence', () => {
     expect(deriveKycUiState(kyc({status: 'requiresAction'}))).toBe(
       'actionRequired',
     );
+    expect(deriveKycUiState(kyc({status: 'inProgress'}))).toBe('inProgress');
     expect(deriveKycUiState(kyc({status: 'notStarted'}))).toBe('notStarted');
   });
 
@@ -39,7 +41,6 @@ describe('deriveKycUiState — backend precedence', () => {
 
   it('falls back to inReview for any in-flight/unknown backend status', () => {
     expect(deriveKycUiState(kyc({status: 'pendingReview'}))).toBe('inReview');
-    expect(deriveKycUiState(kyc({status: 'inProgress'}))).toBe('inReview');
     expect(deriveKycUiState(kyc({status: 'somethingNew'}))).toBe('inReview');
   });
 });
@@ -114,6 +115,12 @@ describe('isKycEligibleToStart', () => {
     ).toBe(true);
   });
 
+  it('is false once the backend reports an open attempt', () => {
+    expect(
+      isKycEligibleToStart(kyc({status: 'inProgress', tier: -1}), null, true),
+    ).toBe(false);
+  });
+
   it('is false when the SDK reports an in-progress session', () => {
     expect(isKycEligibleToStart(eligible, 'Incomplete', true)).toBe(false);
     expect(isKycEligibleToStart(eligible, 'Pending', true)).toBe(false);
@@ -163,6 +170,7 @@ describe('selectors read the current network slice', () => {
     info: KycInfo | null,
     sdkStatus: string | null = null,
     verified = true,
+    statusFetched = true,
   ): any => ({
     APP: {network: Network.mainnet},
     BITPAY_ID: {user: {[Network.mainnet]: {verified}}},
@@ -176,6 +184,11 @@ describe('selectors read the current network slice', () => {
         [Network.mainnet]: sdkStatus,
         [Network.testnet]: null,
         [Network.regtest]: null,
+      },
+      statusFetched: {
+        [Network.mainnet]: statusFetched,
+        [Network.testnet]: false,
+        [Network.regtest]: false,
       },
     },
   });
@@ -211,6 +224,17 @@ describe('selectors read the current network slice', () => {
     ).toBe(false);
   });
 
+  it('selectCanStartKyc is false until the backend status is fetched', () => {
+    const eligible = kyc({status: 'notStarted', tier: -1});
+    expect(selectCanStartKyc(buildState(eligible, null, true, false))).toBe(
+      false,
+    );
+    expect(
+      selectKycStatusFetched(buildState(eligible, null, true, false)),
+    ).toBe(false);
+    expect(selectKycStatusFetched(buildState(eligible))).toBe(true);
+  });
+
   it('selectCanStartKyc is false when the email is not verified', () => {
     expect(
       selectCanStartKyc(
@@ -243,6 +267,14 @@ describe('selectKycBannerState', () => {
       sdkStatus: {[Network.mainnet]: sdkStatus},
       bannerAck: {[Network.mainnet]: ack},
     },
+  });
+
+  it('shows a persistent banner for an open attempt (RN-2901)', () => {
+    expect(
+      selectKycBannerState(
+        buildState({info: kyc({status: 'inProgress', tier: -1})}),
+      ),
+    ).toBe('inProgress');
   });
 
   it('shows the persistent banners regardless of any acknowledgement', () => {

--- a/src/store/sumsub/sumsub.selectors.ts
+++ b/src/store/sumsub/sumsub.selectors.ts
@@ -13,6 +13,8 @@ const backendStatusToUiState = (status?: string): KycUiState => {
       return 'denied';
     case 'requiresAction':
       return 'actionRequired';
+    case 'inProgress':
+      return 'inProgress';
     case 'notStarted':
     case undefined:
       return 'notStarted';
@@ -70,7 +72,11 @@ export const isKycEligibleToStart = (
 
 // Banners that stay up for as long as the KYC sits in that state — they are not
 // dismissible and must never be suppressed by an acknowledgement.
-const PERSISTENT_BANNER_STATES: KycUiState[] = ['actionRequired', 'inReview'];
+const PERSISTENT_BANNER_STATES: KycUiState[] = [
+  'inProgress',
+  'actionRequired',
+  'inReview',
+];
 
 // Banners that announce an outcome. They are events, not standing state, so
 // they are shown once per transition and then acknowledged.
@@ -87,6 +93,11 @@ export const selectSdkStatus = (state: RootState): string | null =>
 
 export const selectKycUiState = (state: RootState): KycUiState =>
   deriveKycUiState(selectKycInfo(state), selectSdkStatus(state));
+
+// False until `getKycStatus` answers in this app run; a rehydrated `kyc` alone
+// is not a fresh enough signal to prompt the user to start KYC.
+export const selectKycStatusFetched = (state: RootState): boolean =>
+  !!state.SUMSUB?.statusFetched?.[state.APP.network];
 
 export const selectKycBannerAck = (state: RootState): KycBannerAck | null =>
   state.SUMSUB?.bannerAck?.[state.APP.network] ?? null;
@@ -126,6 +137,7 @@ export const selectKycBannerState = (state: RootState): KycUiState | null => {
 };
 
 export const selectCanStartKyc = (state: RootState): boolean =>
+  selectKycStatusFetched(state) &&
   isKycEligibleToStart(
     selectKycInfo(state),
     selectSdkStatus(state),

--- a/src/store/sumsub/sumsub.types.ts
+++ b/src/store/sumsub/sumsub.types.ts
@@ -3,6 +3,7 @@ import {KycInfo} from './sumsub.reducer';
 
 export type KycUiState =
   | 'notStarted'
+  | 'inProgress'
   | 'actionRequired'
   | 'denied'
   | 'inReview'


### PR DESCRIPTION
A user who abandoned identity verification midway — closing the app while the SumSub SDK still had steps pending — was greeted by the "Get Verified" prompt on relaunch, as if they had never started. SumSub itself resumes correctly: reopening drops the user back exactly where they left off with their documents intact. Only the app's entry point was wrong.

Fix: This calls the new `BitPayUser.startKycAttempt` RPC right before launching the SDK, which covers both the initial start and every resume.