### PR TITLE
Backup: Fix - never move onto an occupied path, retry failed writes

### DIFF
--- a/src/store/backup/fs-backup.spec.ts
+++ b/src/store/backup/fs-backup.spec.ts
@@ -9,6 +9,7 @@
  * chain) to get a fresh module instance per-test.
  */
 import RNFS from 'react-native-fs';
+import * as Sentry from '@sentry/react-native';
 
 // Mock only what fs-backup needs from helper-methods. Using requireActual here
 // would pull in the bwc/bitcore-lib chain and cause duplicate-instance errors
@@ -33,6 +34,76 @@ jest.mock('../../store/log/initLogs', () => ({
 }));
 
 const mockedRNFS = RNFS as jest.Mocked<typeof RNFS>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: in-memory fs reproducing the native semantics this module has to
+// survive — Android writeFile ENOENTs when the parent directory is gone, and
+// iOS moveFile refuses to overwrite an existing destination (Android renameTo
+// does overwrite, so these tests hold the stricter platform to account).
+// ─────────────────────────────────────────────────────────────────────────────
+type Entry = 'dir' | 'final' | 'bak' | 'tmp';
+
+const entryOf = (path: string): Entry =>
+  path.endsWith('.tmp')
+    ? 'tmp'
+    : path.endsWith('.bak')
+    ? 'bak'
+    : path.endsWith('.json')
+    ? 'final'
+    : 'dir';
+
+function mockFs(initial: Entry[] = []): Map<Entry, string> {
+  const fs = new Map<Entry, string>(initial.map(e => [e, `stale-${e}`]));
+
+  (mockedRNFS.exists as jest.Mock).mockImplementation((path: string) =>
+    Promise.resolve(fs.has(entryOf(path))),
+  );
+  (mockedRNFS.mkdir as jest.Mock).mockImplementation((path: string) => {
+    fs.set(entryOf(path), '');
+    return Promise.resolve();
+  });
+  (mockedRNFS.writeFile as jest.Mock).mockImplementation(
+    (path: string, contents: string) => {
+      if (!fs.has('dir')) {
+        return Promise.reject(
+          new Error(
+            `ENOENT: open failed: ENOENT (No such file or directory), open '${path}'`,
+          ),
+        );
+      }
+      fs.set(entryOf(path), contents);
+      return Promise.resolve();
+    },
+  );
+  (mockedRNFS.unlink as jest.Mock).mockImplementation((path: string) => {
+    fs.delete(entryOf(path));
+    return Promise.resolve();
+  });
+  (mockedRNFS.moveFile as jest.Mock).mockImplementation(
+    (src: string, dest: string) => {
+      if (!fs.has(entryOf(src))) {
+        return Promise.reject(
+          new Error(`"${src}" couldn't be moved: the former doesn't exist`),
+        );
+      }
+      if (fs.has(entryOf(dest))) {
+        return Promise.reject(
+          new Error(
+            `"${src}" couldn't be moved: an item with the same name already exists`,
+          ),
+        );
+      }
+      fs.set(entryOf(dest), fs.get(entryOf(src))!);
+      fs.delete(entryOf(src));
+      return Promise.resolve();
+    },
+  );
+
+  return fs;
+}
+
+const realMove = () =>
+  (mockedRNFS.moveFile as jest.Mock).getMockImplementation()!;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helper: get a fresh module instance (resets module-level cachedBackupExists)
@@ -90,11 +161,7 @@ describe('backupFileExists', () => {
 describe('backupPersistRoot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (mockedRNFS.exists as jest.Mock).mockResolvedValue(false);
-    (mockedRNFS.writeFile as jest.Mock).mockResolvedValue(undefined);
-    (mockedRNFS.moveFile as jest.Mock).mockResolvedValue(undefined);
-    (mockedRNFS.unlink as jest.Mock).mockResolvedValue(undefined);
-    (mockedRNFS.mkdir as jest.Mock).mockResolvedValue(undefined);
+    mockFs(['dir']);
   });
 
   it('strips MARKET_STATS, PORTFOLIO, RATE, SHOP_CATALOG and keeps other fields', async () => {
@@ -106,7 +173,6 @@ describe('backupPersistRoot', () => {
       SHOP_CATALOG: {d: 4},
       WALLET: {keys: {}},
     });
-    (mockedRNFS.exists as jest.Mock).mockResolvedValue(false);
     await backupPersistRoot(raw);
 
     expect(mockedRNFS.writeFile).toHaveBeenCalledTimes(1);
@@ -123,90 +189,198 @@ describe('backupPersistRoot', () => {
   it('writes raw JSON unchanged when JSON.parse fails', async () => {
     const {backupPersistRoot} = getFreshModule();
     const rawJson = 'not valid json {{{}}}';
-    (mockedRNFS.exists as jest.Mock).mockResolvedValue(false);
     await backupPersistRoot(rawJson);
 
     expect(mockedRNFS.writeFile).toHaveBeenCalledTimes(1);
     expect((mockedRNFS.writeFile as jest.Mock).mock.calls[0][1]).toBe(rawJson);
   });
 
-  it('creates the directory when it does not exist', async () => {
+  it('creates the directory when it does not exist and still lands the backup', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(false) // ensureDir: BASE_DIR not exists → mkdir
-      .mockResolvedValue(false); // final file does not exist
+    const fs = mockFs([]);
     await backupPersistRoot('{}');
     expect(mockedRNFS.mkdir).toHaveBeenCalledTimes(1);
+    expect(fs.has('final')).toBe(true);
+    expect(fs.has('tmp')).toBe(false);
   });
 
   it('skips mkdir when the directory already exists', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValue(false); // no final file
     await backupPersistRoot('{}');
     expect(mockedRNFS.mkdir).not.toHaveBeenCalled();
   });
 
   it('rotates final→backup and moves temp→final when final exists but backup does not', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValueOnce(true) // finalExists = true
-      .mockResolvedValueOnce(false); // bakExists = false → no unlink
+    const fs = mockFs(['dir', 'final']);
     await backupPersistRoot('{}');
-    expect(mockedRNFS.unlink).not.toHaveBeenCalled();
     expect(mockedRNFS.moveFile).toHaveBeenCalledTimes(2); // FINAL→BAK, TEMP→FINAL
+    expect(fs.get('final')).toBe('{}');
+    expect(fs.get('bak')).toBe('stale-final'); // previous final rolled over
   });
 
-  it('unlinks old backup before rotating when both final and backup exist', async () => {
+  it('unlinks the old backup before rotating when both final and backup exist', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValueOnce(true) // finalExists = true
-      .mockResolvedValueOnce(true); // bakExists = true → unlink
+    const fs = mockFs(['dir', 'final', 'bak']);
     await backupPersistRoot('{}');
+    // FINAL→BAK is attempted, fails on the occupied .bak, unlinks and retries
     expect(mockedRNFS.unlink).toHaveBeenCalledTimes(1);
-    expect(mockedRNFS.moveFile).toHaveBeenCalledTimes(2);
+    expect(mockedRNFS.moveFile).toHaveBeenCalledTimes(3);
+    expect(fs.get('final')).toBe('{}');
   });
 
-  it('still moves temp→final even when the final→backup rotation throws', async () => {
+  // A failed rotation leaves the final file in place, and iOS moveFile refuses
+  // to overwrite it: `"persist-root.json.tmp" couldn't be moved to "redux"
+  // because an item with the same name already exists`.
+  it('lands the new final file when the final→backup rotation keeps failing', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValueOnce(true) // finalExists
-      .mockResolvedValueOnce(false); // bakExists = false
-    (mockedRNFS.moveFile as jest.Mock)
-      .mockRejectedValueOnce(new Error('rotate failed'))
-      .mockResolvedValueOnce(undefined);
-    await backupPersistRoot('{}');
-    expect(mockedRNFS.moveFile).toHaveBeenCalledTimes(2);
+    const fs = mockFs(['dir', 'final']);
+    const move = realMove();
+    (mockedRNFS.moveFile as jest.Mock).mockImplementation((src, dest) =>
+      dest.endsWith('.bak')
+        ? Promise.reject(new Error('rotate failed'))
+        : move(src, dest),
+    );
+
+    await expect(backupPersistRoot('{"new":true}')).resolves.toBeUndefined();
+    expect(fs.get('final')).toBe('{"new":true}'); // not the stale file
+    expect(fs.has('tmp')).toBe(false);
+    // A frozen .bak is reported, but only once per session
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    await backupPersistRoot('{"newer":true}');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
   });
 
-  it('cleans up temp file when writeFile throws', async () => {
+  it('recovers the rotation when the first final→backup move throws', async () => {
     const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.writeFile as jest.Mock).mockRejectedValueOnce(
+    const fs = mockFs(['dir', 'final']);
+    const move = realMove();
+    let calls = 0;
+    (mockedRNFS.moveFile as jest.Mock).mockImplementation((src, dest) =>
+      ++calls === 1
+        ? Promise.reject(new Error('rotate failed'))
+        : move(src, dest),
+    );
+
+    await expect(backupPersistRoot('{"new":true}')).resolves.toBeUndefined();
+    expect(fs.get('final')).toBe('{"new":true}');
+    expect(fs.get('bak')).toBe('stale-final');
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  // `ENOENT: open failed: ENOENT (No such file or directory), open
+  // '.../cache/bitpay/redux/persist-root.json.tmp'` — the cache directory was
+  // wiped after ensureDir() had already checked it.
+  it('retries the write when the cache directory is wiped before the write', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    const fs = mockFs(['dir']);
+    const write = (mockedRNFS.writeFile as jest.Mock).getMockImplementation()!;
+    let wiped = false;
+    (mockedRNFS.writeFile as jest.Mock).mockImplementation((path, contents) => {
+      if (!wiped) {
+        wiped = true;
+        fs.clear(); // system cleared the cache dir between ensureDir and here
+      }
+      return write(path, contents);
+    });
+
+    await expect(backupPersistRoot('{}')).resolves.toBeUndefined();
+    expect(mockedRNFS.writeFile).toHaveBeenCalledTimes(2);
+    expect(mockedRNFS.mkdir).toHaveBeenCalledTimes(1); // recreated on the retry
+    expect(fs.get('final')).toBe('{}');
+  });
+
+  it('retries the write when the cache directory is wiped between write and move', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    const fs = mockFs(['dir']);
+    const move = realMove();
+    let wiped = false;
+    (mockedRNFS.moveFile as jest.Mock).mockImplementation((src, dest) => {
+      if (!wiped) {
+        wiped = true;
+        fs.clear();
+      }
+      return move(src, dest);
+    });
+
+    await expect(backupPersistRoot('{}')).resolves.toBeUndefined();
+    expect(mockedRNFS.writeFile).toHaveBeenCalledTimes(2);
+    expect(fs.get('final')).toBe('{}');
+  });
+
+  it('cleans up the temp file and rejects when the write keeps failing', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    const fs = mockFs(['dir']);
+    (mockedRNFS.writeFile as jest.Mock).mockImplementation(() => {
+      fs.set('tmp', '');
+      return Promise.reject(new Error('write error'));
+    });
+
+    await expect(backupPersistRoot('{}')).rejects.toThrow('write error');
+    expect(mockedRNFS.writeFile).toHaveBeenCalledTimes(2);
+    expect(fs.has('tmp')).toBe(false);
+    // A write that never lands is the case that does get reported
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the original error even if temp file cleanup also fails', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    mockFs(['dir', 'tmp']);
+    (mockedRNFS.writeFile as jest.Mock).mockRejectedValue(
       new Error('write error'),
     );
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValueOnce(true); // tmpExists = true → unlink temp
-    await backupPersistRoot('{}');
-    expect(mockedRNFS.unlink).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not throw even if temp file cleanup also fails', async () => {
-    const {backupPersistRoot} = getFreshModule();
-    (mockedRNFS.writeFile as jest.Mock).mockRejectedValueOnce(
-      new Error('write error'),
-    );
-    (mockedRNFS.exists as jest.Mock)
-      .mockResolvedValueOnce(true) // ensureDir: dir exists
-      .mockResolvedValueOnce(true); // tmpExists = true
-    (mockedRNFS.unlink as jest.Mock).mockRejectedValueOnce(
+    (mockedRNFS.unlink as jest.Mock).mockRejectedValue(
       new Error('unlink error'),
     );
+
+    await expect(backupPersistRoot('{}')).rejects.toThrow('write error');
+  });
+
+  it('reports once and gives up when the directory cannot be created', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    mockFs([]);
+    (mockedRNFS.mkdir as jest.Mock).mockRejectedValue(new Error('mkdir error'));
+
+    await expect(backupPersistRoot('{}')).rejects.toThrow('mkdir error');
+    expect(mockedRNFS.writeFile).not.toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an in-flight backup to settle before starting the next', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    const fs = mockFs(['dir']);
+    const write = (mockedRNFS.writeFile as jest.Mock).getMockImplementation()!;
+    let release: () => void = () => {};
+    const gate = new Promise<void>(resolve => (release = resolve));
+    let writes = 0;
+    (mockedRNFS.writeFile as jest.Mock).mockImplementation(async (p, c) => {
+      if (++writes === 1) {
+        await gate;
+      }
+      return write(p, c);
+    });
+
+    const first = backupPersistRoot('{"n":1}');
+    const second = backupPersistRoot('{"n":2}');
+    await new Promise(resolve => setImmediate(resolve));
+    expect(writes).toBe(1); // the second call has not started
+
+    release();
+    await Promise.all([first, second]);
+    expect(writes).toBe(2);
+    expect(fs.get('final')).toBe('{"n":2}'); // applied in order
+  });
+
+  it('keeps the queue usable after a failed backup', async () => {
+    const {backupPersistRoot} = getFreshModule();
+    (mockedRNFS.writeFile as jest.Mock).mockRejectedValue(
+      new Error('write error'),
+    );
+    await expect(backupPersistRoot('{}')).rejects.toThrow('write error');
+
+    const fs = mockFs(['dir']);
     await expect(backupPersistRoot('{}')).resolves.toBeUndefined();
+    expect(fs.get('final')).toBe('{}');
   });
 });
 

--- a/src/store/backup/fs-backup.ts
+++ b/src/store/backup/fs-backup.ts
@@ -12,23 +12,29 @@ const BACKUP_FILE = BASE_DIR + '/persist-root.json.bak';
 const TEMP_FILE = BASE_DIR + '/persist-root.json.tmp';
 
 let cachedBackupExists: boolean = false;
+let rotateReported: boolean = false;
 
 // Serial queue — ensures only one write uses the shared TEMP_FILE at a time
 let backupQueue: Promise<void> = Promise.resolve();
 
 async function ensureDir(): Promise<void> {
+  const exists = await RNFS.exists(BASE_DIR);
+  if (!exists) {
+    await RNFS.mkdir(BASE_DIR);
+  }
+}
+
+// iOS moveFile (NSFileManager moveItemAtPath) throws instead of overwriting an
+// existing destination; Android renameTo replaces it atomically, so only clear
+// the destination once a move has actually failed
+async function moveOverwriting(src: string, dest: string): Promise<void> {
   try {
-    const exists = await RNFS.exists(BASE_DIR);
-    if (!exists) {
-      await RNFS.mkdir(BASE_DIR);
-    }
-  } catch (err) {
-    initLogs.add(
-      LogActions.persistLog(
-        LogActions.error(`Backup ensureDir failed - ${getErrorString(err)}`),
-      ),
-    );
-    Sentry.captureException(err, {level: 'error'});
+    await RNFS.moveFile(src, dest);
+  } catch {
+    try {
+      await RNFS.unlink(dest);
+    } catch {}
+    await RNFS.moveFile(src, dest);
   }
 }
 
@@ -46,72 +52,74 @@ export async function backupFileExists(): Promise<boolean> {
 }
 
 export function backupPersistRoot(rawJson: string): Promise<void> {
-  backupQueue = backupQueue
-    .then(() => _backupPersistRoot(rawJson))
-    .catch(() => {});
-  return backupQueue;
+  const run = backupQueue.then(() => _backupPersistRoot(rawJson));
+  // Keep the queue serial without poisoning it, while still surfacing failures
+  backupQueue = run.catch(() => {});
+  return run;
 }
 
 async function _backupPersistRoot(rawJson: string): Promise<void> {
+  let filtered = rawJson;
   try {
-    let filtered = rawJson;
+    const parsed = JSON.parse(rawJson);
+    delete parsed.MARKET_STATS;
+    delete parsed.PORTFOLIO;
+    delete parsed.PORTFOLIO_CHARTS;
+    delete parsed.RATE;
+    delete parsed.SHOP_CATALOG;
+    filtered = JSON.stringify(parsed);
+  } catch {
+    // If parse fails, keep raw json — better to have a backup than none
+  }
+
+  // Both platforms can wipe the cache directory at any point — including between
+  // ensureDir() and the write, or between the write and the move — so recreate
+  // it and retry once before giving up
+  for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const parsed = JSON.parse(rawJson);
-      delete parsed.MARKET_STATS;
-      delete parsed.PORTFOLIO;
-      delete parsed.PORTFOLIO_CHARTS;
-      delete parsed.RATE;
-      delete parsed.SHOP_CATALOG;
-      filtered = JSON.stringify(parsed);
-    } catch (_) {
-      // If parse fails, keep raw json — better to have a backup than none
-    }
+      await ensureDir();
+      await RNFS.writeFile(TEMP_FILE, filtered, 'utf8');
 
-    await ensureDir();
-
-    // Write to temp file first
-    await RNFS.writeFile(TEMP_FILE, filtered, 'utf8');
-
-    // Rotate current to .bak if present
-    const finalExists = await RNFS.exists(FINAL_FILE);
-    if (finalExists) {
-      try {
-        // Remove old .bak if exists to keep only one rolling backup
-        const bakExists = await RNFS.exists(BACKUP_FILE);
-        if (bakExists) {
-          await RNFS.unlink(BACKUP_FILE);
+      const finalExists = await RNFS.exists(FINAL_FILE);
+      if (finalExists) {
+        try {
+          await moveOverwriting(FINAL_FILE, BACKUP_FILE);
+        } catch (err) {
+          initLogs.add(
+            LogActions.persistLog(
+              LogActions.error(`Backup rotate failed - ${getErrorString(err)}`),
+            ),
+          );
+          // Once per session: a permanently frozen .bak must not be silent, but
+          // rotation runs on every backup and is best-effort
+          if (!rotateReported) {
+            rotateReported = true;
+            Sentry.captureException(err, {level: 'error'});
+          }
         }
-      } catch (_) {}
+      }
+
+      await moveOverwriting(TEMP_FILE, FINAL_FILE);
+      cachedBackupExists = true;
+      return;
+    } catch (err) {
       try {
-        await RNFS.moveFile(FINAL_FILE, BACKUP_FILE);
-      } catch (err) {
+        const tmpExists = await RNFS.exists(TEMP_FILE);
+        if (tmpExists) {
+          await RNFS.unlink(TEMP_FILE);
+        }
+      } catch {}
+      if (attempt > 0) {
+        cachedBackupExists = false;
         initLogs.add(
           LogActions.persistLog(
-            LogActions.error(`Backup rotate failed - ${getErrorString(err)}`),
+            LogActions.error(`Backup write failed - ${getErrorString(err)}`),
           ),
         );
         Sentry.captureException(err, {level: 'error'});
+        throw err;
       }
     }
-
-    // Atomically move temp to final
-    await RNFS.moveFile(TEMP_FILE, FINAL_FILE);
-    cachedBackupExists = true;
-  } catch (err) {
-    // Best-effort logging; avoid throwing to not impact primary persist
-    initLogs.add(
-      LogActions.persistLog(
-        LogActions.error(`Backup write failed - ${getErrorString(err)}`),
-      ),
-    );
-    Sentry.captureException(err, {level: 'error'});
-    // Cleanup temp if left behind
-    try {
-      const tmpExists = await RNFS.exists(TEMP_FILE);
-      if (tmpExists) {
-        await RNFS.unlink(TEMP_FILE);
-      }
-    } catch (_) {}
   }
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -127,6 +127,9 @@ const FS_BACKUP_TRIGGER_ACTIONS = new Set<string>([
 ]);
 
 let backupTriggerAction: string | null = null;
+// Bounds the retry below: persist:root is written with throttle 0, so an
+// unrecoverable filesystem keeps re-arming on every slice change
+let backupFailures = 0;
 
 // Module-scoped logger that safely logs before and after store initialization
 let storeDispatch: ((action: AnyAction) => void) | null = null;
@@ -222,15 +225,21 @@ export const reduxStorage: Storage = {
     try {
       if (key === 'persist:root' && typeof valueToStore === 'string') {
         const hasBackup = await backupFileExists();
-        if (backupTriggerAction || !hasBackup) {
+        if ((backupTriggerAction || !hasBackup) && backupFailures < 3) {
           const triggerLabel = backupTriggerAction ?? 'no existing backup';
           backupPersistRoot(valueToStore)
-            .then(() =>
+            .then(() => {
+              backupFailures = 0;
               logManager.debug(
                 `Backed up store to filesystem, triggered by ${triggerLabel}.`,
-              ),
-            )
-            .catch(() => {});
+              );
+            })
+            // Retry on the next persist:root write rather than waiting for
+            // another trigger action, which may never come
+            .catch(() => {
+              backupFailures++;
+              backupTriggerAction = triggerLabel;
+            });
           backupTriggerAction = null;
         }
       }
@@ -452,6 +461,7 @@ const getStore = async () => {
         if (action && typeof action.type === 'string') {
           if (FS_BACKUP_TRIGGER_ACTIONS.has(action.type)) {
             backupTriggerAction = action.type;
+            backupFailures = 0;
           }
         }
       } catch (_) {}


### PR DESCRIPTION
Fixes the ENOENT family in src/store/backup/fs-backup.ts: `BITPAY-APP-7`, `-2X`, `-52`, `-K`, `-N` and `-21`. Ruled out with data: not disk space (fails with 163 GB free), not low-end devices (spread across all three device.class buckets), not Android-only.


### Two bugs:

1. The cache directory `cache/bitpay/redux` can be cleared by the OS at any moment, including between ensureDir() and the write. There was no retry, so every occurrence reported and no backup landed.
2. iOS moveFile (NSFileManager moveItemAtPath, RNFSManager.m:419) throws instead of overwriting an existing destination; Android renameTo (RNFSManager.java:365) replaces it. Once a rotation failed and left the final file behind, TEMP→FINAL could never land on iOS. `BITPAY-APP-21` is that rotation path — all 10 occurrences carry the `Backup rotate failed` breadcrumb, none carry `Backup read final failed`.

### Changes:

- Retry the whole ensureDir → write → rotate → move sequence once. Only the second failure logs, reports and rejects.
- moveOverwriting: attempt the move first, clear the destination only after it fails. Keeps Android's atomic rename and fixes iOS.
- backupPersistRoot returns the real promise instead of the swallowed one, so index.ts no longer logs success for a failed write.
- A failed backup re-arms the trigger so the next persist:root write retries, bounded to 3 consecutive failures. rootPersistConfig sets no throttle and redux-persist defaults to 0, so persist:root is written on every slice change — unbounded re-arming would hammer a permanently broken filesystem.
- Rotation failures report to Sentry once per session: reporting every occurrence is the noise this PR is removing, reporting none would make a permanently frozen .bak invisible.

### Test on iOS and Android

Driven by a temporary `__DEV__` harness (not part of this diff) that wipes `BASE_DIR` right after `ensureDir()` and forces the rotation to throw, once each per app launch. Replacing the `redux` directory with a regular file does not work: `exists()` returns true and `ensureDir` skips the `mkdir` on both attempts.

Directory wiped between `ensureDir()` and the write — the retry recreates it and the backup lands:

```
[Debug] Backed up store to filesystem, triggered by WALLET/UPDATE_WALLET_NAME.
```

Rotation forced to fail, leaving the final file occupying the destination — this is the iOS bug, and before this PR the move died here:

```
[Error] Backup rotate failed - dev: forced rotate failure
[Debug] Backed up store to filesystem, triggered by WALLET/UPDATE_WALLET_NAME.
```

`Library/Caches/bitpay/redux` holds a fresh `persist-root.json` in both cases, with no `.tmp` left behind.

### Android

Same two cases, driven by the same harness. With the rotation forced to fail, `renameTo` overwrites the occupied final file on the first move and the unlink fallback never runs — the asymmetry this PR relies on, and the reason `moveOverwriting` attempts the move before clearing the destination:

```
[Debug] Backed up store to filesystem, triggered by WALLET/SET_CUSTOM_TOKENS_MIGRATION_COMPLETE.
[Error] Backup rotate failed - dev: forced rotate failure
[Debug] Backed up store to filesystem, triggered by WALLET/SET_ACCOUNT_EVM_CREATION_MIGRATION_COMPLETE.
```

`/data/data/com.bitpay.wallet/cache/bitpay/redux` ends up in the same state as iOS.
