### PR TITLE
Logs: Fix - record post-startup logs instead of dropping them

### DIFF
--- a/src/navigation/tabs/settings/about/screens/SessionLog.tsx
+++ b/src/navigation/tabs/settings/about/screens/SessionLog.tsx
@@ -168,10 +168,13 @@ const SessionLogs = ({}: SessionLogsScreenProps) => {
   const currentSessionStartTime = logs.length
     ? new Date(logs[0].timestamp)
     : new Date();
-  const [filteredPersistedLogs, setFilteredPersistedLogs] = useState(
-    [] as LogEntry[],
-  );
+  // persist:logs also holds this session's entries (fs-backup/transforms write
+  // there directly), so split by timestamp — not by source — to keep them out
+  // of the "Previous Sessions" section and out of the export's previous block
   const [persistedLogs, setPersistedLogs] = useState([] as LogEntry[]);
+  const filteredPersistedLogs = persistedLogs.filter(
+    log => log.level <= filterLevel,
+  );
 
   const printLogs = (logsToPrint: LogEntry[]) =>
     logsToPrint
@@ -283,13 +286,11 @@ const SessionLogs = ({}: SessionLogsScreenProps) => {
   useEffect(() => {
     const value = storage.getString('persist:logs');
     if (value) {
-      const _filteredPersistedLogs = JSON.parse(value).filter(
-        (log: LogEntry) =>
-          log.level <= filterLevel &&
-          new Date(log.timestamp) < currentSessionStartTime,
+      setPersistedLogs(
+        JSON.parse(value).filter(
+          (log: LogEntry) => new Date(log.timestamp) < currentSessionStartTime,
+        ),
       );
-      setPersistedLogs(JSON.parse(value));
-      setFilteredPersistedLogs(_filteredPersistedLogs);
     }
   }, []);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -128,18 +128,11 @@ const FS_BACKUP_TRIGGER_ACTIONS = new Set<string>([
 
 let backupTriggerAction: string | null = null;
 
-// Module-scoped logger that safely logs before and after store initialization
 let storeDispatch: ((action: AnyAction) => void) | null = null;
-const addLog = (log: AddLog) => {
-  try {
-    if (storeDispatch) {
-      storeDispatch(log);
-    } else {
-      // Fallback to initLogs buffer until store is ready
-      initLogs.add(log);
-    }
-  } catch (_) {}
-};
+// Never dispatches: every caller logs a storage failure, and ADD_PERSISTED_LOG
+// mutates LOG state, which makes redux-persist write persist:root through the
+// same storage that just failed
+const addLog = (log: AddLog) => initLogs.add(log);
 
 const restoreFromBackup = (reason: string): Promise<string | null> => {
   const startTs = Date.now();

--- a/src/store/log/initLogs.spec.ts
+++ b/src/store/log/initLogs.spec.ts
@@ -1,0 +1,141 @@
+import {LogLevel} from './log.models';
+import {LogActionTypes, AddLog} from './log.types';
+
+const mockStorage = {
+  getString: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockLogManager = {addLog: jest.fn()};
+
+jest.mock('../index', () => ({
+  get storage() {
+    return mockStorage;
+  },
+}));
+
+jest.mock('../../managers/LogManager', () => ({
+  get logManager() {
+    return mockLogManager;
+  },
+}));
+
+const entry = (message: string): AddLog => ({
+  type: LogActionTypes.ADD_PERSISTED_LOG,
+  payload: {level: LogLevel.Error, message, timestamp: '2026-09-02T11:20:59Z'},
+});
+
+// Module-level `drained` has to reset between tests
+const getFreshModule = () => {
+  let mod!: typeof import('./initLogs');
+  jest.isolateModules(() => {
+    mod = require('./initLogs');
+  });
+  return mod;
+};
+
+describe('initLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorage.getString.mockReturnValue(undefined);
+  });
+
+  it('buffers logs added before the store exists, without touching MMKV', () => {
+    const {add} = getFreshModule();
+    add(entry('before store'));
+    expect(mockStorage.set).not.toHaveBeenCalled();
+  });
+
+  it('dispatches buffered logs once on drain and empties the buffer', () => {
+    const {add, drainAndDispatch} = getFreshModule();
+    const dispatch = jest.fn();
+    add(entry('first'));
+    add(entry('second'));
+
+    drainAndDispatch(dispatch);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+
+    dispatch.mockClear();
+    drainAndDispatch(dispatch);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('appends to persist:logs instead of dispatching once the store is up', () => {
+    const {add, drainAndDispatch} = getFreshModule();
+    const dispatch = jest.fn();
+    drainAndDispatch(dispatch);
+    dispatch.mockClear();
+
+    mockStorage.getString.mockReturnValue(
+      JSON.stringify([entry('older').payload]),
+    );
+    add(entry('Backup write failed - ENOENT'));
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(mockStorage.set).toHaveBeenCalledTimes(1);
+    const [key, written] = mockStorage.set.mock.calls[0];
+    expect(key).toBe('persist:logs');
+    expect(JSON.parse(written)).toEqual([
+      entry('older').payload,
+      entry('Backup write failed - ENOENT').payload,
+    ]);
+  });
+
+  it('keeps only the newest 500 entries', () => {
+    const {add, drainAndDispatch} = getFreshModule();
+    drainAndDispatch(jest.fn());
+
+    mockStorage.getString.mockReturnValue(
+      JSON.stringify(
+        Array.from({length: 500}, (_, i) => entry(`old ${i}`).payload),
+      ),
+    );
+    add(entry('newest'));
+
+    const written = JSON.parse(mockStorage.set.mock.calls[0][1]);
+    expect(written).toHaveLength(500);
+    expect(written[0].message).toBe('old 1');
+    expect(written[499].message).toBe('newest');
+  });
+
+  it('swallows MMKV failures so logging never breaks the caller', () => {
+    const {add, drainAndDispatch} = getFreshModule();
+    drainAndDispatch(jest.fn());
+    mockStorage.set.mockImplementation(() => {
+      throw new Error('MMKV full');
+    });
+
+    expect(() => add(entry('boom'))).not.toThrow();
+  });
+});
+
+describe('persist:logs writers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('caps the reducer path at 500 too, so the two writers agree', () => {
+    const {logReducer} = require('./log.reducer');
+    mockStorage.getString.mockReturnValue(
+      JSON.stringify(
+        Array.from({length: 500}, (_, i) => entry(`old ${i}`).payload),
+      ),
+    );
+
+    logReducer({logs: []}, entry('newest'));
+
+    const written = JSON.parse(mockStorage.set.mock.calls[0][1]);
+    expect(written).toHaveLength(500);
+    expect(written[499].message).toBe('newest');
+  });
+
+  it('feeds logManager so persisted logs show in the current session', () => {
+    const {logReducer} = require('./log.reducer');
+
+    logReducer({logs: []}, entry('Backup write failed - ENOENT'));
+
+    expect(mockLogManager.addLog).toHaveBeenCalledWith(
+      entry('Backup write failed - ENOENT').payload,
+    );
+  });
+});

--- a/src/store/log/initLogs.ts
+++ b/src/store/log/initLogs.ts
@@ -1,13 +1,50 @@
+import {LogEntry, sanitizeLogMessage} from './log.models';
 import type {AddLog} from './log.types';
+import {logManager} from '../../managers/LogManager';
+import {storage} from '../index';
 
 // For storing logs before the store is initialized
 const initLogs: AddLog[] = [];
+let drained = false;
+
+// CLEAR_LOGS only prunes persist:logs at startup, so a session stuck in a
+// failure loop would grow the array all session long — and every append
+// re-serializes the whole thing
+const MAX_PERSISTED_LOGS = 500;
+
+// Single writer for persist:logs, shared with the ADD_PERSISTED_LOG reducer so
+// the cap and the redaction can't diverge between the two paths
+export const appendPersistedLog = (entry: LogEntry): LogEntry => {
+  const sanitized = {...entry, message: sanitizeLogMessage(entry.message)};
+
+  // Session Log reads logManager, not LOG.logs — without this, persisted logs
+  // are missing from both on-screen sections and from the exported current
+  // session. Not a second dispatch: ADD_LOG dirties LOG state, which makes
+  // redux-persist write persist:root, itself a path that logs here
+  logManager.addLog(sanitized);
+
+  try {
+    const persistedLogs = storage.getString('persist:logs') || '[]';
+    storage.set(
+      'persist:logs',
+      JSON.stringify(
+        [...JSON.parse(persistedLogs), sanitized].slice(-MAX_PERSISTED_LOGS),
+      ),
+    );
+  } catch {}
+  return sanitized;
+};
 
 export const add = (log: AddLog) => {
+  if (drained) {
+    appendPersistedLog(log.payload);
+    return;
+  }
   initLogs.push(log);
 };
 
 export const drainAndDispatch = (dispatch: (action: AddLog) => void) => {
+  drained = true;
   if (initLogs.length === 0) {
     return;
   }

--- a/src/store/log/log.models.ts
+++ b/src/store/log/log.models.ts
@@ -22,3 +22,8 @@ export interface LogEntry {
    */
   message: string;
 }
+
+export const sanitizeLogMessage = (message: string) =>
+  message
+    .replace('/xpriv.*/', '[...]')
+    .replace('/walletPrivKey.*/', 'walletPrivKey:[...]');

--- a/src/store/log/log.reducer.ts
+++ b/src/store/log/log.reducer.ts
@@ -1,6 +1,7 @@
 import moment from 'moment';
-import {LogEntry} from './log.models';
+import {LogEntry, sanitizeLogMessage} from './log.models';
 import {LogActionType, LogActionTypes} from './log.types';
+import {appendPersistedLog} from './initLogs';
 import {storage} from '../index';
 
 export const logReduxPersistBlackList = ['logs'];
@@ -31,23 +32,9 @@ export const logReducer = (
       };
 
     case LogActionTypes.ADD_PERSISTED_LOG:
-      const newPersistedLog = {
-        timestamp: action.payload.timestamp,
-        level: action.payload.level,
-        message: sanitizeLogMessage(action.payload.message),
-      };
-
-      // Store persisted logs in a different entry in storage
-      // to avoid losing them if anything happens to persist:root
-      try {
-        const persistLogs = storage.getString('persist:logs') || '[]';
-        storage.set(
-          'persist:logs',
-          JSON.stringify([...JSON.parse(persistLogs), newPersistedLog]),
-        );
-      } catch (error) {
-        console.error('Error adding persisted log:', error);
-      }
+      // Persisted logs live under their own storage key so they survive
+      // anything happening to persist:root
+      const newPersistedLog = appendPersistedLog(action.payload);
 
       return {
         ...state,
@@ -84,10 +71,3 @@ export const logReducer = (
       return state;
   }
 };
-
-function sanitizeLogMessage(message: string) {
-  message = message.replace('/xpriv.*/', '[...]');
-  message = message.replace('/walletPrivKey.*/', 'walletPrivKey:[...]');
-
-  return message;
-}


### PR DESCRIPTION
Logs emitted after store initialization were silently discarded: `initLogs.add` only buffered them, and that buffer is drained once at store creation and never again — so every log from `fs-backup.ts` and `transforms.ts` went nowhere. Backup failures like `Backup write failed - ENOENT` never reached the `LOG` slice or the `persist:logs` MMKV key, so they showed in neither section of Session Log and were missing from the log file users email to support; only the Sentry breadcrumb survived.

The fix appends to `persist:logs` directly rather than dispatching, because `ADD_PERSISTED_LOG` mutates `LOG` state and triggers a `persist:root` write — itself a path that logs here, so dispatching would close the loop. `addLog` in `store/index.ts` had that exact loop with MMKV failures and now routes through the same path.

### Steps to reproduce (only Android):

1. Create and remove cache folders: 

```
adb shell run-as com.bitpay.wallet mkdir -p cache/bitpay; adb shell run-as com.bitpay.wallet rm -rf cache/bitpay/redux; adb shell run-as com.bitpay.wallet touch cache/bitpay/redux; adb shell run-as com.bitpay.wallet ls -l cache/bitpay
```

2. Wallet Settings → Hide Wallet: tap 3-4 times

```
[Error] Backup write failed - ENOENT: open failed: ENOTDIR (Not a directory), open '/data/user/0/com.bitpay.wallet/cache/bitpay/redux/persist-root.json.tmp'
```

3. Finish testing: 

```
adb shell run-as com.bitpay.wallet rm -f cache/bitpay/redux
```

### Side Notes

`persist:logs` is only pruned at startup (`CLEAR_LOGS`, 7-day cutoff) and every append re-serializes the whole array, so a session stuck in a failure loop grew it unbounded — now that backup errors actually reach it, that's a real path. Capped at the newest 500 entries on write.