### PR TITLE
Sentry: Fix - keep event.user.id so per-issue user counts work

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Sentry.init({
   sendDefaultPii: false,
   enableLogs: false,
   enableAutoNativeBreadcrumbs: false,
-  autoSessionTracking: false,
+  autoSessionTracking: true,
   maxBreadcrumbs: 500,
   beforeSend(event) {
     if (event.contexts) {
@@ -65,8 +65,18 @@ Sentry.init({
       delete event.tags.device;
       delete event.tags.device_id;
     }
+    // Keep event.user.id. With no user set explicitly, the RN SDK fills it from
+    // deviceContextIntegration with the native installation ID -- a random
+    // per-install UUID minted by the native SDK, not PII. Deleting it left every
+    // JS-layer issue reporting count_unique(user) == 0 while native crashes --
+    // which never run this hook, because beforeSend is stripped from the options
+    // handed to the native SDK -- reported real user counts. Strip the actually
+    // identifying fields instead.
     if (event.user) {
-      delete event.user.id;
+      delete event.user.email;
+      delete event.user.username;
+      delete event.user.ip_address;
+      delete event.user.geo;
     }
     if (event.breadcrumbs) {
       event.breadcrumbs = event.breadcrumbs.filter(b => b.category === 'log');


### PR DESCRIPTION
Jira: [RN-2935](https://bitpayprod.atlassian.net/browse/RN-2935) · epic [RN-2926](https://bitpayprod.atlassian.net/browse/RN-2926)

## The problem

`beforeSend` deletes `event.user.id` on every event it sees — which is every JS-layer event.

The RN SDK's `deviceContextIntegration` populates `event.user` with the native **installation ID** (a random per-install UUID, not PII), and event processors run *before* `beforeSend` — so the id is present and then removed.

`beforeSend` is stripped from the options handed to the native SDK, so native-captured events (ANR, AppHang, WatchdogTermination, JSI) never run this hook and keep their user. That asymmetry is the whole finding.

## Measured impact

From a 90-day Sentry analysis (11 Jun – 8 Sep 2026):

- **46,748 of 56,343 events in the top 40 issues — 83% — report zero unique users.**
- The only issues reporting real counts are native crashes, e.g. App Hanging at 2,651 events / 2,055 users.
- Every JS-layer issue reports exactly zero: all network errors, every `TypeError`, the whole AppsFlyer cluster, every redux-persist failure.

## Scope: this is about per-issue triage, not release health

Worth being precise, because an earlier draft of this PR overstated it. **Release health works today** — crash-free session and crash-free user rate per release are populated from session data and are perfectly usable (e.g. iOS 14.45.0+1 at 98.98% crash-free users vs 14.46.3+1 at 99.81%).

What is broken is the per-issue half: for any individual issue there is no way to distinguish **one user hitting it 4,000 times from 4,000 users hitting it once**. Those are very different bugs with the same row in Sentry, and that is what this fixes.

`Sentry.setUser` is never called anywhere in the repo.

## What this changes

Stops deleting `user.id`; strips `email` / `username` / `ip_address` / `geo` instead. `sendDefaultPii: false` is untouched — the install ID gives correct unique counts without enabling IP collection.

## Privacy

Only the SDK installation ID is retained: a random UUID with no derivation from wallet, key, account, or device. Deliberately **not** sending BitPay ID `eid`, `email`, or any wallet address — `eid` is a durable handle on a KYC'd identity sharing an object with `dateOfBirth`, `legalGivenName`, `phone` and `address`. If per-account correlation is ever needed, use a salted hash.

## Follow-up, deliberately not in this PR

`index.js` also carries `autoSessionTracking: false`, which is a **dead key** — the option in `@sentry/react-native` 7.11.0 is `enableAutoSessionTracking`, so this line does nothing and the native SDKs track sessions by their own default (383,140 sessions in the last 14 days confirm it). It is harmless but actively misleading: it reads as "sessions are off" when they are on. Worth either removing or renaming to the real option, as its own change.

Draft: needs a device check that JS-layer issues start reporting non-zero users, and that no PII appears on an event.
