### PR TITLE
Buy/Sell: Fix - error handling when no available offers

### DIFF
--- a/src/navigation/services/components/externalServicesOfferSelector.tsx
+++ b/src/navigation/services/components/externalServicesOfferSelector.tsx
@@ -2299,6 +2299,7 @@ const ExternalServicesOfferSelector: React.FC<
     sellOffers.moonpay.amountReceivingAltFiatCurrency = undefined;
     sellOffers.moonpay.fiatMoney = undefined;
     sellOffers.moonpay.expanded = false;
+    setFinishedMoonpay(true);
     setUpdateViewSell(Math.random());
   };
 
@@ -2547,6 +2548,7 @@ const ExternalServicesOfferSelector: React.FC<
     sellOffers.ramp.amountReceivingAltFiatCurrency = undefined;
     sellOffers.ramp.fiatMoney = undefined;
     sellOffers.ramp.expanded = false;
+    setFinishedRamp(true);
     setUpdateViewSell(Math.random());
   };
 
@@ -2717,6 +2719,7 @@ const ExternalServicesOfferSelector: React.FC<
     sellOffers.simplex.amountReceivingAltFiatCurrency = undefined;
     sellOffers.simplex.fiatMoney = undefined;
     sellOffers.simplex.expanded = false;
+    setFinishedSimplex(true);
     setUpdateViewSell(Math.random());
   };
 
@@ -2994,15 +2997,17 @@ const ExternalServicesOfferSelector: React.FC<
           offer.amountReceiving !== '0' &&
           Number(offer.amountReceiving) > 0,
       );
-      if (filteredOffers.length === 0 && allExchangesFinished) {
-        setOfferWarnMsg(
-          t(
-            'There are currently no offers that satisfy your request. Please try again later.',
-          ),
-        );
-        setSelectedOffer(undefined);
-        onSelectOffer?.(undefined);
-        setSelectedOfferLoading(false);
+      if (filteredOffers.length === 0) {
+        if (allExchangesFinished) {
+          setOfferWarnMsg(
+            t(
+              'There are currently no offers that satisfy your request. Please try again later.',
+            ),
+          );
+          setSelectedOffer(undefined);
+          onSelectOffer?.(undefined);
+          setSelectedOfferLoading(false);
+        }
         return;
       }
       const _selectedOffer = _.clone(filteredOffers).reduce((prev, curr) =>
@@ -3077,6 +3082,21 @@ const ExternalServicesOfferSelector: React.FC<
     }
 
     const offersTimeout = setTimeout(() => {
+      const moonpayReady = finishedMoonpay === null || finishedMoonpay === true;
+      const rampReady = finishedRamp === null || finishedRamp === true;
+      const simplexReady = finishedSimplex === null || finishedSimplex === true;
+      const allSellExchangesFinished =
+        moonpayReady && rampReady && simplexReady;
+
+      const hasParticipatingExchange =
+        finishedMoonpay !== null ||
+        finishedRamp !== null ||
+        finishedSimplex !== null;
+
+      if (!hasParticipatingExchange) {
+        return;
+      }
+
       const offersArray = Object.values(sellOffers);
       const filteredOffers = offersArray.filter(
         offer =>
@@ -3085,14 +3105,16 @@ const ExternalServicesOfferSelector: React.FC<
           offer.amountReceiving !== '0',
       );
       if (filteredOffers.length === 0) {
-        setOfferWarnMsg(
-          t(
-            'There are currently no offers that satisfy your request. Please try again later.',
-          ),
-        );
-        setSelectedOffer(undefined);
-        onSelectOffer?.(undefined);
-        setSelectedOfferLoading(false);
+        if (allSellExchangesFinished) {
+          setOfferWarnMsg(
+            t(
+              'There are currently no offers that satisfy your request. Please try again later.',
+            ),
+          );
+          setSelectedOffer(undefined);
+          onSelectOffer?.(undefined);
+          setSelectedOfferLoading(false);
+        }
         return;
       }
       const _selectedOffer = _.clone(filteredOffers).reduce((prev, curr) =>


### PR DESCRIPTION
Fixes a crash in the buy offer-selection flow and aligns the sell flow's "no offers" warning logic with it.

Buy flow: Array.prototype.reduce() was called without an initial value on filteredOffers even when allExchangesFinished was false and the array was empty, causing `TypeError: Array.prototype.reduce() requires an initial value with empty array` (reported in Sentry)

Sell flow: added the equivalent allSellExchangesFinished/hasParticipatingExchange check (mirroring the buy flow, scoped to Moonpay/Ramp/Simplex) so the "no offers" warning isn't shown prematurely while one of the sell exchanges is still loading.